### PR TITLE
[sql] support DESC pushdown for scan

### DIFF
--- a/sql/rs/src/filter.rs
+++ b/sql/rs/src/filter.rs
@@ -346,38 +346,31 @@ impl ScanAccessPlan {
     pub(crate) fn predicate_fully_enforced_by_primary_key(&self, model: &TableModel) -> bool {
         let mut enforced_pk_positions = vec![false; model.primary_key_indices.len()];
 
-        for (pk_pos, (&col_idx, &kind)) in model
-            .primary_key_indices
-            .iter()
-            .zip(model.primary_key_kinds.iter())
-            .enumerate()
-        {
+        for (pk_pos, &kind) in model.primary_key_kinds.iter().enumerate() {
             let Some(constraint) = self.predicate_checks.iter().find_map(|check| match check {
                 PredicateAccess::Pk {
                     pk_pos: check_pos,
                     constraint,
-                } if model.primary_key_indices[*check_pos] == col_idx => Some(constraint),
+                } if *check_pos == pk_pos => Some(constraint),
                 _ => None,
             }) else {
                 break;
             };
 
-            match primary_key_range_enforcement(kind, constraint) {
-                PrimaryKeyRangeEnforcement::Point => {
+            match primary_key_range_constraint(kind, constraint) {
+                PrimaryKeyRangeConstraint::Point(_) => {
                     enforced_pk_positions[pk_pos] = true;
                 }
-                PrimaryKeyRangeEnforcement::Terminal => {
+                PrimaryKeyRangeConstraint::Terminal(_) => {
                     enforced_pk_positions[pk_pos] = true;
                     break;
                 }
-                PrimaryKeyRangeEnforcement::NotEnforced => break,
+                PrimaryKeyRangeConstraint::NotEnforced => break,
             }
         }
 
         self.predicate_checks.iter().all(|check| match check {
-            PredicateAccess::Pk { pk_pos, .. } => {
-                enforced_pk_positions.get(*pk_pos).copied().unwrap_or(false)
-            }
+            PredicateAccess::Pk { pk_pos, .. } => enforced_pk_positions[*pk_pos],
             PredicateAccess::NonPk { .. } => false,
         })
     }
@@ -466,59 +459,6 @@ pub(crate) fn matches_encoded_constraint(
             }
             true
         }
-    }
-}
-
-#[derive(Clone, Copy)]
-enum PrimaryKeyRangeEnforcement {
-    Point,
-    Terminal,
-    NotEnforced,
-}
-
-fn primary_key_range_enforcement(
-    kind: ColumnKind,
-    constraint: &PredicateConstraint,
-) -> PrimaryKeyRangeEnforcement {
-    match (kind, constraint) {
-        (ColumnKind::Utf8, PredicateConstraint::StringEq(value)) => {
-            if encode_string_variable(value).is_ok() {
-                PrimaryKeyRangeEnforcement::Point
-            } else {
-                PrimaryKeyRangeEnforcement::NotEnforced
-            }
-        }
-        (ColumnKind::Int64, PredicateConstraint::IntRange { min, max }) => {
-            if min.is_some() && min == max {
-                PrimaryKeyRangeEnforcement::Point
-            } else {
-                PrimaryKeyRangeEnforcement::Terminal
-            }
-        }
-        (ColumnKind::Int64, PredicateConstraint::IntIn(values)) if !values.is_empty() => {
-            PrimaryKeyRangeEnforcement::Terminal
-        }
-        (ColumnKind::UInt64, PredicateConstraint::UInt64Range { min, max }) => {
-            if min.is_some() && min == max {
-                PrimaryKeyRangeEnforcement::Point
-            } else {
-                PrimaryKeyRangeEnforcement::Terminal
-            }
-        }
-        (ColumnKind::UInt64, PredicateConstraint::UInt64In(values)) if !values.is_empty() => {
-            PrimaryKeyRangeEnforcement::Terminal
-        }
-        (ColumnKind::FixedSizeBinary(expected), PredicateConstraint::FixedBinaryEq(value))
-            if value.len() == expected =>
-        {
-            PrimaryKeyRangeEnforcement::Point
-        }
-        (ColumnKind::FixedSizeBinary(expected), PredicateConstraint::FixedBinaryIn(values))
-            if !values.is_empty() && values.iter().all(|value| value.len() == expected) =>
-        {
-            PrimaryKeyRangeEnforcement::Terminal
-        }
-        _ => PrimaryKeyRangeEnforcement::NotEnforced,
     }
 }
 

--- a/sql/rs/src/filter.rs
+++ b/sql/rs/src/filter.rs
@@ -345,6 +345,7 @@ impl ScanAccessPlan {
 
     pub(crate) fn predicate_fully_enforced_by_primary_key(&self, model: &TableModel) -> bool {
         let mut enforced_pk_positions = vec![false; model.primary_key_indices.len()];
+        let mut prefix_encoded_width = 0usize;
 
         for (pk_pos, &kind) in model.primary_key_kinds.iter().enumerate() {
             let Some(constraint) = self.predicate_checks.iter().find_map(|check| match check {
@@ -357,9 +358,15 @@ impl ScanAccessPlan {
                 break;
             };
 
-            match primary_key_range_constraint(kind, constraint) {
-                PrimaryKeyRangeConstraint::Point(_) => {
+            match primary_key_range_constraint_for_prefix(
+                model,
+                prefix_encoded_width,
+                kind,
+                constraint,
+            ) {
+                PrimaryKeyRangeConstraint::Point(point) => {
                     enforced_pk_positions[pk_pos] = true;
+                    prefix_encoded_width += point.encoded_width;
                 }
                 PrimaryKeyRangeConstraint::Terminal(_) => {
                     enforced_pk_positions[pk_pos] = true;

--- a/sql/rs/src/filter.rs
+++ b/sql/rs/src/filter.rs
@@ -344,13 +344,39 @@ impl ScanAccessPlan {
     }
 
     pub(crate) fn predicate_fully_enforced_by_primary_key(&self, model: &TableModel) -> bool {
+        let mut enforced_pk_positions = vec![false; model.primary_key_indices.len()];
+
+        for (pk_pos, (&col_idx, &kind)) in model
+            .primary_key_indices
+            .iter()
+            .zip(model.primary_key_kinds.iter())
+            .enumerate()
+        {
+            let Some(constraint) = self.predicate_checks.iter().find_map(|check| match check {
+                PredicateAccess::Pk {
+                    pk_pos: check_pos,
+                    constraint,
+                } if model.primary_key_indices[*check_pos] == col_idx => Some(constraint),
+                _ => None,
+            }) else {
+                break;
+            };
+
+            match primary_key_range_enforcement(kind, constraint) {
+                PrimaryKeyRangeEnforcement::Point => {
+                    enforced_pk_positions[pk_pos] = true;
+                }
+                PrimaryKeyRangeEnforcement::Terminal => {
+                    enforced_pk_positions[pk_pos] = true;
+                    break;
+                }
+                PrimaryKeyRangeEnforcement::NotEnforced => break,
+            }
+        }
+
         self.predicate_checks.iter().all(|check| match check {
-            PredicateAccess::Pk { pk_pos, constraint } => {
-                let kind = model.primary_key_kinds[*pk_pos];
-                !matches!(
-                    compile_encoded_constraint(kind, constraint),
-                    EncodedConstraintCompile::Unsupported
-                )
+            PredicateAccess::Pk { pk_pos, .. } => {
+                enforced_pk_positions.get(*pk_pos).copied().unwrap_or(false)
             }
             PredicateAccess::NonPk { .. } => false,
         })
@@ -440,6 +466,59 @@ pub(crate) fn matches_encoded_constraint(
             }
             true
         }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum PrimaryKeyRangeEnforcement {
+    Point,
+    Terminal,
+    NotEnforced,
+}
+
+fn primary_key_range_enforcement(
+    kind: ColumnKind,
+    constraint: &PredicateConstraint,
+) -> PrimaryKeyRangeEnforcement {
+    match (kind, constraint) {
+        (ColumnKind::Utf8, PredicateConstraint::StringEq(value)) => {
+            if encode_string_variable(value).is_ok() {
+                PrimaryKeyRangeEnforcement::Point
+            } else {
+                PrimaryKeyRangeEnforcement::NotEnforced
+            }
+        }
+        (ColumnKind::Int64, PredicateConstraint::IntRange { min, max }) => {
+            if min.is_some() && min == max {
+                PrimaryKeyRangeEnforcement::Point
+            } else {
+                PrimaryKeyRangeEnforcement::Terminal
+            }
+        }
+        (ColumnKind::Int64, PredicateConstraint::IntIn(values)) if !values.is_empty() => {
+            PrimaryKeyRangeEnforcement::Terminal
+        }
+        (ColumnKind::UInt64, PredicateConstraint::UInt64Range { min, max }) => {
+            if min.is_some() && min == max {
+                PrimaryKeyRangeEnforcement::Point
+            } else {
+                PrimaryKeyRangeEnforcement::Terminal
+            }
+        }
+        (ColumnKind::UInt64, PredicateConstraint::UInt64In(values)) if !values.is_empty() => {
+            PrimaryKeyRangeEnforcement::Terminal
+        }
+        (ColumnKind::FixedSizeBinary(expected), PredicateConstraint::FixedBinaryEq(value))
+            if value.len() == expected =>
+        {
+            PrimaryKeyRangeEnforcement::Point
+        }
+        (ColumnKind::FixedSizeBinary(expected), PredicateConstraint::FixedBinaryIn(values))
+            if !values.is_empty() && values.iter().all(|value| value.len() == expected) =>
+        {
+            PrimaryKeyRangeEnforcement::Terminal
+        }
+        _ => PrimaryKeyRangeEnforcement::NotEnforced,
     }
 }
 

--- a/sql/rs/src/lib.rs
+++ b/sql/rs/src/lib.rs
@@ -6719,6 +6719,59 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn kv_scan_impossible_utf8_primary_key_equality_skips_scan() {
+        let state = MockState {
+            kv: Arc::new(Mutex::new(BTreeMap::new())),
+            range_calls: Arc::new(AtomicUsize::new(0)),
+            range_reduce_calls: Arc::new(AtomicUsize::new(0)),
+            sequence_number: Arc::new(AtomicU64::new(0)),
+        };
+        let (base_url, shutdown_tx) = spawn_mock_server(state.clone()).await;
+        let client = StoreClient::new(&base_url);
+
+        let schema = KvSchema::new(client.clone())
+            .table(
+                "items",
+                vec![TableColumnConfig::new("id", DataType::Utf8, false)],
+                vec!["id".to_string()],
+                vec![],
+            )
+            .expect("schema");
+        let mut writer = schema.batch_writer();
+        writer
+            .insert("items", vec![CellValue::Utf8("present".to_string())])
+            .expect("row");
+        writer.flush().await.expect("seed rows");
+
+        let ctx = SessionContext::new();
+        schema.register_all(&ctx).expect("register");
+
+        let oversized = "a".repeat(exoware_sdk::keys::MAX_KEY_LEN + 1);
+        let sql = format!("SELECT id FROM items WHERE id = '{oversized}'");
+
+        state.range_calls.store(0, AtomicOrdering::SeqCst);
+        let batches = ctx
+            .sql(&sql)
+            .await
+            .expect("query")
+            .collect()
+            .await
+            .expect("collect");
+        assert_eq!(
+            batches.iter().map(|batch| batch.num_rows()).sum::<usize>(),
+            0,
+            "an unencodable PK equality can never match any row"
+        );
+        assert_eq!(
+            state.range_calls.load(AtomicOrdering::SeqCst),
+            0,
+            "an impossible PK equality must not issue a range scan"
+        );
+
+        let _ = shutdown_tx.send(());
+    }
+
+    #[tokio::test]
     async fn kv_scan_index_limit_does_not_push_upstream_when_seen_dedup_can_drop_entries() {
         let observed_limit = Arc::new(AtomicUsize::new(0));
         let config = KvTableConfig::new(

--- a/sql/rs/src/lib.rs
+++ b/sql/rs/src/lib.rs
@@ -708,6 +708,21 @@ mod tests {
         }
     }
 
+    fn collect_i64_column(batches: &[RecordBatch], col_idx: usize) -> Vec<i64> {
+        let mut values = Vec::new();
+        for batch in batches {
+            for row_idx in 0..batch.num_rows() {
+                match ScalarValue::try_from_array(batch.column(col_idx), row_idx)
+                    .expect("int64 scalar should decode")
+                {
+                    ScalarValue::Int64(Some(value)) => values.push(value),
+                    other => panic!("unexpected int64 scalar: {other:?}"),
+                }
+            }
+        }
+        values
+    }
+
     async fn explain_plan_rows(ctx: &SessionContext, sql: &str) -> Vec<(String, String)> {
         let batches = ctx
             .sql(&format!("EXPLAIN {sql}"))
@@ -2959,10 +2974,26 @@ mod tests {
         let mut pred = QueryPredicate::default();
         pred.constraints.insert(
             model.primary_key_indices[0],
-            PredicateConstraint::IntIn(vec![100, 200, 300]),
+            PredicateConstraint::IntIn(vec![200, 100, 300]),
         );
         let ranges = pred.primary_key_ranges(&model).unwrap();
         assert_eq!(ranges.len(), 3);
+        let expected_starts = [100, 200, 300]
+            .into_iter()
+            .map(|id| {
+                let value = CellValue::Int64(id);
+                encode_primary_key_bound(model.table_prefix, &[&value], &model, false)
+                    .expect("primary key lower bound")
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            ranges
+                .iter()
+                .map(|range| range.start.clone())
+                .collect::<Vec<_>>(),
+            expected_starts,
+            "primary_key_ranges should sort terminal IN ranges by encoded start key"
+        );
     }
 
     #[test]
@@ -6566,6 +6597,122 @@ mod tests {
         assert_eq!(
             ScalarValue::try_from_array(batch.column(1), 0).expect("height scalar"),
             ScalarValue::UInt64(Some(9))
+        );
+
+        let _ = shutdown_tx.send(());
+    }
+
+    #[tokio::test]
+    async fn kv_topk_reverse_scan_orders_multiple_primary_key_ranges() {
+        let state = MockState {
+            kv: Arc::new(Mutex::new(BTreeMap::new())),
+            range_calls: Arc::new(AtomicUsize::new(0)),
+            range_reduce_calls: Arc::new(AtomicUsize::new(0)),
+            sequence_number: Arc::new(AtomicU64::new(0)),
+        };
+        let (base_url, shutdown_tx) = spawn_mock_server(state.clone()).await;
+        let client = StoreClient::new(&base_url);
+
+        let schema = KvSchema::new(client.clone())
+            .table(
+                "events",
+                vec![TableColumnConfig::new("id", DataType::Int64, false)],
+                vec!["id".to_string()],
+                vec![],
+            )
+            .expect("schema");
+        let mut writer = schema.batch_writer();
+        for id in [1, 3, 10, 20] {
+            writer
+                .insert("events", vec![CellValue::Int64(id)])
+                .expect("row");
+        }
+        writer.flush().await.expect("seed rows");
+
+        let ctx = SessionContext::new();
+        schema.register_all(&ctx).expect("register");
+        let sql = "SELECT id \
+                   FROM events \
+                   WHERE id IN (3, 20, 1, 10) \
+                   ORDER BY id DESC \
+                   LIMIT 3";
+        let explain = physical_plan_text(&explain_plan_rows(&ctx, sql).await);
+        assert!(
+            explain.contains("KvScanExec: limit=Some(3), direction=Reverse"),
+            "test must exercise reverse top-K scan pushdown over IN ranges:\n{explain}"
+        );
+
+        state.range_calls.store(0, AtomicOrdering::SeqCst);
+        let batches = ctx
+            .sql(sql)
+            .await
+            .expect("query")
+            .collect()
+            .await
+            .expect("collect");
+        assert_eq!(collect_i64_column(&batches, 0), vec![20, 10, 3]);
+        assert_eq!(
+            state.range_calls.load(AtomicOrdering::SeqCst),
+            3,
+            "reverse scan should stop after the three highest IN ranges"
+        );
+
+        let _ = shutdown_tx.send(());
+    }
+
+    #[tokio::test]
+    async fn kv_topk_reverse_scan_applies_offset_over_multiple_primary_key_ranges() {
+        let state = MockState {
+            kv: Arc::new(Mutex::new(BTreeMap::new())),
+            range_calls: Arc::new(AtomicUsize::new(0)),
+            range_reduce_calls: Arc::new(AtomicUsize::new(0)),
+            sequence_number: Arc::new(AtomicU64::new(0)),
+        };
+        let (base_url, shutdown_tx) = spawn_mock_server(state.clone()).await;
+        let client = StoreClient::new(&base_url);
+
+        let schema = KvSchema::new(client.clone())
+            .table(
+                "events",
+                vec![TableColumnConfig::new("id", DataType::Int64, false)],
+                vec!["id".to_string()],
+                vec![],
+            )
+            .expect("schema");
+        let mut writer = schema.batch_writer();
+        for id in [1, 3, 10, 20] {
+            writer
+                .insert("events", vec![CellValue::Int64(id)])
+                .expect("row");
+        }
+        writer.flush().await.expect("seed rows");
+
+        let ctx = SessionContext::new();
+        schema.register_all(&ctx).expect("register");
+        let sql = "SELECT id \
+                   FROM events \
+                   WHERE id IN (3, 20, 1, 10) \
+                   ORDER BY id DESC \
+                   LIMIT 2 OFFSET 1";
+        let explain = physical_plan_text(&explain_plan_rows(&ctx, sql).await);
+        assert!(
+            explain.contains("KvScanExec: limit=Some(3), direction=Reverse"),
+            "OFFSET requires fetching offset + limit rows from the reverse scan:\n{explain}"
+        );
+
+        state.range_calls.store(0, AtomicOrdering::SeqCst);
+        let batches = ctx
+            .sql(sql)
+            .await
+            .expect("query")
+            .collect()
+            .await
+            .expect("collect");
+        assert_eq!(collect_i64_column(&batches, 0), vec![10, 3]);
+        assert_eq!(
+            state.range_calls.load(AtomicOrdering::SeqCst),
+            3,
+            "reverse OFFSET scan should fetch only offset + limit IN ranges"
         );
 
         let _ = shutdown_tx.send(());

--- a/sql/rs/src/lib.rs
+++ b/sql/rs/src/lib.rs
@@ -5902,6 +5902,7 @@ mod tests {
     struct ObservedLimitRangeHarness {
         release_second_chunk: Arc<Notify>,
         observed_limit: Arc<AtomicUsize>,
+        observed_mode: Arc<AtomicUsize>,
         first_frame: ProtoRangeFrame,
         second_frame: ProtoRangeFrame,
     }
@@ -5936,6 +5937,12 @@ mod tests {
         ) -> connectrpc::ServiceResult<connectrpc::ServiceStream<ProtoRangeFrame>> {
             let limit = request.limit.map(|v| v as usize).unwrap_or(usize::MAX);
             self.observed_limit.store(limit, AtomicOrdering::SeqCst);
+            let mode = match parse_range_traversal_direction(request.mode) {
+                Ok(RangeTraversalDirection::Forward) => 0,
+                Ok(RangeTraversalDirection::Reverse) => 1,
+                Err(_) => usize::MAX,
+            };
+            self.observed_mode.store(mode, AtomicOrdering::SeqCst);
             let release_second_chunk = self.release_second_chunk.clone();
             let first_frame = self.first_frame.clone();
             let second_frame = self.second_frame.clone();
@@ -6131,6 +6138,7 @@ mod tests {
     async fn kv_scan_sql_limit_is_pushed_upstream_on_exact_streaming_scan() {
         let release_second_chunk = Arc::new(Notify::new());
         let observed_limit = Arc::new(AtomicUsize::new(0));
+        let observed_mode = Arc::new(AtomicUsize::new(usize::MAX));
         let model = simple_int64_model(0);
 
         let encoded_row = (StoredRow { values: vec![None] }).encode().to_vec();
@@ -6146,6 +6154,7 @@ mod tests {
         let harness = ObservedLimitRangeHarness {
             release_second_chunk: release_second_chunk.clone(),
             observed_limit: observed_limit.clone(),
+            observed_mode,
             first_frame,
             second_frame,
         };
@@ -6172,7 +6181,6 @@ mod tests {
             .expect("schema");
         let ctx = SessionContext::new();
         schema.register_all(&ctx).expect("register");
-
         let batches = tokio::time::timeout(Duration::from_millis(200), async {
             ctx.sql("SELECT id FROM items LIMIT 1")
                 .await
@@ -6194,6 +6202,251 @@ mod tests {
             "exact streaming scan should push SQL LIMIT upstream"
         );
         release_second_chunk.notify_one();
+    }
+
+    #[tokio::test]
+    async fn kv_scan_activity_desc_order_pushes_reverse_range_limit() {
+        let release_second_chunk = Arc::new(Notify::new());
+        let observed_limit = Arc::new(AtomicUsize::new(0));
+        let observed_mode = Arc::new(AtomicUsize::new(usize::MAX));
+        let config = KvTableConfig::new(
+            0,
+            vec![
+                TableColumnConfig::new("account", DataType::UInt64, false),
+                TableColumnConfig::new("height", DataType::UInt64, false),
+                TableColumnConfig::new("index", DataType::UInt64, false),
+                TableColumnConfig::new("role", DataType::UInt64, false),
+            ],
+            vec![
+                "account".to_string(),
+                "height".to_string(),
+                "index".to_string(),
+                "role".to_string(),
+            ],
+            vec![],
+        )
+        .expect("config");
+        let model = TableModel::from_config(&config).expect("model");
+        let encoded_row = (StoredRow {
+            values: vec![None, None, None, None],
+        })
+        .encode()
+        .to_vec();
+
+        let receiver_key = encode_primary_key(
+            model.table_prefix,
+            &[
+                &CellValue::UInt64(7),
+                &CellValue::UInt64(9),
+                &CellValue::UInt64(4),
+                &CellValue::UInt64(1),
+            ],
+            &model,
+        )
+        .expect("receiver primary key");
+        let sender_key = encode_primary_key(
+            model.table_prefix,
+            &[
+                &CellValue::UInt64(7),
+                &CellValue::UInt64(9),
+                &CellValue::UInt64(4),
+                &CellValue::UInt64(0),
+            ],
+            &model,
+        )
+        .expect("sender primary key");
+
+        let first_frame = proto_range_entries_frame(vec![(receiver_key, encoded_row.clone())]);
+        let second_frame = proto_range_entries_frame(vec![(sender_key, encoded_row)]);
+
+        let harness = ObservedLimitRangeHarness {
+            release_second_chunk: release_second_chunk.clone(),
+            observed_limit: observed_limit.clone(),
+            observed_mode: observed_mode.clone(),
+            first_frame,
+            second_frame,
+        };
+        let connect = ConnectRpcService::new(QueryServiceServer::new(harness))
+            .with_compression(connect_compression_registry());
+        let app = Router::new().fallback_service(connect);
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind test listener");
+        let url = format!("http://{}", listener.local_addr().expect("listener addr"));
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.expect("serve test app");
+        });
+
+        let client = StoreClient::new(&url);
+        let schema = KvSchema::new(client)
+            .table(
+                "tx_activity",
+                vec![
+                    TableColumnConfig::new("account", DataType::UInt64, false),
+                    TableColumnConfig::new("height", DataType::UInt64, false),
+                    TableColumnConfig::new("index", DataType::UInt64, false),
+                    TableColumnConfig::new("role", DataType::UInt64, false),
+                ],
+                vec![
+                    "account".to_string(),
+                    "height".to_string(),
+                    "index".to_string(),
+                    "role".to_string(),
+                ],
+                vec![],
+            )
+            .expect("schema");
+        let ctx = SessionContext::new();
+        schema.register_all(&ctx).expect("register");
+
+        let batches = tokio::time::timeout(Duration::from_millis(200), async {
+            ctx.sql(
+                "SELECT height, index, role \
+                 FROM tx_activity \
+                 WHERE account = 7 \
+                 ORDER BY height DESC, index DESC, role DESC \
+                 LIMIT 1",
+            )
+            .await
+            .expect("query")
+            .collect()
+            .await
+            .expect("collect")
+        })
+        .await
+        .expect("activity DESC LIMIT query should not wait for a delayed second chunk");
+
+        assert_eq!(
+            batches.iter().map(|batch| batch.num_rows()).sum::<usize>(),
+            1
+        );
+        assert_eq!(
+            observed_mode.load(AtomicOrdering::SeqCst),
+            1,
+            "activity DESC primary-key order should use reverse range traversal"
+        );
+        assert_eq!(
+            observed_limit.load(AtomicOrdering::SeqCst),
+            1,
+            "activity DESC LIMIT should push the top-K limit to the range request"
+        );
+        release_second_chunk.notify_one();
+    }
+
+    #[tokio::test]
+    async fn kv_scan_activity_mixed_order_does_not_push_range_limit() {
+        let state = MockState {
+            kv: Arc::new(Mutex::new(BTreeMap::new())),
+            range_calls: Arc::new(AtomicUsize::new(0)),
+            range_reduce_calls: Arc::new(AtomicUsize::new(0)),
+            sequence_number: Arc::new(AtomicU64::new(0)),
+        };
+        let (base_url, shutdown_tx) = spawn_mock_server(state).await;
+        let client = StoreClient::new(&base_url);
+
+        let schema = KvSchema::new(client)
+            .table(
+                "tx_activity",
+                vec![
+                    TableColumnConfig::new("account", DataType::UInt64, false),
+                    TableColumnConfig::new("height", DataType::UInt64, false),
+                    TableColumnConfig::new("index", DataType::UInt64, false),
+                    TableColumnConfig::new("role", DataType::UInt64, false),
+                ],
+                vec![
+                    "account".to_string(),
+                    "height".to_string(),
+                    "index".to_string(),
+                    "role".to_string(),
+                ],
+                vec![],
+            )
+            .expect("schema");
+        let ctx = SessionContext::new();
+        schema.register_all(&ctx).expect("register");
+
+        let explain = physical_plan_text(
+            &explain_plan_rows(
+                &ctx,
+                "SELECT height, index, role \
+                 FROM tx_activity \
+                 WHERE account = 7 \
+                 ORDER BY height DESC, index DESC, role ASC \
+                 LIMIT 1",
+            )
+            .await,
+        );
+        assert!(explain.contains("KvScanExec:"));
+        assert!(
+            explain.contains("KvScanExec: limit=None"),
+            "mixed direction order cannot be a bounded key-order scan:\n{explain}"
+        );
+        assert!(
+            !explain.contains("KvScanExec: limit=Some(1)"),
+            "mixed direction order incorrectly pushed top-K into the scan:\n{explain}"
+        );
+
+        let _ = shutdown_tx.send(());
+    }
+
+    #[tokio::test]
+    async fn kv_topk_sort_pushdown_stops_at_filter_exec() {
+        let state = MockState {
+            kv: Arc::new(Mutex::new(BTreeMap::new())),
+            range_calls: Arc::new(AtomicUsize::new(0)),
+            range_reduce_calls: Arc::new(AtomicUsize::new(0)),
+            sequence_number: Arc::new(AtomicU64::new(0)),
+        };
+        let (base_url, shutdown_tx) = spawn_mock_server(state).await;
+        let client = StoreClient::new(&base_url);
+
+        let schema = KvSchema::new(client)
+            .table(
+                "tx_activity",
+                vec![
+                    TableColumnConfig::new("account", DataType::UInt64, false),
+                    TableColumnConfig::new("height", DataType::UInt64, false),
+                    TableColumnConfig::new("index", DataType::UInt64, false),
+                    TableColumnConfig::new("role", DataType::UInt64, false),
+                ],
+                vec![
+                    "account".to_string(),
+                    "height".to_string(),
+                    "index".to_string(),
+                    "role".to_string(),
+                ],
+                vec![],
+            )
+            .expect("schema");
+        let ctx = SessionContext::new();
+        schema.register_all(&ctx).expect("register");
+
+        let explain = physical_plan_text(
+            &explain_plan_rows(
+                &ctx,
+                "SELECT height, index, role \
+                 FROM tx_activity \
+                 WHERE account = 7 AND height + 0 > 1 \
+                 ORDER BY height DESC, index DESC, role DESC \
+                 LIMIT 1",
+            )
+            .await,
+        );
+        assert!(
+            explain.contains("FilterExec"),
+            "unsupported filter should remain above scan:\n{explain}"
+        );
+        assert!(
+            explain.contains("KvScanExec: limit=None"),
+            "top-K fetch must not cross a row-dropping filter:\n{explain}"
+        );
+        assert!(
+            !explain.contains("KvScanExec: limit=Some(1)"),
+            "top-K fetch crossed a filter into the scan:\n{explain}"
+        );
+
+        let _ = shutdown_tx.send(());
     }
 
     #[tokio::test]

--- a/sql/rs/src/lib.rs
+++ b/sql/rs/src/lib.rs
@@ -40,8 +40,11 @@ mod tests {
     use datafusion::arrow::array::{Float64Array, Int64Array, LargeStringArray, StringViewArray};
     use datafusion::arrow::datatypes::{i256, DataType, TimeUnit};
     use datafusion::arrow::record_batch::RecordBatch;
-    use datafusion::common::ScalarValue;
+    use datafusion::common::{config::ConfigOptions, ScalarValue};
     use datafusion::logical_expr::{Expr, Operator};
+    use datafusion::physical_optimizer::limit_pushdown::LimitPushdown;
+    use datafusion::physical_optimizer::PhysicalOptimizerRule;
+    use datafusion::physical_plan::limit::GlobalLimitExec;
     use datafusion::physical_plan::ExecutionPlan;
     use datafusion::prelude::SessionContext;
     use exoware_sdk::keys::{Key, KeyCodec};
@@ -6204,6 +6207,31 @@ mod tests {
         release_second_chunk.notify_one();
     }
 
+    #[test]
+    fn kv_scan_physical_limit_pushdown_sets_leaf_fetch() {
+        let model = Arc::new(simple_int64_model(0));
+        let scan = Arc::new(KvScanExec::new(
+            StoreClient::new("http://127.0.0.1:0"),
+            model.clone(),
+            Arc::new(Vec::new()),
+            QueryPredicate::default(),
+            None,
+            model.schema.clone(),
+            None,
+        ));
+        let limited: Arc<dyn ExecutionPlan> = Arc::new(GlobalLimitExec::new(scan, 0, Some(1)));
+
+        let optimized = LimitPushdown::new()
+            .optimize(limited, &ConfigOptions::new())
+            .expect("limit pushdown");
+
+        let scan = optimized
+            .as_any()
+            .downcast_ref::<KvScanExec>()
+            .expect("physical limit should be converted to a scan fetch");
+        assert_eq!(scan.fetch(), Some(1));
+    }
+
     #[tokio::test]
     async fn kv_scan_activity_desc_order_pushes_reverse_range_limit() {
         let release_second_chunk = Arc::new(Notify::new());
@@ -6444,6 +6472,100 @@ mod tests {
         assert!(
             !explain.contains("KvScanExec: limit=Some(1)"),
             "top-K fetch crossed a filter into the scan:\n{explain}"
+        );
+
+        let _ = shutdown_tx.send(());
+    }
+
+    #[tokio::test]
+    async fn kv_topk_reverse_scan_keeps_reading_after_later_pk_filter_rejects_first_key() {
+        let state = MockState {
+            kv: Arc::new(Mutex::new(BTreeMap::new())),
+            range_calls: Arc::new(AtomicUsize::new(0)),
+            range_reduce_calls: Arc::new(AtomicUsize::new(0)),
+            sequence_number: Arc::new(AtomicU64::new(0)),
+        };
+        let (base_url, shutdown_tx) = spawn_mock_server(state).await;
+        let client = StoreClient::new(&base_url);
+
+        let schema = KvSchema::new(client.clone())
+            .table(
+                "tx_activity",
+                vec![
+                    TableColumnConfig::new("account", DataType::UInt64, false),
+                    TableColumnConfig::new("height", DataType::UInt64, false),
+                    TableColumnConfig::new("index", DataType::UInt64, false),
+                    TableColumnConfig::new("role", DataType::UInt64, false),
+                ],
+                vec![
+                    "account".to_string(),
+                    "height".to_string(),
+                    "index".to_string(),
+                    "role".to_string(),
+                ],
+                vec![],
+            )
+            .expect("schema");
+        let mut writer = schema.batch_writer();
+        writer
+            .insert(
+                "tx_activity",
+                vec![
+                    CellValue::UInt64(8),
+                    CellValue::UInt64(0),
+                    CellValue::UInt64(0),
+                    CellValue::UInt64(0),
+                ],
+            )
+            .expect("non-matching higher key");
+        writer
+            .insert(
+                "tx_activity",
+                vec![
+                    CellValue::UInt64(7),
+                    CellValue::UInt64(9),
+                    CellValue::UInt64(4),
+                    CellValue::UInt64(1),
+                ],
+            )
+            .expect("matching lower key");
+        writer.flush().await.expect("seed rows");
+
+        let ctx = SessionContext::new();
+        schema.register_all(&ctx).expect("register");
+        let sql = "SELECT account, height \
+                   FROM tx_activity \
+                   WHERE account >= 7 AND height = 9 \
+                   ORDER BY account DESC \
+                   LIMIT 1";
+        let explain = physical_plan_text(&explain_plan_rows(&ctx, sql).await);
+        assert!(
+            explain.contains("KvScanExec: limit=Some(1), direction=Reverse"),
+            "test must exercise reverse top-K scan pushdown:\n{explain}"
+        );
+
+        let batches = ctx
+            .sql(sql)
+            .await
+            .expect("query")
+            .collect()
+            .await
+            .expect("collect");
+        assert_eq!(
+            batches.iter().map(|batch| batch.num_rows()).sum::<usize>(),
+            1
+        );
+        let batch = batches
+            .iter()
+            .find(|batch| batch.num_rows() > 0)
+            .expect("non-empty result batch");
+        assert_eq!(
+            ScalarValue::try_from_array(batch.column(0), 0).expect("account scalar"),
+            ScalarValue::UInt64(Some(7))
+        );
+        assert_eq!(
+            ScalarValue::try_from_array(batch.column(1), 0).expect("height scalar"),
+            ScalarValue::UInt64(Some(9))
         );
 
         let _ = shutdown_tx.send(());

--- a/sql/rs/src/lib.rs
+++ b/sql/rs/src/lib.rs
@@ -2953,6 +2953,21 @@ mod tests {
     }
 
     #[test]
+    fn oversized_utf8_primary_key_constraint_is_empty_terminal_range() {
+        let too_large = "a".repeat(exoware_sdk::keys::MAX_KEY_LEN + 1);
+        match primary_key_range_constraint(
+            ColumnKind::Utf8,
+            &PredicateConstraint::StringEq(too_large),
+        ) {
+            PrimaryKeyRangeConstraint::Terminal(spans) => assert!(
+                spans.is_empty(),
+                "unencodable UTF-8 PK equality should be impossible"
+            ),
+            other => panic!("unexpected oversized UTF-8 PK constraint: {other:?}"),
+        }
+    }
+
+    #[test]
     fn in_predicate_generates_multiple_index_ranges() {
         let (model, specs) = test_model();
         let region_idx = *model.columns_by_name.get("region").unwrap();
@@ -3088,6 +3103,41 @@ mod tests {
             ranges.len(),
             2,
             "duplicate FixedBinary IN values must be deduped"
+        );
+    }
+
+    #[test]
+    fn composite_utf8_primary_key_prefix_overflow_produces_no_ranges() {
+        let config = KvTableConfig::new(
+            0,
+            vec![
+                TableColumnConfig::new("a", DataType::Utf8, false),
+                TableColumnConfig::new("b", DataType::Utf8, false),
+            ],
+            vec!["a".to_string(), "b".to_string()],
+            vec![],
+        )
+        .unwrap();
+        let model = TableModel::from_config(&config).unwrap();
+        let capacity = model.primary_key_codec.payload_capacity_bytes();
+        let a = "a".repeat(capacity - 10);
+        let b = "b".repeat(10);
+        let a_width = encode_string_variable(&a).expect("a should encode").len();
+        let b_width = encode_string_variable(&b).expect("b should encode").len();
+        assert!(a_width <= capacity, "first component should fit alone");
+        assert!(
+            a_width + b_width > capacity,
+            "composite UTF-8 prefix should overflow"
+        );
+
+        let mut pred = QueryPredicate::default();
+        pred.constraints.insert(0, PredicateConstraint::StringEq(a));
+        pred.constraints.insert(1, PredicateConstraint::StringEq(b));
+
+        let ranges = pred.primary_key_ranges(&model).unwrap();
+        assert!(
+            ranges.is_empty(),
+            "overflowing composite UTF-8 PK equality can never match"
         );
     }
 
@@ -6746,7 +6796,11 @@ mod tests {
         let ctx = SessionContext::new();
         schema.register_all(&ctx).expect("register");
 
-        let oversized = "a".repeat(exoware_sdk::keys::MAX_KEY_LEN + 1);
+        let oversized = "a".repeat(
+            primary_key_codec(0)
+                .expect("primary-key codec")
+                .payload_capacity_bytes(),
+        );
         let sql = format!("SELECT id FROM items WHERE id = '{oversized}'");
 
         state.range_calls.store(0, AtomicOrdering::SeqCst);

--- a/sql/rs/src/predicate.rs
+++ b/sql/rs/src/predicate.rs
@@ -42,6 +42,109 @@ pub(crate) enum PredicateConstraint {
     FixedBinaryIn(Vec<Vec<u8>>),
 }
 
+#[derive(Debug, Clone)]
+pub(crate) struct PrimaryKeyTerminalRange {
+    lower: CellValue,
+    upper: CellValue,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum PrimaryKeyRangeConstraint {
+    Point(CellValue),
+    Terminal(Vec<PrimaryKeyTerminalRange>),
+    NotEnforced,
+}
+
+impl PrimaryKeyRangeConstraint {
+    pub(crate) fn is_point(&self) -> bool {
+        matches!(self, Self::Point(_))
+    }
+}
+
+pub(crate) fn primary_key_range_constraint(
+    kind: ColumnKind,
+    constraint: &PredicateConstraint,
+) -> PrimaryKeyRangeConstraint {
+    match (kind, constraint) {
+        (ColumnKind::Utf8, PredicateConstraint::StringEq(value)) => {
+            if encode_string_variable(value).is_ok() {
+                PrimaryKeyRangeConstraint::Point(CellValue::Utf8(value.clone()))
+            } else {
+                PrimaryKeyRangeConstraint::NotEnforced
+            }
+        }
+        (ColumnKind::Int64, PredicateConstraint::IntRange { min, max }) => {
+            let lower = min.unwrap_or(i64::MIN);
+            let upper = max.unwrap_or(i64::MAX);
+            if lower > upper {
+                PrimaryKeyRangeConstraint::Terminal(Vec::new())
+            } else if min.is_some() && min == max {
+                PrimaryKeyRangeConstraint::Point(CellValue::Int64(lower))
+            } else {
+                PrimaryKeyRangeConstraint::Terminal(vec![PrimaryKeyTerminalRange {
+                    lower: CellValue::Int64(lower),
+                    upper: CellValue::Int64(upper),
+                }])
+            }
+        }
+        (ColumnKind::Int64, PredicateConstraint::IntIn(values)) if !values.is_empty() => {
+            PrimaryKeyRangeConstraint::Terminal(
+                values
+                    .iter()
+                    .map(|&value| PrimaryKeyTerminalRange {
+                        lower: CellValue::Int64(value),
+                        upper: CellValue::Int64(value),
+                    })
+                    .collect(),
+            )
+        }
+        (ColumnKind::UInt64, PredicateConstraint::UInt64Range { min, max }) => {
+            let lower = min.unwrap_or(0);
+            let upper = max.unwrap_or(u64::MAX);
+            if lower > upper {
+                PrimaryKeyRangeConstraint::Terminal(Vec::new())
+            } else if min.is_some() && min == max {
+                PrimaryKeyRangeConstraint::Point(CellValue::UInt64(lower))
+            } else {
+                PrimaryKeyRangeConstraint::Terminal(vec![PrimaryKeyTerminalRange {
+                    lower: CellValue::UInt64(lower),
+                    upper: CellValue::UInt64(upper),
+                }])
+            }
+        }
+        (ColumnKind::UInt64, PredicateConstraint::UInt64In(values)) if !values.is_empty() => {
+            PrimaryKeyRangeConstraint::Terminal(
+                values
+                    .iter()
+                    .map(|&value| PrimaryKeyTerminalRange {
+                        lower: CellValue::UInt64(value),
+                        upper: CellValue::UInt64(value),
+                    })
+                    .collect(),
+            )
+        }
+        (ColumnKind::FixedSizeBinary(expected), PredicateConstraint::FixedBinaryEq(value))
+            if value.len() == expected =>
+        {
+            PrimaryKeyRangeConstraint::Point(CellValue::FixedBinary(value.clone()))
+        }
+        (ColumnKind::FixedSizeBinary(expected), PredicateConstraint::FixedBinaryIn(values))
+            if !values.is_empty() && values.iter().all(|value| value.len() == expected) =>
+        {
+            PrimaryKeyRangeConstraint::Terminal(
+                values
+                    .iter()
+                    .map(|value| PrimaryKeyTerminalRange {
+                        lower: CellValue::FixedBinary(value.clone()),
+                        upper: CellValue::FixedBinary(value.clone()),
+                    })
+                    .collect(),
+            )
+        }
+        _ => PrimaryKeyRangeConstraint::NotEnforced,
+    }
+}
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct QueryPredicate {
     pub(crate) constraints: HashMap<usize, PredicateConstraint>,
@@ -1674,165 +1777,50 @@ impl QueryPredicate {
             return Ok(Vec::new());
         }
 
-        // Walk PK columns left-to-right collecting equality-constrained
-        // prefix values. When we hit a range-constrained or unconstrained
-        // column, produce the final key range(s).
         let mut prefix_values: Vec<CellValue> = Vec::new();
 
-        for (pos, (&pk_idx, &pk_kind)) in model
+        for (&pk_idx, &pk_kind) in model
             .primary_key_indices
             .iter()
             .zip(model.primary_key_kinds.iter())
-            .enumerate()
         {
-            match pk_kind {
-                ColumnKind::FixedSizeBinary(_) => match self.constraints.get(&pk_idx) {
-                    Some(PredicateConstraint::FixedBinaryEq(data)) => {
-                        prefix_values.push(CellValue::FixedBinary(data.clone()));
-                        continue;
-                    }
-                    Some(PredicateConstraint::FixedBinaryIn(values)) => {
-                        let mut ranges = Vec::with_capacity(values.len());
-                        for data in values {
-                            let mut lo = prefix_values.clone();
-                            lo.push(CellValue::FixedBinary(data.clone()));
-                            let refs: Vec<&CellValue> = lo.iter().collect();
-                            ranges.push(KeyRange {
-                                start: encode_primary_key_bound(
-                                    model.table_prefix,
-                                    &refs,
-                                    model,
-                                    false,
-                                )
-                                .map_err(DataFusionError::Execution)?,
-                                end: encode_primary_key_bound(
-                                    model.table_prefix,
-                                    &refs,
-                                    model,
-                                    true,
-                                )
-                                .map_err(DataFusionError::Execution)?,
-                            });
-                        }
-                        return Ok(ranges);
-                    }
-                    _ => break,
-                },
-                ColumnKind::Int64 => {
-                    if let Some(PredicateConstraint::IntIn(values)) = self.constraints.get(&pk_idx)
-                    {
-                        let mut ranges = Vec::with_capacity(values.len());
-                        for &v in values {
-                            let mut lo = prefix_values.clone();
-                            lo.push(CellValue::Int64(v));
-                            let refs: Vec<&CellValue> = lo.iter().collect();
-                            ranges.push(KeyRange {
-                                start: encode_primary_key_bound(
-                                    model.table_prefix,
-                                    &refs,
-                                    model,
-                                    false,
-                                )
-                                .map_err(DataFusionError::Execution)?,
-                                end: encode_primary_key_bound(
-                                    model.table_prefix,
-                                    &refs,
-                                    model,
-                                    true,
-                                )
-                                .map_err(DataFusionError::Execution)?,
-                            });
-                        }
-                        return Ok(ranges);
-                    }
-                    let (pk_min, pk_max) = self.int_bounds(pk_idx);
-                    if let (Some(lo), Some(hi)) = (pk_min, pk_max) {
-                        if lo == hi {
-                            prefix_values.push(CellValue::Int64(lo));
-                            continue;
-                        }
-                    }
-                    if pk_min.is_none() && pk_max.is_none() && pos == 0 {
-                        return Ok(vec![primary_key_prefix_range(model.table_prefix)]);
-                    }
-                    let mut lo = prefix_values.clone();
-                    lo.push(CellValue::Int64(pk_min.unwrap_or(i64::MIN)));
-                    let mut hi = prefix_values;
-                    hi.push(CellValue::Int64(pk_max.unwrap_or(i64::MAX)));
-                    let lo_refs: Vec<&CellValue> = lo.iter().collect();
-                    let hi_refs: Vec<&CellValue> = hi.iter().collect();
-                    return Ok(vec![KeyRange {
-                        start: encode_primary_key_bound(model.table_prefix, &lo_refs, model, false)
-                            .map_err(DataFusionError::Execution)?,
-                        end: encode_primary_key_bound(model.table_prefix, &hi_refs, model, true)
-                            .map_err(DataFusionError::Execution)?,
-                    }]);
+            let Some(constraint) = self.constraints.get(&pk_idx) else {
+                break;
+            };
+            match primary_key_range_constraint(pk_kind, constraint) {
+                PrimaryKeyRangeConstraint::Point(value) => {
+                    prefix_values.push(value);
                 }
-                ColumnKind::UInt64 => {
-                    if let Some(PredicateConstraint::UInt64In(values)) =
-                        self.constraints.get(&pk_idx)
-                    {
-                        let mut ranges = Vec::new();
-                        for &v in values {
-                            let mut lo = prefix_values.clone();
-                            lo.push(CellValue::UInt64(v));
-                            let refs: Vec<&CellValue> = lo.iter().collect();
-                            ranges.push(KeyRange {
-                                start: encode_primary_key_bound(
-                                    model.table_prefix,
-                                    &refs,
-                                    model,
-                                    false,
-                                )
-                                .map_err(DataFusionError::Execution)?,
-                                end: encode_primary_key_bound(
-                                    model.table_prefix,
-                                    &refs,
-                                    model,
-                                    true,
-                                )
-                                .map_err(DataFusionError::Execution)?,
-                            });
-                        }
-                        return Ok(ranges);
-                    }
-                    let (pk_min, pk_max) = match self.constraints.get(&pk_idx) {
-                        Some(PredicateConstraint::UInt64Range { min, max }) => (*min, *max),
-                        _ => (None, None),
-                    };
-                    let pk_lower = pk_min.unwrap_or(0);
-                    let pk_upper = pk_max.unwrap_or(u64::MAX);
-                    if pk_lower > pk_upper {
-                        return Ok(Vec::new());
-                    }
-                    if pk_lower == pk_upper {
-                        prefix_values.push(CellValue::UInt64(pk_lower));
-                        continue;
-                    }
-                    if pk_min.is_none() && pk_max.is_none() && pos == 0 {
-                        return Ok(vec![primary_key_prefix_range(model.table_prefix)]);
-                    }
-                    let mut lo = prefix_values.clone();
-                    lo.push(CellValue::UInt64(pk_lower));
-                    let mut hi = prefix_values;
-                    hi.push(CellValue::UInt64(pk_upper));
-                    let lo_refs: Vec<&CellValue> = lo.iter().collect();
-                    let hi_refs: Vec<&CellValue> = hi.iter().collect();
-                    return Ok(vec![KeyRange {
-                        start: encode_primary_key_bound(model.table_prefix, &lo_refs, model, false)
+                PrimaryKeyRangeConstraint::Terminal(spans) => {
+                    let mut ranges = Vec::with_capacity(spans.len());
+                    for span in spans {
+                        let mut lo = prefix_values.clone();
+                        lo.push(span.lower);
+                        let mut hi = prefix_values.clone();
+                        hi.push(span.upper);
+                        let lo_refs: Vec<&CellValue> = lo.iter().collect();
+                        let hi_refs: Vec<&CellValue> = hi.iter().collect();
+                        ranges.push(KeyRange {
+                            start: encode_primary_key_bound(
+                                model.table_prefix,
+                                &lo_refs,
+                                model,
+                                false,
+                            )
                             .map_err(DataFusionError::Execution)?,
-                        end: encode_primary_key_bound(model.table_prefix, &hi_refs, model, true)
+                            end: encode_primary_key_bound(
+                                model.table_prefix,
+                                &hi_refs,
+                                model,
+                                true,
+                            )
                             .map_err(DataFusionError::Execution)?,
-                    }]);
-                }
-                ColumnKind::Utf8 => {
-                    if let Some(PredicateConstraint::StringEq(s)) = self.constraints.get(&pk_idx) {
-                        prefix_values.push(CellValue::Utf8(s.clone()));
-                        continue;
+                        });
                     }
-                    break;
+                    ranges.sort_by(|lhs, rhs| lhs.start.cmp(&rhs.start));
+                    return Ok(ranges);
                 }
-                _ => break,
+                PrimaryKeyRangeConstraint::NotEnforced => break,
             }
         }
 

--- a/sql/rs/src/predicate.rs
+++ b/sql/rs/src/predicate.rs
@@ -49,16 +49,23 @@ pub(crate) struct PrimaryKeyTerminalRange {
 }
 
 #[derive(Debug, Clone)]
+pub(crate) struct PrimaryKeyPointConstraint {
+    pub(crate) value: CellValue,
+    pub(crate) encoded_width: usize,
+}
+
+#[derive(Debug, Clone)]
 pub(crate) enum PrimaryKeyRangeConstraint {
-    Point(CellValue),
+    Point(PrimaryKeyPointConstraint),
     Terminal(Vec<PrimaryKeyTerminalRange>),
     NotEnforced,
 }
 
-impl PrimaryKeyRangeConstraint {
-    pub(crate) fn is_point(&self) -> bool {
-        matches!(self, Self::Point(_))
-    }
+fn primary_key_point(value: CellValue, encoded_width: usize) -> PrimaryKeyRangeConstraint {
+    PrimaryKeyRangeConstraint::Point(PrimaryKeyPointConstraint {
+        value,
+        encoded_width,
+    })
 }
 
 pub(crate) fn primary_key_range_constraint(
@@ -67,10 +74,9 @@ pub(crate) fn primary_key_range_constraint(
 ) -> PrimaryKeyRangeConstraint {
     match (kind, constraint) {
         (ColumnKind::Utf8, PredicateConstraint::StringEq(value)) => {
-            if encode_string_variable(value).is_ok() {
-                PrimaryKeyRangeConstraint::Point(CellValue::Utf8(value.clone()))
-            } else {
-                PrimaryKeyRangeConstraint::Terminal(Vec::new())
+            match encode_string_variable(value) {
+                Ok(encoded) => primary_key_point(CellValue::Utf8(value.clone()), encoded.len()),
+                Err(_) => PrimaryKeyRangeConstraint::Terminal(Vec::new()),
             }
         }
         (ColumnKind::Int64, PredicateConstraint::IntRange { min, max }) => {
@@ -79,7 +85,7 @@ pub(crate) fn primary_key_range_constraint(
             if lower > upper {
                 PrimaryKeyRangeConstraint::Terminal(Vec::new())
             } else if min.is_some() && min == max {
-                PrimaryKeyRangeConstraint::Point(CellValue::Int64(lower))
+                primary_key_point(CellValue::Int64(lower), kind.key_width())
             } else {
                 PrimaryKeyRangeConstraint::Terminal(vec![PrimaryKeyTerminalRange {
                     lower: CellValue::Int64(lower),
@@ -104,7 +110,7 @@ pub(crate) fn primary_key_range_constraint(
             if lower > upper {
                 PrimaryKeyRangeConstraint::Terminal(Vec::new())
             } else if min.is_some() && min == max {
-                PrimaryKeyRangeConstraint::Point(CellValue::UInt64(lower))
+                primary_key_point(CellValue::UInt64(lower), kind.key_width())
             } else {
                 PrimaryKeyRangeConstraint::Terminal(vec![PrimaryKeyTerminalRange {
                     lower: CellValue::UInt64(lower),
@@ -126,7 +132,7 @@ pub(crate) fn primary_key_range_constraint(
         (ColumnKind::FixedSizeBinary(expected), PredicateConstraint::FixedBinaryEq(value))
             if value.len() == expected =>
         {
-            PrimaryKeyRangeConstraint::Point(CellValue::FixedBinary(value.clone()))
+            primary_key_point(CellValue::FixedBinary(value.clone()), expected)
         }
         (ColumnKind::FixedSizeBinary(expected), PredicateConstraint::FixedBinaryIn(values))
             if !values.is_empty() && values.iter().all(|value| value.len() == expected) =>
@@ -142,6 +148,58 @@ pub(crate) fn primary_key_range_constraint(
             )
         }
         _ => PrimaryKeyRangeConstraint::NotEnforced,
+    }
+}
+
+fn primary_key_value_encoded_width(value: &CellValue, kind: ColumnKind) -> Option<usize> {
+    encode_cell_into_ordered_key_bytes(value, kind)
+        .ok()
+        .map(|encoded| encoded.len())
+}
+
+fn primary_key_prefix_width_fits(
+    model: &TableModel,
+    prefix_encoded_width: usize,
+    value_encoded_width: usize,
+) -> bool {
+    prefix_encoded_width
+        .checked_add(value_encoded_width)
+        .is_some_and(|width| width <= model.primary_key_codec.payload_capacity_bytes())
+}
+
+pub(crate) fn primary_key_range_constraint_for_prefix(
+    model: &TableModel,
+    prefix_encoded_width: usize,
+    kind: ColumnKind,
+    constraint: &PredicateConstraint,
+) -> PrimaryKeyRangeConstraint {
+    match primary_key_range_constraint(kind, constraint) {
+        PrimaryKeyRangeConstraint::Point(point) => {
+            if primary_key_prefix_width_fits(model, prefix_encoded_width, point.encoded_width) {
+                PrimaryKeyRangeConstraint::Point(point)
+            } else {
+                PrimaryKeyRangeConstraint::Terminal(Vec::new())
+            }
+        }
+        PrimaryKeyRangeConstraint::Terminal(spans) => {
+            let fitting_spans = spans
+                .into_iter()
+                .filter(|span| {
+                    let Some(lower_width) = primary_key_value_encoded_width(&span.lower, kind)
+                    else {
+                        return false;
+                    };
+                    let Some(upper_width) = primary_key_value_encoded_width(&span.upper, kind)
+                    else {
+                        return false;
+                    };
+                    primary_key_prefix_width_fits(model, prefix_encoded_width, lower_width)
+                        && primary_key_prefix_width_fits(model, prefix_encoded_width, upper_width)
+                })
+                .collect();
+            PrimaryKeyRangeConstraint::Terminal(fitting_spans)
+        }
+        PrimaryKeyRangeConstraint::NotEnforced => PrimaryKeyRangeConstraint::NotEnforced,
     }
 }
 
@@ -1778,6 +1836,7 @@ impl QueryPredicate {
         }
 
         let mut prefix_values: Vec<CellValue> = Vec::new();
+        let mut prefix_encoded_width = 0usize;
 
         for (&pk_idx, &pk_kind) in model
             .primary_key_indices
@@ -1787,9 +1846,15 @@ impl QueryPredicate {
             let Some(constraint) = self.constraints.get(&pk_idx) else {
                 break;
             };
-            match primary_key_range_constraint(pk_kind, constraint) {
-                PrimaryKeyRangeConstraint::Point(value) => {
-                    prefix_values.push(value);
+            match primary_key_range_constraint_for_prefix(
+                model,
+                prefix_encoded_width,
+                pk_kind,
+                constraint,
+            ) {
+                PrimaryKeyRangeConstraint::Point(point) => {
+                    prefix_encoded_width += point.encoded_width;
+                    prefix_values.push(point.value);
                 }
                 PrimaryKeyRangeConstraint::Terminal(spans) => {
                     let mut ranges = Vec::with_capacity(spans.len());

--- a/sql/rs/src/predicate.rs
+++ b/sql/rs/src/predicate.rs
@@ -70,7 +70,7 @@ pub(crate) fn primary_key_range_constraint(
             if encode_string_variable(value).is_ok() {
                 PrimaryKeyRangeConstraint::Point(CellValue::Utf8(value.clone()))
             } else {
-                PrimaryKeyRangeConstraint::NotEnforced
+                PrimaryKeyRangeConstraint::Terminal(Vec::new())
             }
         }
         (ColumnKind::Int64, PredicateConstraint::IntRange { min, max }) => {

--- a/sql/rs/src/scan.rs
+++ b/sql/rs/src/scan.rs
@@ -175,21 +175,43 @@ impl KvScanExec {
     }
 
     fn primary_key_order_columns_after_eq_prefix(&self) -> Vec<usize> {
-        self.model
+        let mut prefix_encoded_width = 0usize;
+        let mut key_columns = Vec::new();
+        let mut in_order_tail = false;
+
+        for (&col_idx, &kind) in self
+            .model
             .primary_key_indices
             .iter()
-            .copied()
-            .zip(self.model.primary_key_kinds.iter().copied())
-            .skip_while(|(col_idx, kind)| {
-                self.predicate
-                    .constraints
-                    .get(col_idx)
-                    .is_some_and(|constraint| {
-                        primary_key_range_constraint(*kind, constraint).is_point()
-                    })
-            })
-            .map(|(col_idx, _kind)| col_idx)
-            .collect()
+            .zip(self.model.primary_key_kinds.iter())
+        {
+            if in_order_tail {
+                key_columns.push(col_idx);
+                continue;
+            }
+
+            let Some(constraint) = self.predicate.constraints.get(&col_idx) else {
+                in_order_tail = true;
+                key_columns.push(col_idx);
+                continue;
+            };
+            match primary_key_range_constraint_for_prefix(
+                &self.model,
+                prefix_encoded_width,
+                kind,
+                constraint,
+            ) {
+                PrimaryKeyRangeConstraint::Point(point) => {
+                    prefix_encoded_width += point.encoded_width;
+                }
+                PrimaryKeyRangeConstraint::Terminal(_) | PrimaryKeyRangeConstraint::NotEnforced => {
+                    in_order_tail = true;
+                    key_columns.push(col_idx);
+                }
+            }
+        }
+
+        key_columns
     }
 
     pub(crate) fn plan_diagnostics(&self) -> DataFusionResult<AccessPathDiagnostics> {

--- a/sql/rs/src/scan.rs
+++ b/sql/rs/src/scan.rs
@@ -292,10 +292,6 @@ impl ExecutionPlan for KvScanExec {
         )))
     }
 
-    fn supports_limit_pushdown(&self) -> bool {
-        true
-    }
-
     fn with_fetch(&self, limit: Option<usize>) -> Option<Arc<dyn ExecutionPlan>> {
         let limit = match (self.limit, limit) {
             (Some(existing), Some(limit)) => Some(existing.min(limit)),

--- a/sql/rs/src/scan.rs
+++ b/sql/rs/src/scan.rs
@@ -179,12 +179,16 @@ impl KvScanExec {
             .primary_key_indices
             .iter()
             .copied()
-            .skip_while(|col_idx| {
+            .zip(self.model.primary_key_kinds.iter().copied())
+            .skip_while(|(col_idx, kind)| {
                 self.predicate
                     .constraints
                     .get(col_idx)
-                    .is_some_and(single_value_constraint)
+                    .is_some_and(|constraint| {
+                        primary_key_range_constraint(*kind, constraint).is_point()
+                    })
             })
+            .map(|(col_idx, _kind)| col_idx)
             .collect()
     }
 
@@ -380,27 +384,11 @@ pub(crate) async fn stream_kv_scan(
             .access_plan
             .index_covers_required_non_pk(&index_specs[plan.spec_idx])
         {
-            return stream_index_scan(
-                tx,
-                ctx,
-                index_specs,
-                &plan,
-                flush_threshold,
-                target_rows,
-                direction,
-            )
-            .await;
+            return stream_index_scan(tx, ctx, index_specs, &plan, flush_threshold, target_rows)
+                .await;
         }
-        return stream_index_lookup_scan(
-            tx,
-            ctx,
-            index_specs,
-            &plan,
-            flush_threshold,
-            target_rows,
-            direction,
-        )
-        .await;
+        return stream_index_lookup_scan(tx, ctx, index_specs, &plan, flush_threshold, target_rows)
+            .await;
     }
 
     let exact = ctx
@@ -489,7 +477,6 @@ pub(crate) async fn stream_index_lookup_scan(
     plan: &IndexPlan,
     flush_threshold: usize,
     target_rows: usize,
-    direction: ScanDirection,
 ) -> DataFusionResult<()> {
     let spec = &index_specs[plan.spec_idx];
     let key_predicate_plan = ctx
@@ -502,13 +489,18 @@ pub(crate) async fn stream_index_lookup_scan(
     let mut emitted = 0usize;
     let mut batch_builder = ProjectedBatchBuilder::from_access_plan(ctx.model, ctx.access_plan);
 
-    for range in ordered_ranges(&plan.ranges, direction) {
+    for range in &plan.ranges {
         if emitted + batch_builder.row_count() >= target_rows {
             break;
         }
-        let mut stream =
-            range_stream_with_direction(ctx.session, range, usize::MAX, flush_threshold, direction)
-                .await?;
+        let mut stream = range_stream_with_direction(
+            ctx.session,
+            range,
+            usize::MAX,
+            flush_threshold,
+            ScanDirection::Forward,
+        )
+        .await?;
         while let Some(chunk) = stream
             .next_chunk()
             .await
@@ -598,7 +590,6 @@ pub(crate) async fn stream_index_scan(
     plan: &IndexPlan,
     flush_threshold: usize,
     target_rows: usize,
-    direction: ScanDirection,
 ) -> DataFusionResult<()> {
     let spec = &index_specs[plan.spec_idx];
     let key_predicate_plan = ctx
@@ -611,7 +602,7 @@ pub(crate) async fn stream_index_scan(
     let mut emitted = 0usize;
     let mut batch_builder = ProjectedBatchBuilder::from_access_plan(ctx.model, ctx.access_plan);
 
-    for range in ordered_ranges(&plan.ranges, direction) {
+    for range in &plan.ranges {
         if emitted + batch_builder.row_count() >= target_rows {
             break;
         }
@@ -619,9 +610,14 @@ pub(crate) async fn stream_index_scan(
         if remaining == 0 {
             break;
         }
-        let mut stream =
-            range_stream_with_direction(ctx.session, range, usize::MAX, flush_threshold, direction)
-                .await?;
+        let mut stream = range_stream_with_direction(
+            ctx.session,
+            range,
+            usize::MAX,
+            flush_threshold,
+            ScanDirection::Forward,
+        )
+        .await?;
         while let Some(chunk) = stream
             .next_chunk()
             .await
@@ -717,35 +713,6 @@ async fn range_stream_with_direction(
         )
         .await
         .map_err(|e| DataFusionError::External(Box::new(e)))
-}
-
-fn single_value_constraint(constraint: &PredicateConstraint) -> bool {
-    match constraint {
-        PredicateConstraint::StringEq(_)
-        | PredicateConstraint::BoolEq(_)
-        | PredicateConstraint::FixedBinaryEq(_) => true,
-        PredicateConstraint::IntRange {
-            min: Some(min),
-            max: Some(max),
-        } => min == max,
-        PredicateConstraint::UInt64Range {
-            min: Some(min),
-            max: Some(max),
-        } => min == max,
-        PredicateConstraint::FloatRange {
-            min: Some((min, min_inclusive)),
-            max: Some((max, max_inclusive)),
-        } => *min_inclusive && *max_inclusive && min == max,
-        PredicateConstraint::Decimal128Range {
-            min: Some(min),
-            max: Some(max),
-        } => min == max,
-        PredicateConstraint::Decimal256Range {
-            min: Some(min),
-            max: Some(max),
-        } => min == max,
-        _ => false,
-    }
 }
 
 #[derive(Debug, Clone, Default)]

--- a/sql/rs/src/scan.rs
+++ b/sql/rs/src/scan.rs
@@ -5,18 +5,23 @@ use std::sync::Arc;
 
 use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::common::config::ConfigOptions;
+use datafusion::common::tree_node::{Transformed, TransformedResult, TreeNode};
 use datafusion::common::{DataFusionError, Result as DataFusionResult};
 use datafusion::execution::context::TaskContext;
-use datafusion::physical_expr::{EquivalenceProperties, Partitioning};
+use datafusion::physical_expr::expressions::Column;
+use datafusion::physical_expr::{EquivalenceProperties, Partitioning, PhysicalSortExpr};
+use datafusion::physical_optimizer::PhysicalOptimizerRule;
 use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
+use datafusion::physical_plan::sorts::sort::SortExec;
 use datafusion::physical_plan::{
-    stream::RecordBatchStreamAdapter, DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties,
-    SendableRecordBatchStream,
+    coop::CooperativeExec, stream::RecordBatchStreamAdapter, DisplayAs, DisplayFormatType,
+    ExecutionPlan, PlanProperties, SendableRecordBatchStream, SortOrderPushdownResult,
 };
 use exoware_sdk::keys::Key;
 use exoware_sdk::kv_codec::decode_stored_row;
-use exoware_sdk::SerializableReadSession;
 use exoware_sdk::StoreClient;
+use exoware_sdk::{RangeMode, RangeStream, SerializableReadSession};
 use futures::SinkExt;
 
 use crate::builder::*;
@@ -26,19 +31,53 @@ use crate::filter::*;
 use crate::predicate::*;
 use crate::types::*;
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ScanDirection {
+    Forward,
+    Reverse,
+}
+
+impl ScanDirection {
+    fn range_mode(self) -> RangeMode {
+        match self {
+            Self::Forward => RangeMode::Forward,
+            Self::Reverse => RangeMode::Reverse,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
 pub(crate) struct KvScanExec {
     pub(crate) client: StoreClient,
     pub(crate) model: Arc<TableModel>,
     pub(crate) index_specs: Arc<Vec<ResolvedIndexSpec>>,
     pub(crate) predicate: QueryPredicate,
     pub(crate) limit: Option<usize>,
+    pub(crate) direction: ScanDirection,
     pub(crate) projected_schema: SchemaRef,
     pub(crate) projection: Option<Vec<usize>>,
     pub(crate) properties: PlanProperties,
 }
 
 impl KvScanExec {
+    fn make_properties(
+        projected_schema: SchemaRef,
+        output_ordering: Option<Vec<PhysicalSortExpr>>,
+    ) -> PlanProperties {
+        let equivalence_properties = match output_ordering {
+            Some(ordering) if !ordering.is_empty() => {
+                EquivalenceProperties::new_with_orderings(projected_schema.clone(), [ordering])
+            }
+            _ => EquivalenceProperties::new(projected_schema.clone()),
+        };
+        PlanProperties::new(
+            equivalence_properties,
+            Partitioning::UnknownPartitioning(1),
+            EmissionType::Incremental,
+            Boundedness::Bounded,
+        )
+    }
+
     pub(crate) fn new(
         client: StoreClient,
         model: Arc<TableModel>,
@@ -48,22 +87,105 @@ impl KvScanExec {
         projected_schema: SchemaRef,
         projection: Option<Vec<usize>>,
     ) -> Self {
-        let properties = PlanProperties::new(
-            EquivalenceProperties::new(projected_schema.clone()),
-            Partitioning::UnknownPartitioning(1),
-            EmissionType::Incremental,
-            Boundedness::Bounded,
-        );
+        let properties = Self::make_properties(projected_schema.clone(), None);
         Self {
             client,
             model,
             index_specs,
             predicate,
             limit,
+            direction: ScanDirection::Forward,
             projected_schema,
             projection,
             properties,
         }
+    }
+
+    fn with_scan_options(
+        &self,
+        limit: Option<usize>,
+        direction: ScanDirection,
+        output_ordering: Option<Vec<PhysicalSortExpr>>,
+    ) -> Self {
+        let properties = Self::make_properties(self.projected_schema.clone(), output_ordering);
+        Self {
+            client: self.client.clone(),
+            model: self.model.clone(),
+            index_specs: self.index_specs.clone(),
+            predicate: self.predicate.clone(),
+            limit,
+            direction,
+            projected_schema: self.projected_schema.clone(),
+            projection: self.projection.clone(),
+            properties,
+        }
+    }
+
+    fn with_ordering(
+        &self,
+        direction: ScanDirection,
+        output_ordering: Vec<PhysicalSortExpr>,
+    ) -> Self {
+        self.with_scan_options(self.limit, direction, Some(output_ordering))
+    }
+
+    fn order_direction_for_primary_key(
+        &self,
+        order: &[PhysicalSortExpr],
+    ) -> DataFusionResult<Option<ScanDirection>> {
+        if order.is_empty() || self.predicate.contradiction {
+            return Ok(None);
+        }
+        if self
+            .predicate
+            .choose_index_plan(&self.model, &self.index_specs)?
+            .is_some()
+        {
+            return Ok(None);
+        }
+
+        let key_columns = self.primary_key_order_columns_after_eq_prefix();
+        if order.len() > key_columns.len() {
+            return Ok(None);
+        }
+
+        let first_desc = order[0].options.descending;
+        let direction = if first_desc {
+            ScanDirection::Reverse
+        } else {
+            ScanDirection::Forward
+        };
+
+        for (sort_expr, &expected_col_idx) in order.iter().zip(key_columns.iter()) {
+            if sort_expr.options.descending != first_desc {
+                return Ok(None);
+            }
+            let Some(column) = sort_expr.expr.as_any().downcast_ref::<Column>() else {
+                return Ok(None);
+            };
+            let Some(&actual_col_idx) = self.model.columns_by_name.get(column.name()) else {
+                return Ok(None);
+            };
+            if actual_col_idx != expected_col_idx {
+                return Ok(None);
+            }
+        }
+
+        Ok(Some(direction))
+    }
+
+    fn primary_key_order_columns_after_eq_prefix(&self) -> Vec<usize> {
+        self.model
+            .primary_key_indices
+            .iter()
+            .copied()
+            .skip_while(|col_idx| {
+                self.predicate
+                    .constraints
+                    .get(col_idx)
+                    .is_some_and(single_value_constraint)
+            })
+            .collect()
     }
 
     pub(crate) fn plan_diagnostics(&self) -> DataFusionResult<AccessPathDiagnostics> {
@@ -81,15 +203,16 @@ impl DisplayAs for KvScanExec {
         match self.plan_diagnostics() {
             Ok(diag) => write!(
                 f,
-                "KvScanExec: limit={:?}, {}, query_stats={}",
+                "KvScanExec: limit={:?}, direction={:?}, {}, query_stats={}",
                 self.limit,
+                self.direction,
                 format_access_path_diagnostics(&diag),
                 format_query_stats_explain(QueryStatsExplainSurface::StreamedRangeDetail)
             ),
             Err(err) => write!(
                 f,
-                "KvScanExec: limit={:?}, diagnostics_error={err}",
-                self.limit
+                "KvScanExec: limit={:?}, direction={:?}, diagnostics_error={err}",
+                self.limit, self.direction
             ),
         }
     }
@@ -145,6 +268,7 @@ impl ExecutionPlan for KvScanExec {
         let index_specs = self.index_specs.clone();
         let predicate = self.predicate.clone();
         let limit = self.limit;
+        let direction = self.direction;
         let projection = self.projection.clone();
         let projected_schema = self.projected_schema.clone();
         let access_plan = Arc::new(ScanAccessPlan::new(&model, &projection, &predicate));
@@ -157,7 +281,7 @@ impl ExecutionPlan for KvScanExec {
                 projected_schema: &projected_schema,
                 access_plan: &access_plan,
             };
-            if let Err(e) = stream_kv_scan(&mut tx, &ctx, &index_specs, limit).await {
+            if let Err(e) = stream_kv_scan(&mut tx, &ctx, &index_specs, limit, direction).await {
                 let _ = tx.send(Err(e)).await;
             }
         });
@@ -166,6 +290,43 @@ impl ExecutionPlan for KvScanExec {
             self.projected_schema.clone(),
             rx,
         )))
+    }
+
+    fn supports_limit_pushdown(&self) -> bool {
+        true
+    }
+
+    fn with_fetch(&self, limit: Option<usize>) -> Option<Arc<dyn ExecutionPlan>> {
+        let limit = match (self.limit, limit) {
+            (Some(existing), Some(limit)) => Some(existing.min(limit)),
+            (None, Some(limit)) => Some(limit),
+            (_, None) => None,
+        };
+        Some(Arc::new(
+            self.with_scan_options(
+                limit,
+                self.direction,
+                self.properties
+                    .output_ordering()
+                    .map(|ordering| ordering.iter().cloned().collect::<Vec<PhysicalSortExpr>>()),
+            ),
+        ))
+    }
+
+    fn fetch(&self) -> Option<usize> {
+        self.limit
+    }
+
+    fn try_pushdown_sort(
+        &self,
+        order: &[PhysicalSortExpr],
+    ) -> DataFusionResult<SortOrderPushdownResult<Arc<dyn ExecutionPlan>>> {
+        let Some(direction) = self.order_direction_for_primary_key(order)? else {
+            return Ok(SortOrderPushdownResult::Unsupported);
+        };
+        Ok(SortOrderPushdownResult::Inexact {
+            inner: Arc::new(self.with_ordering(direction, order.to_vec())),
+        })
     }
 }
 
@@ -204,6 +365,7 @@ pub(crate) async fn stream_kv_scan(
     ctx: &ScanCtx<'_>,
     index_specs: &[ResolvedIndexSpec],
     limit: Option<usize>,
+    direction: ScanDirection,
 ) -> DataFusionResult<()> {
     if ctx.predicate.contradiction {
         return Ok(());
@@ -222,17 +384,33 @@ pub(crate) async fn stream_kv_scan(
             .access_plan
             .index_covers_required_non_pk(&index_specs[plan.spec_idx])
         {
-            return stream_index_scan(tx, ctx, index_specs, &plan, flush_threshold, target_rows)
-                .await;
-        }
-        return stream_index_lookup_scan(tx, ctx, index_specs, &plan, flush_threshold, target_rows)
+            return stream_index_scan(
+                tx,
+                ctx,
+                index_specs,
+                &plan,
+                flush_threshold,
+                target_rows,
+                direction,
+            )
             .await;
+        }
+        return stream_index_lookup_scan(
+            tx,
+            ctx,
+            index_specs,
+            &plan,
+            flush_threshold,
+            target_rows,
+            direction,
+        )
+        .await;
     }
 
     let exact = ctx
         .access_plan
         .predicate_fully_enforced_by_primary_key(ctx.model);
-    stream_pk_scan(tx, ctx, flush_threshold, target_rows, exact).await
+    stream_pk_scan(tx, ctx, flush_threshold, target_rows, exact, direction).await
 }
 
 pub(crate) async fn stream_pk_scan(
@@ -241,12 +419,13 @@ pub(crate) async fn stream_pk_scan(
     flush_threshold: usize,
     target_rows: usize,
     exact: bool,
+    direction: ScanDirection,
 ) -> DataFusionResult<()> {
     let ranges = ctx.predicate.primary_key_ranges(ctx.model)?;
     let mut emitted = 0usize;
     let mut batch_builder = ProjectedBatchBuilder::from_access_plan(ctx.model, ctx.access_plan);
 
-    for range in &ranges {
+    for range in ordered_ranges(&ranges, direction) {
         if range.start > range.end {
             continue;
         }
@@ -259,11 +438,9 @@ pub(crate) async fn stream_pk_scan(
         }
         let raw_limit = if exact { remaining } else { usize::MAX };
 
-        let mut stream = ctx
-            .session
-            .range_stream(&range.start, &range.end, raw_limit, flush_threshold)
-            .await
-            .map_err(|e| DataFusionError::External(Box::new(e)))?;
+        let mut stream =
+            range_stream_with_direction(ctx.session, range, raw_limit, flush_threshold, direction)
+                .await?;
         while let Some(chunk) = stream
             .next_chunk()
             .await
@@ -316,6 +493,7 @@ pub(crate) async fn stream_index_lookup_scan(
     plan: &IndexPlan,
     flush_threshold: usize,
     target_rows: usize,
+    direction: ScanDirection,
 ) -> DataFusionResult<()> {
     let spec = &index_specs[plan.spec_idx];
     let key_predicate_plan = ctx
@@ -328,15 +506,13 @@ pub(crate) async fn stream_index_lookup_scan(
     let mut emitted = 0usize;
     let mut batch_builder = ProjectedBatchBuilder::from_access_plan(ctx.model, ctx.access_plan);
 
-    for range in &plan.ranges {
+    for range in ordered_ranges(&plan.ranges, direction) {
         if emitted + batch_builder.row_count() >= target_rows {
             break;
         }
-        let mut stream = ctx
-            .session
-            .range_stream(&range.start, &range.end, usize::MAX, flush_threshold)
-            .await
-            .map_err(|e| DataFusionError::External(Box::new(e)))?;
+        let mut stream =
+            range_stream_with_direction(ctx.session, range, usize::MAX, flush_threshold, direction)
+                .await?;
         while let Some(chunk) = stream
             .next_chunk()
             .await
@@ -426,6 +602,7 @@ pub(crate) async fn stream_index_scan(
     plan: &IndexPlan,
     flush_threshold: usize,
     target_rows: usize,
+    direction: ScanDirection,
 ) -> DataFusionResult<()> {
     let spec = &index_specs[plan.spec_idx];
     let key_predicate_plan = ctx
@@ -438,7 +615,7 @@ pub(crate) async fn stream_index_scan(
     let mut emitted = 0usize;
     let mut batch_builder = ProjectedBatchBuilder::from_access_plan(ctx.model, ctx.access_plan);
 
-    for range in &plan.ranges {
+    for range in ordered_ranges(&plan.ranges, direction) {
         if emitted + batch_builder.row_count() >= target_rows {
             break;
         }
@@ -446,11 +623,9 @@ pub(crate) async fn stream_index_scan(
         if remaining == 0 {
             break;
         }
-        let mut stream = ctx
-            .session
-            .range_stream(&range.start, &range.end, usize::MAX, flush_threshold)
-            .await
-            .map_err(|e| DataFusionError::External(Box::new(e)))?;
+        let mut stream =
+            range_stream_with_direction(ctx.session, range, usize::MAX, flush_threshold, direction)
+                .await?;
         while let Some(chunk) = stream
             .next_chunk()
             .await
@@ -517,4 +692,148 @@ pub(crate) async fn stream_index_scan(
 
     let _ = flush_projected_batch(tx, ctx, &mut batch_builder, &mut emitted).await?;
     Ok(())
+}
+
+fn ordered_ranges<'a>(
+    ranges: &'a [KeyRange],
+    direction: ScanDirection,
+) -> Box<dyn Iterator<Item = &'a KeyRange> + Send + 'a> {
+    match direction {
+        ScanDirection::Forward => Box::new(ranges.iter()),
+        ScanDirection::Reverse => Box::new(ranges.iter().rev()),
+    }
+}
+
+async fn range_stream_with_direction(
+    session: &SerializableReadSession,
+    range: &KeyRange,
+    limit: usize,
+    batch_size: usize,
+    direction: ScanDirection,
+) -> DataFusionResult<RangeStream> {
+    session
+        .range_stream_with_mode(
+            &range.start,
+            &range.end,
+            limit,
+            batch_size,
+            direction.range_mode(),
+        )
+        .await
+        .map_err(|e| DataFusionError::External(Box::new(e)))
+}
+
+fn single_value_constraint(constraint: &PredicateConstraint) -> bool {
+    match constraint {
+        PredicateConstraint::StringEq(_)
+        | PredicateConstraint::BoolEq(_)
+        | PredicateConstraint::FixedBinaryEq(_) => true,
+        PredicateConstraint::IntRange {
+            min: Some(min),
+            max: Some(max),
+        } => min == max,
+        PredicateConstraint::UInt64Range {
+            min: Some(min),
+            max: Some(max),
+        } => min == max,
+        PredicateConstraint::FloatRange {
+            min: Some((min, min_inclusive)),
+            max: Some((max, max_inclusive)),
+        } => *min_inclusive && *max_inclusive && min == max,
+        PredicateConstraint::Decimal128Range {
+            min: Some(min),
+            max: Some(max),
+        } => min == max,
+        PredicateConstraint::Decimal256Range {
+            min: Some(min),
+            max: Some(max),
+        } => min == max,
+        _ => false,
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct KvTopKSortPushdownRule;
+
+impl KvTopKSortPushdownRule {
+    pub(crate) fn new() -> Self {
+        Self
+    }
+}
+
+impl PhysicalOptimizerRule for KvTopKSortPushdownRule {
+    fn optimize(
+        &self,
+        plan: Arc<dyn ExecutionPlan>,
+        config: &ConfigOptions,
+    ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        if !config.optimizer.enable_sort_pushdown {
+            return Ok(plan);
+        }
+
+        plan.transform_down(|plan: Arc<dyn ExecutionPlan>| {
+            let Some(sort_exec) = plan.as_any().downcast_ref::<SortExec>() else {
+                return Ok(Transformed::no(plan));
+            };
+            let Some(fetch) = sort_exec.fetch() else {
+                return Ok(Transformed::no(plan));
+            };
+            let Some(ordered_scan) = push_topk_fetch_to_ordered_scan(
+                sort_exec.input().clone(),
+                sort_exec.expr(),
+                fetch,
+            )?
+            else {
+                return Ok(Transformed::no(plan));
+            };
+            let sort = SortExec::new(sort_exec.expr().clone(), ordered_scan)
+                .with_fetch(Some(fetch))
+                .with_preserve_partitioning(sort_exec.preserve_partitioning());
+            Ok(Transformed::yes(Arc::new(sort) as Arc<dyn ExecutionPlan>))
+        })
+        .data()
+    }
+
+    fn name(&self) -> &str {
+        "kv_topk_sort_pushdown"
+    }
+
+    fn schema_check(&self) -> bool {
+        true
+    }
+}
+
+fn push_topk_fetch_to_ordered_scan(
+    plan: Arc<dyn ExecutionPlan>,
+    order: &[PhysicalSortExpr],
+    fetch: usize,
+) -> DataFusionResult<Option<Arc<dyn ExecutionPlan>>> {
+    if let Some(scan_exec) = plan.as_any().downcast_ref::<KvScanExec>() {
+        let Some(direction) = scan_exec.order_direction_for_primary_key(order)? else {
+            return Ok(None);
+        };
+        let limit = Some(
+            scan_exec
+                .limit
+                .map_or(fetch, |existing| existing.min(fetch)),
+        );
+        return Ok(Some(Arc::new(scan_exec.with_scan_options(
+            limit,
+            direction,
+            Some(order.to_vec()),
+        ))));
+    }
+
+    if plan.as_any().downcast_ref::<CooperativeExec>().is_none() {
+        return Ok(None);
+    }
+    let children = plan.children();
+    if children.len() != 1 {
+        return Ok(None);
+    }
+    let Some(new_child) = push_topk_fetch_to_ordered_scan(Arc::clone(children[0]), order, fetch)?
+    else {
+        return Ok(None);
+    };
+    plan.with_new_children(vec![new_child]).map(Some)
 }

--- a/sql/rs/src/schema.rs
+++ b/sql/rs/src/schema.rs
@@ -8,6 +8,7 @@ use datafusion::catalog::Session;
 use datafusion::common::{DataFusionError, Result as DataFusionResult, SchemaExt};
 use datafusion::datasource::sink::DataSinkExec;
 use datafusion::datasource::TableProvider;
+use datafusion::execution::SessionStateBuilder;
 use datafusion::logical_expr::dml::InsertOp;
 use datafusion::logical_expr::{Expr, TableProviderFilterPushDown, TableType};
 use datafusion::physical_plan::ExecutionPlan;
@@ -130,6 +131,7 @@ impl KvSchema {
     pub fn register_all(self, ctx: &SessionContext) -> DataFusionResult<()> {
         let _ = ctx.remove_optimizer_rule("kv_aggregate_pushdown");
         ctx.add_optimizer_rule(Arc::new(KvAggregatePushdownRule::new()));
+        register_kv_physical_optimizer(ctx);
         for (name, config) in &self.tables {
             register_kv_table(ctx, name, self.client.clone(), config.clone())?;
         }
@@ -389,6 +391,28 @@ impl KvSchema {
         send_backfill_event(progress_tx, IndexBackfillEvent::Completed { report });
         Ok(report)
     }
+}
+
+fn register_kv_physical_optimizer(ctx: &SessionContext) {
+    let state_ref = ctx.state_ref();
+    let mut state = state_ref.write();
+    if state
+        .physical_optimizers()
+        .iter()
+        .any(|rule| rule.name() == "kv_topk_sort_pushdown")
+    {
+        return;
+    }
+    let mut rules = state.physical_optimizers().to_vec();
+    let insert_at = rules
+        .iter()
+        .position(|rule| rule.name() == "SanityCheckPlan")
+        .unwrap_or(rules.len());
+    rules.insert(insert_at, Arc::new(KvTopKSortPushdownRule::new()));
+    let new_state = SessionStateBuilder::new_from_existing(state.clone())
+        .with_physical_optimizer_rules(rules)
+        .build();
+    *state = new_state;
 }
 
 pub(crate) fn send_backfill_event(

--- a/sql/rs/src/schema.rs
+++ b/sql/rs/src/schema.rs
@@ -129,9 +129,7 @@ impl KvSchema {
     }
 
     pub fn register_all(self, ctx: &SessionContext) -> DataFusionResult<()> {
-        let _ = ctx.remove_optimizer_rule("kv_aggregate_pushdown");
-        ctx.add_optimizer_rule(Arc::new(KvAggregatePushdownRule::new()));
-        register_kv_physical_optimizer(ctx);
+        register_kv_optimizers(ctx);
         for (name, config) in &self.tables {
             register_kv_table(ctx, name, self.client.clone(), config.clone())?;
         }
@@ -393,17 +391,18 @@ impl KvSchema {
     }
 }
 
-fn register_kv_physical_optimizer(ctx: &SessionContext) {
+fn register_kv_optimizers(ctx: &SessionContext) {
+    let _ = ctx.remove_optimizer_rule("kv_aggregate_pushdown");
+    ctx.add_optimizer_rule(Arc::new(KvAggregatePushdownRule::new()));
+
     let state_ref = ctx.state_ref();
     let mut state = state_ref.write();
-    if state
+    let mut rules = state
         .physical_optimizers()
         .iter()
-        .any(|rule| rule.name() == "kv_topk_sort_pushdown")
-    {
-        return;
-    }
-    let mut rules = state.physical_optimizers().to_vec();
+        .filter(|rule| rule.name() != "kv_topk_sort_pushdown")
+        .cloned()
+        .collect::<Vec<_>>();
     let insert_at = rules
         .iter()
         .position(|rule| rule.name() == "SanityCheckPlan")


### PR DESCRIPTION
## Summary

Adds **DESC (reverse) scan support** and **top-K limit pushdown** for primary-key-ordered queries in the SQL/KV layer. Queries like `... ORDER BY pk_cols DESC LIMIT k` now stream keys in reverse directly from the store and push the limit down, instead of scanning the full range and sorting in memory.

## Changes

### Reverse scan direction (`scan.rs`)
- New `ScanDirection` (`Forward`/`Reverse`) enum mapping to `RangeMode`, threaded through `stream_kv_scan` -> `stream_pk_scan`.
- `range_stream_with_direction` issues range reads in the requested direction; `ordered_ranges` reverses range iteration order so multi-range scans (e.g. `IN` lists) stay globally ordered.
- Index scans (`stream_index_scan`, `stream_index_lookup_scan`) are explicitly forward-only.

### Sort pushdown (`scan.rs`)
- `KvScanExec::try_pushdown_sort` sets the scan direction + output ordering when `ORDER BY` is a same-direction prefix of the primary-key columns following the equality-constrained prefix.
- `order_direction_for_primary_key` / `primary_key_order_columns_after_eq_prefix` decide whether an ordering can be satisfied by key order (bails out when a secondary index plan is chosen).
- `KvScanExec` now carries `direction` + advertises output ordering via `EquivalenceProperties`; `DisplayAs` includes `direction=`.

### Top-K limit pushdown (`scan.rs`, `schema.rs`)
- New `KvTopKSortPushdownRule` physical optimizer rule pushes a `SortExec`'s fetch into the scan (descending only through `CooperativeExec`), so `LIMIT k`/`OFFSET` fetch the minimal number of rows.
- `KvScanExec::with_fetch` / `fetch` implement standard limit pushdown (combining existing + new limit via `min`).
- `register_kv_optimizers` installs the rule ahead of `SanityCheckPlan` (gated by `enable_sort_pushdown`).

### Unified primary-key range classification (`predicate.rs`, `filter.rs`)
- New `primary_key_range_constraint` is the single source of truth for how a predicate constraint maps onto a primary-key range: `Point(value)`, `Terminal(spans)`, or `NotEnforced`.
- `predicate_fully_enforced_by_primary_key` (exactness oracle) and `primary_key_ranges` (range builder) now both derive from it, so they cannot disagree. This fixes a latent bug where exactness was judged with the *secondary-index* encoder, which over-claimed `exact=true` for constraints the pk-range builder cannot narrow (e.g. `Utf8 IN`, range-then-eq), causing limit pushdown to return fewer than `LIMIT` rows.
- `primary_key_ranges` is rewritten around the classifier and sorts emitted ranges by key, which is required for correct reverse ordering over `IN` lists.

## Tests
- `kv_scan_physical_limit_pushdown_sets_leaf_fetch` - `LimitPushdown` converts a physical limit into a scan fetch.
- `kv_scan_activity_desc_order_pushes_reverse_range_limit` - DESC + `LIMIT` pushes a reverse range limit to the store.
- `kv_scan_activity_mixed_order_does_not_push_range_limit` - mixed ASC/DESC ordering is not pushed.
- `kv_topk_sort_pushdown_stops_at_filter_exec` - top-K fetch does not cross a row-dropping filter.
- `kv_topk_reverse_scan_keeps_reading_after_later_pk_filter_rejects_first_key` - inexact reverse scan keeps reading past non-matching keys.
- `kv_topk_reverse_scan_orders_multiple_primary_key_ranges` - reverse top-K over multiple `IN` ranges returns rows in DESC order and stops early.
- `kv_topk_reverse_scan_applies_offset_over_multiple_primary_key_ranges` - reverse `LIMIT ... OFFSET` fetches `offset + limit` rows.
