### PR TITLE
[sql] Fix `is null`/`is not null` conjunction in QueryPredicate

### DIFF
--- a/sql/src/lib.rs
+++ b/sql/src/lib.rs
@@ -1587,6 +1587,54 @@ mod tests {
     }
 
     #[test]
+    fn null_predicate_merges_are_order_independent() {
+        use datafusion::logical_expr::col;
+        let config = KvTableConfig::new(
+            0,
+            vec![
+                TableColumnConfig::new("id", DataType::Int64, false),
+                TableColumnConfig::new("label", DataType::Utf8, true),
+            ],
+            vec!["id".to_string()],
+            vec![],
+        )
+        .unwrap();
+        let model = TableModel::from_config(&config).unwrap();
+        let label_idx = *model.columns_by_name.get("label").unwrap();
+        let eq_foo = col("label").eq(Expr::Literal(
+            ScalarValue::Utf8(Some("foo".to_string())),
+            None,
+        ));
+        let is_null = col("label").is_null();
+        let is_not_null = col("label").is_not_null();
+        let row_foo = KvRow {
+            values: vec![CellValue::Int64(1), CellValue::Utf8("foo".to_string())],
+        };
+
+        // (label = 'foo') AND (label IS NOT NULL) — IS NOT NULL is implied;
+        // predicate must reduce to StringEq('foo') in either order.
+        for filters in [
+            [&eq_foo, &is_not_null],
+            [&is_not_null, &eq_foo],
+        ] {
+            let owned: Vec<Expr> = filters.iter().map(|e| (*e).clone()).collect();
+            let pred = QueryPredicate::from_filters(&owned, &model);
+            assert!(!pred.contradiction);
+            assert!(matches!(
+                pred.constraints.get(&label_idx),
+                Some(PredicateConstraint::StringEq(s)) if s == "foo"
+            ));
+            assert!(pred.matches_row(&row_foo));
+        }
+
+        // (label = 'foo') AND (label IS NULL) — must contradict in either order.
+        for filters in [[&eq_foo, &is_null], [&is_null, &eq_foo]] {
+            let owned: Vec<Expr> = filters.iter().map(|e| (*e).clone()).collect();
+            assert!(QueryPredicate::from_filters(&owned, &model).contradiction);
+        }
+    }
+
+    #[test]
     fn table_config_accepts_date32_column() {
         let config = KvTableConfig::new(
             0,

--- a/sql/src/lib.rs
+++ b/sql/src/lib.rs
@@ -1632,6 +1632,56 @@ mod tests {
     }
 
     #[test]
+    fn non_nullable_null_predicates_simplify() {
+        use datafusion::logical_expr::col;
+        let config = KvTableConfig::new(
+            0,
+            vec![
+                TableColumnConfig::new("id", DataType::Int64, false),
+                TableColumnConfig::new("label", DataType::Utf8, true),
+            ],
+            vec!["id".to_string()],
+            vec![],
+        )
+        .unwrap();
+        let model = TableModel::from_config(&config).unwrap();
+
+        let is_null = col("id").is_null();
+        assert!(QueryPredicate::supports_filter(&is_null, &model));
+        assert!(QueryPredicate::from_filters(&[is_null], &model).contradiction);
+
+        let is_not_null = col("id").is_not_null();
+        assert!(QueryPredicate::supports_filter(&is_not_null, &model));
+        let pred = QueryPredicate::from_filters(&[is_not_null], &model);
+        assert!(!pred.contradiction);
+        assert!(pred.constraints.is_empty());
+    }
+
+    #[test]
+    fn null_literal_comparisons_are_contradictions() {
+        use datafusion::logical_expr::col;
+        let config = KvTableConfig::new(
+            0,
+            vec![
+                TableColumnConfig::new("id", DataType::Int64, false),
+                TableColumnConfig::new("label", DataType::Utf8, true),
+            ],
+            vec!["id".to_string()],
+            vec![],
+        )
+        .unwrap();
+        let model = TableModel::from_config(&config).unwrap();
+
+        for filter in [
+            col("label").eq(Expr::Literal(ScalarValue::Utf8(None), None)),
+            col("id").gt(Expr::Literal(ScalarValue::Int64(None), None)),
+        ] {
+            assert!(QueryPredicate::supports_filter(&filter, &model));
+            assert!(QueryPredicate::from_filters(&[filter], &model).contradiction);
+        }
+    }
+
+    #[test]
     fn in_predicate_merges_with_comparisons_order_independent() {
         use datafusion::logical_expr::{col, in_list};
         let config = KvTableConfig::new(

--- a/sql/src/lib.rs
+++ b/sql/src/lib.rs
@@ -1613,10 +1613,7 @@ mod tests {
 
         // (label = 'foo') AND (label IS NOT NULL) — IS NOT NULL is implied;
         // predicate must reduce to StringEq('foo') in either order.
-        for filters in [
-            [&eq_foo, &is_not_null],
-            [&is_not_null, &eq_foo],
-        ] {
+        for filters in [[&eq_foo, &is_not_null], [&is_not_null, &eq_foo]] {
             let owned: Vec<Expr> = filters.iter().map(|e| (*e).clone()).collect();
             let pred = QueryPredicate::from_filters(&owned, &model);
             assert!(!pred.contradiction);
@@ -1632,6 +1629,199 @@ mod tests {
             let owned: Vec<Expr> = filters.iter().map(|e| (*e).clone()).collect();
             assert!(QueryPredicate::from_filters(&owned, &model).contradiction);
         }
+    }
+
+    #[test]
+    fn in_predicate_merges_with_comparisons_order_independent() {
+        use datafusion::logical_expr::{col, in_list};
+        let config = KvTableConfig::new(
+            0,
+            vec![
+                TableColumnConfig::new("id", DataType::Int64, false),
+                TableColumnConfig::new("label", DataType::Utf8, true),
+                TableColumnConfig::new("score", DataType::Int64, true),
+                TableColumnConfig::new("version", DataType::UInt64, true),
+                TableColumnConfig::new("hash", DataType::FixedSizeBinary(2), true),
+            ],
+            vec!["id".to_string()],
+            vec![],
+        )
+        .unwrap();
+        let model = TableModel::from_config(&config).unwrap();
+        let label_idx = *model.columns_by_name.get("label").unwrap();
+        let score_idx = *model.columns_by_name.get("score").unwrap();
+        let version_idx = *model.columns_by_name.get("version").unwrap();
+        let hash_idx = *model.columns_by_name.get("hash").unwrap();
+
+        let label_in = in_list(
+            col("label"),
+            vec![
+                Expr::Literal(ScalarValue::Utf8(Some("foo".to_string())), None),
+                Expr::Literal(ScalarValue::Utf8(Some("bar".to_string())), None),
+            ],
+            false,
+        );
+        let label_eq = col("label").eq(Expr::Literal(
+            ScalarValue::Utf8(Some("foo".to_string())),
+            None,
+        ));
+        for filters in [[&label_in, &label_eq], [&label_eq, &label_in]] {
+            let owned: Vec<Expr> = filters.iter().map(|e| (*e).clone()).collect();
+            let pred = QueryPredicate::from_filters(&owned, &model);
+            assert!(!pred.contradiction);
+            assert!(matches!(
+                pred.constraints.get(&label_idx),
+                Some(PredicateConstraint::StringEq(v)) if v == "foo"
+            ));
+        }
+
+        let label_miss = col("label").eq(Expr::Literal(
+            ScalarValue::Utf8(Some("baz".to_string())),
+            None,
+        ));
+        for filters in [[&label_in, &label_miss], [&label_miss, &label_in]] {
+            let owned: Vec<Expr> = filters.iter().map(|e| (*e).clone()).collect();
+            assert!(QueryPredicate::from_filters(&owned, &model).contradiction);
+        }
+
+        let score_in = in_list(
+            col("score"),
+            vec![
+                Expr::Literal(ScalarValue::Int64(Some(1)), None),
+                Expr::Literal(ScalarValue::Int64(Some(2)), None),
+                Expr::Literal(ScalarValue::Int64(Some(3)), None),
+            ],
+            false,
+        );
+        let score_gt = col("score").gt(Expr::Literal(ScalarValue::Int64(Some(1)), None));
+        for filters in [[&score_in, &score_gt], [&score_gt, &score_in]] {
+            let owned: Vec<Expr> = filters.iter().map(|e| (*e).clone()).collect();
+            let pred = QueryPredicate::from_filters(&owned, &model);
+            assert!(!pred.contradiction);
+            assert!(matches!(
+                pred.constraints.get(&score_idx),
+                Some(PredicateConstraint::IntIn(v)) if v == &vec![2, 3]
+            ));
+        }
+
+        let version_in = in_list(
+            col("version"),
+            vec![
+                Expr::Literal(ScalarValue::UInt64(Some(1)), None),
+                Expr::Literal(ScalarValue::UInt64(Some(2)), None),
+                Expr::Literal(ScalarValue::UInt64(Some(3)), None),
+            ],
+            false,
+        );
+        let version_lt = col("version").lt(Expr::Literal(ScalarValue::UInt64(Some(3)), None));
+        for filters in [[&version_in, &version_lt], [&version_lt, &version_in]] {
+            let owned: Vec<Expr> = filters.iter().map(|e| (*e).clone()).collect();
+            let pred = QueryPredicate::from_filters(&owned, &model);
+            assert!(!pred.contradiction);
+            assert!(matches!(
+                pred.constraints.get(&version_idx),
+                Some(PredicateConstraint::UInt64In(v)) if v == &vec![1, 2]
+            ));
+        }
+
+        let hash_in = in_list(
+            col("hash"),
+            vec![
+                Expr::Literal(
+                    ScalarValue::FixedSizeBinary(2, Some(vec![0xAA, 0xAA])),
+                    None,
+                ),
+                Expr::Literal(
+                    ScalarValue::FixedSizeBinary(2, Some(vec![0xBB, 0xBB])),
+                    None,
+                ),
+            ],
+            false,
+        );
+        let hash_eq = col("hash").eq(Expr::Literal(
+            ScalarValue::FixedSizeBinary(2, Some(vec![0xAA, 0xAA])),
+            None,
+        ));
+        for filters in [[&hash_in, &hash_eq], [&hash_eq, &hash_in]] {
+            let owned: Vec<Expr> = filters.iter().map(|e| (*e).clone()).collect();
+            let pred = QueryPredicate::from_filters(&owned, &model);
+            assert!(!pred.contradiction);
+            assert!(matches!(
+                pred.constraints.get(&hash_idx),
+                Some(PredicateConstraint::FixedBinaryEq(v)) if v == &vec![0xAA, 0xAA]
+            ));
+        }
+    }
+
+    #[test]
+    fn empty_and_null_in_lists_are_exact() {
+        use datafusion::logical_expr::{col, in_list};
+        let config = KvTableConfig::new(
+            0,
+            vec![
+                TableColumnConfig::new("id", DataType::Int64, false),
+                TableColumnConfig::new("label", DataType::Utf8, true),
+                TableColumnConfig::new("score", DataType::Float64, true),
+                TableColumnConfig::new("version", DataType::UInt64, true),
+                TableColumnConfig::new("hash", DataType::FixedSizeBinary(2), true),
+            ],
+            vec!["id".to_string()],
+            vec![],
+        )
+        .unwrap();
+        let model = TableModel::from_config(&config).unwrap();
+        let id_idx = *model.columns_by_name.get("id").unwrap();
+
+        for filter in [
+            in_list(col("id"), vec![], false),
+            in_list(
+                col("id"),
+                vec![Expr::Literal(ScalarValue::Int64(None), None)],
+                false,
+            ),
+            in_list(
+                col("label"),
+                vec![Expr::Literal(ScalarValue::Utf8(None), None)],
+                false,
+            ),
+            in_list(
+                col("score"),
+                vec![Expr::Literal(ScalarValue::Float64(None), None)],
+                false,
+            ),
+            in_list(
+                col("version"),
+                vec![Expr::Literal(ScalarValue::UInt64(None), None)],
+                false,
+            ),
+            in_list(
+                col("hash"),
+                vec![Expr::Literal(ScalarValue::FixedSizeBinary(2, None), None)],
+                false,
+            ),
+        ] {
+            assert!(QueryPredicate::supports_filter(&filter, &model));
+            assert!(QueryPredicate::from_filters(&[filter], &model).contradiction);
+        }
+
+        let filter = in_list(
+            col("id"),
+            vec![
+                Expr::Literal(ScalarValue::Int64(Some(7)), None),
+                Expr::Literal(ScalarValue::Int64(None), None),
+            ],
+            false,
+        );
+        assert!(QueryPredicate::supports_filter(&filter, &model));
+        let pred = QueryPredicate::from_filters(&[filter], &model);
+        assert!(!pred.contradiction);
+        assert!(matches!(
+            pred.constraints.get(&id_idx),
+            Some(PredicateConstraint::IntRange {
+                min: Some(7),
+                max: Some(7)
+            })
+        ));
     }
 
     #[test]

--- a/sql/src/predicate.rs
+++ b/sql/src/predicate.rs
@@ -162,11 +162,14 @@ impl QueryPredicate {
                     if let Some(&col_idx) = model.columns_by_name.get(col_name) {
                         match self.constraints.get(&col_idx) {
                             Some(PredicateConstraint::IsNotNull) => self.contradiction = true,
+                            Some(PredicateConstraint::IsNull) => {}
                             None => {
                                 self.constraints
                                     .insert(col_idx, PredicateConstraint::IsNull);
                             }
-                            _ => {}
+                            // Any value-class constraint (StringEq, IntRange, …)
+                            // asserts a non-null value, so IS NULL contradicts it.
+                            Some(_) => self.contradiction = true,
                         }
                     }
                 }
@@ -180,6 +183,8 @@ impl QueryPredicate {
                                 self.constraints
                                     .insert(col_idx, PredicateConstraint::IsNotNull);
                             }
+                            // Existing value-class constraint already implies
+                            // IS NOT NULL; keep the stronger constraint.
                             _ => {}
                         }
                     }
@@ -229,7 +234,9 @@ impl QueryPredicate {
                     Some(PredicateConstraint::StringEq(existing)) if existing != &value => {
                         self.contradiction = true;
                     }
-                    Some(PredicateConstraint::StringEq(_)) | None => {
+                    Some(PredicateConstraint::StringEq(_))
+                    | Some(PredicateConstraint::IsNotNull)
+                    | None => {
                         self.constraints
                             .insert(col_idx, PredicateConstraint::StringEq(value));
                     }
@@ -250,7 +257,9 @@ impl QueryPredicate {
                     Some(PredicateConstraint::BoolEq(existing)) if *existing != value => {
                         self.contradiction = true;
                     }
-                    Some(PredicateConstraint::BoolEq(_)) | None => {
+                    Some(PredicateConstraint::BoolEq(_))
+                    | Some(PredicateConstraint::IsNotNull)
+                    | None => {
                         self.constraints
                             .insert(col_idx, PredicateConstraint::BoolEq(value));
                     }
@@ -266,11 +275,11 @@ impl QueryPredicate {
                 };
                 let (mut min, mut max) = match self.constraints.get(&col_idx) {
                     Some(PredicateConstraint::IntRange { min, max }) => (*min, *max),
+                    Some(PredicateConstraint::IsNotNull) | None => (None, None),
                     Some(_) => {
                         self.contradiction = true;
                         return;
                     }
-                    None => (None, None),
                 };
                 apply_int_constraint(&mut min, &mut max, op, value, &mut self.contradiction);
                 self.constraints
@@ -283,11 +292,11 @@ impl QueryPredicate {
                 };
                 let (mut lo, mut hi) = match self.constraints.get(&col_idx) {
                     Some(PredicateConstraint::FloatRange { min, max }) => (*min, *max),
+                    Some(PredicateConstraint::IsNotNull) | None => (None, None),
                     Some(_) => {
                         self.contradiction = true;
                         return;
                     }
-                    None => (None, None),
                 };
                 apply_float_constraint(&mut lo, &mut hi, op, value, &mut self.contradiction);
                 self.constraints.insert(
@@ -302,11 +311,11 @@ impl QueryPredicate {
                 };
                 let (mut min, mut max) = match self.constraints.get(&col_idx) {
                     Some(PredicateConstraint::IntRange { min, max }) => (*min, *max),
+                    Some(PredicateConstraint::IsNotNull) | None => (None, None),
                     Some(_) => {
                         self.contradiction = true;
                         return;
                     }
-                    None => (None, None),
                 };
                 apply_int_constraint(&mut min, &mut max, op, value, &mut self.contradiction);
                 self.constraints
@@ -319,11 +328,11 @@ impl QueryPredicate {
                 };
                 let (mut min, mut max) = match self.constraints.get(&col_idx) {
                     Some(PredicateConstraint::IntRange { min, max }) => (*min, *max),
+                    Some(PredicateConstraint::IsNotNull) | None => (None, None),
                     Some(_) => {
                         self.contradiction = true;
                         return;
                     }
-                    None => (None, None),
                 };
                 apply_int_constraint(&mut min, &mut max, op, value, &mut self.contradiction);
                 self.constraints
@@ -336,11 +345,11 @@ impl QueryPredicate {
                 };
                 let (mut min, mut max) = match self.constraints.get(&col_idx) {
                     Some(PredicateConstraint::IntRange { min, max }) => (*min, *max),
+                    Some(PredicateConstraint::IsNotNull) | None => (None, None),
                     Some(_) => {
                         self.contradiction = true;
                         return;
                     }
-                    None => (None, None),
                 };
                 apply_int_constraint(&mut min, &mut max, op, value, &mut self.contradiction);
                 self.constraints
@@ -353,11 +362,11 @@ impl QueryPredicate {
                 };
                 let (mut min, mut max) = match self.constraints.get(&col_idx) {
                     Some(PredicateConstraint::Decimal128Range { min, max }) => (*min, *max),
+                    Some(PredicateConstraint::IsNotNull) | None => (None, None),
                     Some(_) => {
                         self.contradiction = true;
                         return;
                     }
-                    None => (None, None),
                 };
                 apply_decimal128_constraint(&mut min, &mut max, op, value, &mut self.contradiction);
                 self.constraints
@@ -370,11 +379,11 @@ impl QueryPredicate {
                 };
                 let (mut min, mut max) = match self.constraints.get(&col_idx) {
                     Some(PredicateConstraint::UInt64Range { min, max }) => (*min, *max),
+                    Some(PredicateConstraint::IsNotNull) | None => (None, None),
                     Some(_) => {
                         self.contradiction = true;
                         return;
                     }
-                    None => (None, None),
                 };
                 apply_u64_constraint(&mut min, &mut max, op, value, &mut self.contradiction);
                 self.constraints
@@ -392,7 +401,9 @@ impl QueryPredicate {
                     Some(PredicateConstraint::FixedBinaryEq(existing)) if *existing != value => {
                         self.contradiction = true;
                     }
-                    Some(PredicateConstraint::FixedBinaryEq(_)) | None => {
+                    Some(PredicateConstraint::FixedBinaryEq(_))
+                    | Some(PredicateConstraint::IsNotNull)
+                    | None => {
                         self.constraints
                             .insert(col_idx, PredicateConstraint::FixedBinaryEq(value));
                     }
@@ -408,11 +419,11 @@ impl QueryPredicate {
                 };
                 let (mut min, mut max) = match self.constraints.get(&col_idx) {
                     Some(PredicateConstraint::Decimal256Range { min, max }) => (*min, *max),
+                    Some(PredicateConstraint::IsNotNull) | None => (None, None),
                     Some(_) => {
                         self.contradiction = true;
                         return;
                     }
-                    None => (None, None),
                 };
                 apply_i256_constraint(&mut min, &mut max, op, value, &mut self.contradiction);
                 self.constraints
@@ -457,7 +468,7 @@ impl QueryPredicate {
                                 .insert(col_idx, PredicateConstraint::StringIn(intersection));
                         }
                     }
-                    None => {
+                    Some(PredicateConstraint::IsNotNull) | None => {
                         vals.sort_unstable();
                         vals.dedup();
                         if vals.len() == 1 {
@@ -518,7 +529,7 @@ impl QueryPredicate {
                                 .insert(col_idx, PredicateConstraint::IntIn(intersection));
                         }
                     }
-                    None => {
+                    Some(PredicateConstraint::IsNotNull) | None => {
                         vals.sort_unstable();
                         vals.dedup();
                         if vals.len() == 1 {
@@ -584,7 +595,7 @@ impl QueryPredicate {
                                 .insert(col_idx, PredicateConstraint::UInt64In(intersection));
                         }
                     }
-                    None => {
+                    Some(PredicateConstraint::IsNotNull) | None => {
                         vals.sort_unstable();
                         vals.dedup();
                         if vals.len() == 1 {
@@ -631,7 +642,7 @@ impl QueryPredicate {
                                 .insert(col_idx, PredicateConstraint::FixedBinaryIn(intersection));
                         }
                     }
-                    None => {
+                    Some(PredicateConstraint::IsNotNull) | None => {
                         vals.sort();
                         vals.dedup();
                         if vals.len() == 1 {

--- a/sql/src/predicate.rs
+++ b/sql/src/predicate.rs
@@ -77,6 +77,9 @@ impl QueryPredicate {
     }
 
     pub(crate) fn in_list_literal_supported(kind: ColumnKind, literal: &ScalarValue) -> bool {
+        if literal.is_null() {
+            return true;
+        }
         match kind {
             ColumnKind::Utf8 => scalar_to_string(literal).is_some(),
             ColumnKind::Int64 => scalar_to_i64(literal).is_some(),
@@ -234,6 +237,14 @@ impl QueryPredicate {
                     Some(PredicateConstraint::StringEq(existing)) if existing != &value => {
                         self.contradiction = true;
                     }
+                    Some(PredicateConstraint::StringIn(existing)) => {
+                        if existing.contains(&value) {
+                            self.constraints
+                                .insert(col_idx, PredicateConstraint::StringEq(value));
+                        } else {
+                            self.contradiction = true;
+                        }
+                    }
                     Some(PredicateConstraint::StringEq(_))
                     | Some(PredicateConstraint::IsNotNull)
                     | None => {
@@ -275,6 +286,15 @@ impl QueryPredicate {
                 };
                 let (mut min, mut max) = match self.constraints.get(&col_idx) {
                     Some(PredicateConstraint::IntRange { min, max }) => (*min, *max),
+                    Some(PredicateConstraint::IntIn(existing)) => {
+                        let filtered = existing
+                            .iter()
+                            .copied()
+                            .filter(|v| ord_satisfies_op(*v, op, value))
+                            .collect();
+                        self.set_int_values_constraint(col_idx, filtered);
+                        return;
+                    }
                     Some(PredicateConstraint::IsNotNull) | None => (None, None),
                     Some(_) => {
                         self.contradiction = true;
@@ -379,6 +399,15 @@ impl QueryPredicate {
                 };
                 let (mut min, mut max) = match self.constraints.get(&col_idx) {
                     Some(PredicateConstraint::UInt64Range { min, max }) => (*min, *max),
+                    Some(PredicateConstraint::UInt64In(existing)) => {
+                        let filtered = existing
+                            .iter()
+                            .copied()
+                            .filter(|v| ord_satisfies_op(*v, op, value))
+                            .collect();
+                        self.set_u64_values_constraint(col_idx, filtered);
+                        return;
+                    }
                     Some(PredicateConstraint::IsNotNull) | None => (None, None),
                     Some(_) => {
                         self.contradiction = true;
@@ -400,6 +429,14 @@ impl QueryPredicate {
                 match self.constraints.get(&col_idx) {
                     Some(PredicateConstraint::FixedBinaryEq(existing)) if *existing != value => {
                         self.contradiction = true;
+                    }
+                    Some(PredicateConstraint::FixedBinaryIn(existing)) => {
+                        if existing.contains(&value) {
+                            self.constraints
+                                .insert(col_idx, PredicateConstraint::FixedBinaryEq(value));
+                        } else {
+                            self.contradiction = true;
+                        }
                     }
                     Some(PredicateConstraint::FixedBinaryEq(_))
                     | Some(PredicateConstraint::IsNotNull)
@@ -440,15 +477,20 @@ impl QueryPredicate {
         let Some(&col_idx) = model.columns_by_name.get(column) else {
             return;
         };
+        // `IN ()` and `IN (NULL) match no rows.
+        if list
+            .iter()
+            .all(|expr| extract_literal(expr).is_some_and(ScalarValue::is_null))
+        {
+            self.contradiction = true;
+            return;
+        }
         match model.columns[col_idx].kind {
             ColumnKind::Utf8 => {
-                let mut vals: Vec<String> = list
+                let vals: Vec<String> = list
                     .iter()
                     .filter_map(|e| extract_literal(e).and_then(scalar_to_string))
                     .collect();
-                if vals.is_empty() {
-                    return;
-                }
                 match self.constraints.get(&col_idx) {
                     Some(PredicateConstraint::StringEq(existing)) => {
                         if !vals.contains(existing) {
@@ -461,60 +503,26 @@ impl QueryPredicate {
                             .filter(|v| vals.contains(v))
                             .cloned()
                             .collect();
-                        if intersection.is_empty() {
-                            self.contradiction = true;
-                        } else {
-                            self.constraints
-                                .insert(col_idx, PredicateConstraint::StringIn(intersection));
-                        }
+                        self.set_string_values_constraint(col_idx, intersection);
                     }
                     Some(PredicateConstraint::IsNotNull) | None => {
-                        vals.sort_unstable();
-                        vals.dedup();
-                        if vals.len() == 1 {
-                            self.constraints.insert(
-                                col_idx,
-                                PredicateConstraint::StringEq(vals.into_iter().next().unwrap()),
-                            );
-                        } else {
-                            self.constraints
-                                .insert(col_idx, PredicateConstraint::StringIn(vals));
-                        }
+                        self.set_string_values_constraint(col_idx, vals);
                     }
                     _ => self.contradiction = true,
                 }
             }
             ColumnKind::Int64 => {
-                let mut vals: Vec<i64> = list
+                let vals: Vec<i64> = list
                     .iter()
                     .filter_map(|e| extract_literal(e).and_then(scalar_to_i64))
                     .collect();
-                if vals.is_empty() {
-                    return;
-                }
                 match self.constraints.get(&col_idx) {
                     Some(PredicateConstraint::IntRange { min, max }) => {
-                        let mut filtered: Vec<i64> = vals
+                        let filtered = vals
                             .into_iter()
                             .filter(|v| in_i64_bounds(*v, *min, *max))
                             .collect();
-                        filtered.sort_unstable();
-                        filtered.dedup();
-                        if filtered.is_empty() {
-                            self.contradiction = true;
-                        } else if filtered.len() == 1 {
-                            let v = filtered[0];
-                            self.constraints.insert(
-                                col_idx,
-                                PredicateConstraint::IntRange {
-                                    min: Some(v),
-                                    max: Some(v),
-                                },
-                            );
-                        } else {
-                            self.constraints
-                                .insert(col_idx, PredicateConstraint::IntIn(filtered));
-                        }
+                        self.set_int_values_constraint(col_idx, filtered);
                     }
                     Some(PredicateConstraint::IntIn(existing)) => {
                         let intersection: Vec<i64> = existing
@@ -522,65 +530,26 @@ impl QueryPredicate {
                             .filter(|v| vals.contains(v))
                             .copied()
                             .collect();
-                        if intersection.is_empty() {
-                            self.contradiction = true;
-                        } else {
-                            self.constraints
-                                .insert(col_idx, PredicateConstraint::IntIn(intersection));
-                        }
+                        self.set_int_values_constraint(col_idx, intersection);
                     }
                     Some(PredicateConstraint::IsNotNull) | None => {
-                        vals.sort_unstable();
-                        vals.dedup();
-                        if vals.len() == 1 {
-                            let v = vals[0];
-                            self.constraints.insert(
-                                col_idx,
-                                PredicateConstraint::IntRange {
-                                    min: Some(v),
-                                    max: Some(v),
-                                },
-                            );
-                        } else {
-                            self.constraints
-                                .insert(col_idx, PredicateConstraint::IntIn(vals));
-                        }
+                        self.set_int_values_constraint(col_idx, vals);
                     }
                     _ => self.contradiction = true,
                 }
             }
             ColumnKind::UInt64 => {
-                let mut vals: Vec<u64> = list
+                let vals: Vec<u64> = list
                     .iter()
                     .filter_map(|e| extract_literal(e).and_then(scalar_to_u64))
                     .collect();
-                if vals.is_empty() {
-                    self.contradiction = true;
-                    return;
-                }
                 match self.constraints.get(&col_idx) {
                     Some(PredicateConstraint::UInt64Range { min, max }) => {
-                        let mut filtered: Vec<u64> = vals
+                        let filtered = vals
                             .into_iter()
                             .filter(|v| in_u64_bounds(*v, *min, *max))
                             .collect();
-                        filtered.sort_unstable();
-                        filtered.dedup();
-                        if filtered.is_empty() {
-                            self.contradiction = true;
-                        } else if filtered.len() == 1 {
-                            let v = filtered[0];
-                            self.constraints.insert(
-                                col_idx,
-                                PredicateConstraint::UInt64Range {
-                                    min: Some(v),
-                                    max: Some(v),
-                                },
-                            );
-                        } else {
-                            self.constraints
-                                .insert(col_idx, PredicateConstraint::UInt64In(filtered));
-                        }
+                        self.set_u64_values_constraint(col_idx, filtered);
                     }
                     Some(PredicateConstraint::UInt64In(existing)) => {
                         let intersection: Vec<u64> = existing
@@ -588,41 +557,19 @@ impl QueryPredicate {
                             .filter(|v| vals.contains(v))
                             .copied()
                             .collect();
-                        if intersection.is_empty() {
-                            self.contradiction = true;
-                        } else {
-                            self.constraints
-                                .insert(col_idx, PredicateConstraint::UInt64In(intersection));
-                        }
+                        self.set_u64_values_constraint(col_idx, intersection);
                     }
                     Some(PredicateConstraint::IsNotNull) | None => {
-                        vals.sort_unstable();
-                        vals.dedup();
-                        if vals.len() == 1 {
-                            let v = vals[0];
-                            self.constraints.insert(
-                                col_idx,
-                                PredicateConstraint::UInt64Range {
-                                    min: Some(v),
-                                    max: Some(v),
-                                },
-                            );
-                        } else {
-                            self.constraints
-                                .insert(col_idx, PredicateConstraint::UInt64In(vals));
-                        }
+                        self.set_u64_values_constraint(col_idx, vals);
                     }
                     _ => self.contradiction = true,
                 }
             }
             ColumnKind::FixedSizeBinary(_) => {
-                let mut vals: Vec<Vec<u8>> = list
+                let vals: Vec<Vec<u8>> = list
                     .iter()
                     .filter_map(|e| extract_literal(e).and_then(scalar_to_fixed_binary))
                     .collect();
-                if vals.is_empty() {
-                    return;
-                }
                 match self.constraints.get(&col_idx) {
                     Some(PredicateConstraint::FixedBinaryEq(existing)) => {
                         if !vals.contains(existing) {
@@ -635,32 +582,95 @@ impl QueryPredicate {
                             .filter(|v| vals.contains(v))
                             .cloned()
                             .collect();
-                        if intersection.is_empty() {
-                            self.contradiction = true;
-                        } else {
-                            self.constraints
-                                .insert(col_idx, PredicateConstraint::FixedBinaryIn(intersection));
-                        }
+                        self.set_fixed_binary_values_constraint(col_idx, intersection);
                     }
                     Some(PredicateConstraint::IsNotNull) | None => {
-                        vals.sort();
-                        vals.dedup();
-                        if vals.len() == 1 {
-                            self.constraints.insert(
-                                col_idx,
-                                PredicateConstraint::FixedBinaryEq(
-                                    vals.into_iter().next().unwrap(),
-                                ),
-                            );
-                        } else {
-                            self.constraints
-                                .insert(col_idx, PredicateConstraint::FixedBinaryIn(vals));
-                        }
+                        self.set_fixed_binary_values_constraint(col_idx, vals);
                     }
                     _ => self.contradiction = true,
                 }
             }
             _ => {}
+        }
+    }
+
+    fn set_string_values_constraint(&mut self, col_idx: usize, mut vals: Vec<String>) {
+        vals.sort_unstable();
+        vals.dedup();
+        match vals.len() {
+            0 => self.contradiction = true,
+            1 => {
+                self.constraints.insert(
+                    col_idx,
+                    PredicateConstraint::StringEq(vals.into_iter().next().unwrap()),
+                );
+            }
+            _ => {
+                self.constraints
+                    .insert(col_idx, PredicateConstraint::StringIn(vals));
+            }
+        }
+    }
+
+    fn set_int_values_constraint(&mut self, col_idx: usize, mut vals: Vec<i64>) {
+        vals.sort_unstable();
+        vals.dedup();
+        match vals.len() {
+            0 => self.contradiction = true,
+            1 => {
+                let v = vals[0];
+                self.constraints.insert(
+                    col_idx,
+                    PredicateConstraint::IntRange {
+                        min: Some(v),
+                        max: Some(v),
+                    },
+                );
+            }
+            _ => {
+                self.constraints
+                    .insert(col_idx, PredicateConstraint::IntIn(vals));
+            }
+        }
+    }
+
+    fn set_u64_values_constraint(&mut self, col_idx: usize, mut vals: Vec<u64>) {
+        vals.sort_unstable();
+        vals.dedup();
+        match vals.len() {
+            0 => self.contradiction = true,
+            1 => {
+                let v = vals[0];
+                self.constraints.insert(
+                    col_idx,
+                    PredicateConstraint::UInt64Range {
+                        min: Some(v),
+                        max: Some(v),
+                    },
+                );
+            }
+            _ => {
+                self.constraints
+                    .insert(col_idx, PredicateConstraint::UInt64In(vals));
+            }
+        }
+    }
+
+    fn set_fixed_binary_values_constraint(&mut self, col_idx: usize, mut vals: Vec<Vec<u8>>) {
+        vals.sort();
+        vals.dedup();
+        match vals.len() {
+            0 => self.contradiction = true,
+            1 => {
+                self.constraints.insert(
+                    col_idx,
+                    PredicateConstraint::FixedBinaryEq(vals.into_iter().next().unwrap()),
+                );
+            }
+            _ => {
+                self.constraints
+                    .insert(col_idx, PredicateConstraint::FixedBinaryIn(vals));
+            }
         }
     }
 
@@ -2202,6 +2212,17 @@ pub(crate) fn in_f64_bounds(
         }
     }
     true
+}
+
+fn ord_satisfies_op<T: Ord>(value: T, op: Operator, literal: T) -> bool {
+    match op {
+        Operator::Eq => value == literal,
+        Operator::Gt => value > literal,
+        Operator::GtEq => value >= literal,
+        Operator::Lt => value < literal,
+        Operator::LtEq => value <= literal,
+        _ => true,
+    }
 }
 
 pub(crate) fn apply_int_constraint(

--- a/sql/src/predicate.rs
+++ b/sql/src/predicate.rs
@@ -125,6 +125,9 @@ impl QueryPredicate {
                 let Some(col_idx) = model.columns_by_name.get(&column).copied() else {
                     return false;
                 };
+                if literal.is_null() {
+                    return true;
+                }
                 let range_ops = matches!(
                     op,
                     Operator::Eq | Operator::Lt | Operator::LtEq | Operator::Gt | Operator::GtEq
@@ -163,16 +166,20 @@ impl QueryPredicate {
             Expr::IsNull(inner) => {
                 if let Some(col_name) = extract_column_name(inner) {
                     if let Some(&col_idx) = model.columns_by_name.get(col_name) {
-                        match self.constraints.get(&col_idx) {
-                            Some(PredicateConstraint::IsNotNull) => self.contradiction = true,
-                            Some(PredicateConstraint::IsNull) => {}
-                            None => {
-                                self.constraints
-                                    .insert(col_idx, PredicateConstraint::IsNull);
+                        if !model.column(col_idx).nullable {
+                            self.contradiction = true;
+                        } else {
+                            match self.constraints.get(&col_idx) {
+                                Some(PredicateConstraint::IsNotNull) => self.contradiction = true,
+                                Some(PredicateConstraint::IsNull) => {}
+                                None => {
+                                    self.constraints
+                                        .insert(col_idx, PredicateConstraint::IsNull);
+                                }
+                                // Any value-class constraint (StringEq, IntRange, …)
+                                // asserts a non-null value, so IS NULL contradicts it.
+                                Some(_) => self.contradiction = true,
                             }
-                            // Any value-class constraint (StringEq, IntRange, …)
-                            // asserts a non-null value, so IS NULL contradicts it.
-                            Some(_) => self.contradiction = true,
                         }
                     }
                 }
@@ -180,16 +187,19 @@ impl QueryPredicate {
             Expr::IsNotNull(inner) => {
                 if let Some(col_name) = extract_column_name(inner) {
                     if let Some(&col_idx) = model.columns_by_name.get(col_name) {
-                        match self.constraints.get(&col_idx) {
-                            Some(PredicateConstraint::IsNull) => self.contradiction = true,
-                            None => {
-                                self.constraints
-                                    .insert(col_idx, PredicateConstraint::IsNotNull);
+                        if model.column(col_idx).nullable {
+                            match self.constraints.get(&col_idx) {
+                                Some(PredicateConstraint::IsNull) => self.contradiction = true,
+                                None => {
+                                    self.constraints
+                                        .insert(col_idx, PredicateConstraint::IsNotNull);
+                                }
+                                // Existing value-class constraint already implies
+                                // IS NOT NULL; keep the stronger constraint.
+                                _ => {}
                             }
-                            // Existing value-class constraint already implies
-                            // IS NOT NULL; keep the stronger constraint.
-                            _ => {}
                         }
+                        // Non-nullable columns: IS NOT NULL is a tautology, drop it.
                     }
                 }
             }
@@ -224,6 +234,11 @@ impl QueryPredicate {
         let Some(col_idx) = model.columns_by_name.get(column).copied() else {
             return;
         };
+        if literal.is_null() {
+            // `col <op> NULL` is always NULL: no row can satisfy it.
+            self.contradiction = true;
+            return;
+        }
         match model.columns[col_idx].kind {
             ColumnKind::Utf8 => {
                 if op != Operator::Eq {


### PR DESCRIPTION
Fixes interaction between contradiction detection and nullability in `QueryPredicate`. Some filters today would be handled incorrectly by this, for example:
- `WHERE label IS NOT NULL AND label = 'foo'` is not a contradiction but is currently considered one.
- `WHERE label = 'foo' AND label IS NULL` is a contradiction but the `IS NULL` filter was being ignored.

Note that `QueryPredicate` is unlikely to actually observe a filter of this shape, even if the user writes it, because the DF expression simplifier already catches redundancies and contradictions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes predicate contradiction detection and constraint-merging logic for `IS NULL`/`IS NOT NULL`, `IN` lists, and `NULL` literals, which can alter filter pushdown and index planning behavior. Covered by new unit tests but impacts query correctness/performance paths.
> 
> **Overview**
> Fixes `QueryPredicate`’s NULL semantics so `IS NULL`/`IS NOT NULL` constraints properly contradict or simplify based on column nullability and existing value constraints (and no longer depend on filter order).
> 
> Tightens handling of `NULL` literals: simple comparisons like `col <op> NULL` and degenerate `IN` lists (empty or all-NULL) now produce explicit contradictions, while mixed `IN` lists ignore NULLs but remain exact.
> 
> Improves constraint merging between `IN` predicates and comparisons (including range ops for `Int64`/`UInt64`) using shared helpers, and adds comprehensive unit tests to lock in order-independent behavior and edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05b0983e8920a6e9ac5fd0abb1b2a68576922e3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->