### PR TITLE
typed ingest put_batch errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2699,6 +2699,7 @@ dependencies = [
  "futures",
  "http",
  "regex",
+ "thiserror",
  "tokio",
 ]
 

--- a/examples/simulator/src/rocks.rs
+++ b/examples/simulator/src/rocks.rs
@@ -435,9 +435,9 @@ impl Writer {
         // backed by at least one entry. The RPC layer already requires at least one entry per
         // put.
         if kvs.is_empty() {
-            return Err(IngestError::Internal(
-                "cannot ingest an empty batch".to_string(),
-            ));
+            return Err(IngestError::Internal {
+                message: "cannot ingest an empty batch".to_string(),
+            });
         }
         let (response, result) = oneshot::channel();
 
@@ -449,9 +449,11 @@ impl Writer {
             .as_ref()
             .expect("sender is None only during drop, which cannot overlap a call")
             .send(WriteRequest { kvs, response })
-            .map_err(|_| IngestError::Internal("rocks writer stopped".to_string()))?;
-        result.await.map_err(|_| {
-            IngestError::Internal("rocks writer stopped before completing write".to_string())
+            .map_err(|_| IngestError::Internal {
+                message: "rocks writer stopped".to_string(),
+            })?;
+        result.await.map_err(|_| IngestError::Internal {
+            message: "rocks writer stopped before completing write".to_string(),
         })?
     }
 }
@@ -1554,7 +1556,9 @@ mod tests {
         let error = store.put_batch(Vec::new()).await.expect_err("must reject");
         assert_eq!(
             error,
-            IngestError::Internal("cannot ingest an empty batch".to_string())
+            IngestError::Internal {
+                message: "cannot ingest an empty batch".to_string(),
+            }
         );
         assert_eq!(store.current_sequence(), 0);
     }

--- a/examples/simulator/src/rocks.rs
+++ b/examples/simulator/src/rocks.rs
@@ -357,7 +357,7 @@ impl Frontiers {
 
 struct WriteRequest {
     kvs: Vec<(Bytes, Bytes)>,
-    response: oneshot::Sender<Result<u64, String>>,
+    response: oneshot::Sender<Result<u64, IngestError>>,
 }
 
 /// One staged commit group: every coalesced request shares a single sequence number, whose log
@@ -430,12 +430,14 @@ impl Writer {
     }
 
     /// Enqueues one ingest request and resolves once `commit` has durably published it.
-    async fn put_batch(&self, kvs: Vec<(Bytes, Bytes)>) -> Result<u64, String> {
+    async fn put_batch(&self, kvs: Vec<(Bytes, Bytes)>) -> Result<u64, IngestError> {
         // An empty batch would still cut a log row, but rejecting it keeps every sequence
         // backed by at least one entry. The RPC layer already requires at least one entry per
         // put.
         if kvs.is_empty() {
-            return Err("cannot ingest an empty batch".to_string());
+            return Err(IngestError::Internal(
+                "cannot ingest an empty batch".to_string(),
+            ));
         }
         let (response, result) = oneshot::channel();
 
@@ -447,10 +449,10 @@ impl Writer {
             .as_ref()
             .expect("sender is None only during drop, which cannot overlap a call")
             .send(WriteRequest { kvs, response })
-            .map_err(|_| "rocks writer stopped".to_string())?;
-        result
-            .await
-            .map_err(|_| "rocks writer stopped before completing write".to_string())?
+            .map_err(|_| IngestError::Internal("rocks writer stopped".to_string()))?;
+        result.await.map_err(|_| {
+            IngestError::Internal("rocks writer stopped before completing write".to_string())
+        })?
     }
 }
 
@@ -1086,12 +1088,7 @@ impl Sequence for RocksStore {
 // number and replay-log batch.
 impl Ingest for RocksStore {
     async fn put_batch(&self, kvs: Vec<(Bytes, Bytes)>) -> Result<u64, IngestError> {
-        // Local RocksDB writes have no transient-dependency failure mode; a stopped writer is a
-        // broken invariant, so every error here is fatal.
-        self.writer
-            .put_batch(kvs)
-            .await
-            .map_err(IngestError::Internal)
+        self.writer.put_batch(kvs).await
     }
 }
 
@@ -1555,7 +1552,10 @@ mod tests {
         let dir = tempdir().expect("tempdir");
         let store = RocksStore::open(dir.path(), None).expect("open db");
         let error = store.put_batch(Vec::new()).await.expect_err("must reject");
-        assert_eq!(error, "cannot ingest an empty batch");
+        assert_eq!(
+            error,
+            IngestError::Internal("cannot ingest an empty batch".to_string())
+        );
         assert_eq!(store.current_sequence(), 0);
     }
 

--- a/examples/simulator/src/rocks.rs
+++ b/examples/simulator/src/rocks.rs
@@ -41,7 +41,8 @@ use exoware_sdk::prune_policy::{
 };
 use exoware_sdk::selector::compile_payload_regex;
 use exoware_server::{
-    Ingest, Log, LogBatch, Prune, Query, QueryExtra, RangeScan, RangeScanBatch, Sequence,
+    Ingest, IngestError, Log, LogBatch, Prune, Query, QueryExtra, RangeScan, RangeScanBatch,
+    Sequence,
 };
 use parking_lot::Mutex;
 use regex::bytes::Regex;
@@ -1084,8 +1085,13 @@ impl Sequence for RocksStore {
 // The writer folds already-queued requests into one commit group that shares a single sequence
 // number and replay-log batch.
 impl Ingest for RocksStore {
-    async fn put_batch(&self, kvs: Vec<(Bytes, Bytes)>) -> Result<u64, String> {
-        self.writer.put_batch(kvs).await
+    async fn put_batch(&self, kvs: Vec<(Bytes, Bytes)>) -> Result<u64, IngestError> {
+        // Local RocksDB writes have no transient-dependency failure mode; a stopped writer is a
+        // broken invariant, so every error here is fatal.
+        self.writer
+            .put_batch(kvs)
+            .await
+            .map_err(IngestError::Internal)
     }
 }
 

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -17,6 +17,7 @@ connectrpc = { workspace = true }
 futures = { workspace = true }
 http = { workspace = true }
 regex = { workspace = true }
+thiserror = { workspace = true }
 tokio = { workspace = true, features = ["sync"] }
 exoware-sdk = { workspace = true }
 

--- a/server/src/connect.rs
+++ b/server/src/connect.rs
@@ -43,7 +43,7 @@ use tokio::sync::Notify;
 use crate::reduce::RangeReducer;
 use crate::stream::{StreamHub, StreamNotifier};
 use crate::validate::{self, IngestLimits};
-use crate::{Ingest, Log, LogBatch, Prune, Query, QueryExtra, RangeScan, StoreEngine};
+use crate::{Ingest, IngestError, Log, LogBatch, Prune, Query, QueryExtra, RangeScan, StoreEngine};
 
 // TODO (#57): Make limits configurable.
 const MAX_CONNECTRPC_BODY_BYTES: usize = 256 * 1024 * 1024;
@@ -356,6 +356,29 @@ where
     }
 }
 
+/// Maps a backend's transient write failure to the wire. `INGEST_UNAVAILABLE` is distinct from the
+/// pre-call `WORKER_NOT_READY` gate so operators can tell "probe said not ready" from "the request
+/// itself discovered the backend was down".
+fn ingest_unavailable_error(message: String) -> ConnectError {
+    with_retry_info_detail(
+        with_error_info_detail(
+            ConnectError::unavailable(message),
+            ErrorInfo {
+                reason: "INGEST_UNAVAILABLE".to_string(),
+                domain: "store.ingest".to_string(),
+                ..Default::default()
+            },
+        ),
+        RetryInfo {
+            retry_delay: Some(buffa_types::google::protobuf::Duration::from(
+                std::time::Duration::from_secs(1),
+            ))
+            .into(),
+            ..Default::default()
+        },
+    )
+}
+
 impl<I> IngestApi for IngestConnect<I>
 where
     I: Ingest,
@@ -391,7 +414,10 @@ where
             .ingest
             .put_batch(batch)
             .await
-            .map_err(ConnectError::internal)?;
+            .map_err(|e| match e {
+                IngestError::Unavailable(msg) => ingest_unavailable_error(msg),
+                IngestError::Internal(msg) => ConnectError::internal(msg),
+            })?;
 
         // Advance any attached stream frontier after the write is committed.
         if let Some(notifier) = &self.state.notifier {
@@ -1228,7 +1254,7 @@ mod tests {
     use futures::StreamExt;
 
     use crate::{
-        Ingest, Log, Prune, Query, QueryExtra, RangeScan, RangeScanBatch, Sequence,
+        Ingest, IngestError, Log, Prune, Query, QueryExtra, RangeScan, RangeScanBatch, Sequence,
         StreamNotification, StreamNotifier,
     };
 
@@ -1252,6 +1278,7 @@ mod tests {
         range_next_count: usize,
         query_extra: QueryExtra,
         prune_policy_counts: Vec<usize>,
+        put_error: Option<IngestError>,
     }
 
     #[derive(Default)]
@@ -1299,6 +1326,10 @@ mod tests {
     impl FakeEngine {
         fn set_current_sequence(&self, sequence_number: u64) {
             self.state.lock().expect("lock").current_sequence = sequence_number;
+        }
+
+        fn set_put_error(&self, err: IngestError) {
+            self.state.lock().expect("lock").put_error = Some(err);
         }
 
         fn set_batch(&self, sequence_number: u64, kvs: Option<Vec<(Bytes, Bytes)>>) {
@@ -1363,8 +1394,14 @@ mod tests {
     }
 
     impl Ingest for FakeEngine {
-        async fn put_batch(&self, kvs: Vec<(Bytes, Bytes)>) -> Result<u64, String> {
-            let mut state = self.state.lock().map_err(|e| e.to_string())?;
+        async fn put_batch(&self, kvs: Vec<(Bytes, Bytes)>) -> Result<u64, IngestError> {
+            let mut state = self
+                .state
+                .lock()
+                .map_err(|e| IngestError::Internal(e.to_string()))?;
+            if let Some(err) = state.put_error.take() {
+                return Err(err);
+            }
             state.current_sequence += 1;
             let seq = state.current_sequence;
             state.batches.insert(seq, Some(kvs));
@@ -1802,6 +1839,40 @@ mod tests {
             .expect_err("put should reject oversized value");
 
         assert_eq!(err.code, connectrpc::ErrorCode::InvalidArgument);
+    }
+
+    #[tokio::test]
+    async fn ingest_unavailable_surfaces_as_unavailable_with_retry_info() {
+        let engine = Arc::new(FakeEngine::default());
+        engine.set_put_error(IngestError::Unavailable("backend bouncing".to_string()));
+        let connect = IngestConnect::new(IngestState::new(engine));
+
+        let err = IngestApi::put(&connect, Context::default(), put_request(1))
+            .await
+            .expect_err("transient put failure should surface");
+
+        assert_eq!(err.code, connectrpc::ErrorCode::Unavailable);
+        let decoded = decode_connect_error(&err).expect("decode details");
+        assert_eq!(
+            decoded.error_info.expect("error info").reason,
+            "INGEST_UNAVAILABLE"
+        );
+        assert!(decoded.retry_info.is_some());
+    }
+
+    #[tokio::test]
+    async fn ingest_internal_surfaces_as_internal_without_error_info() {
+        let engine = Arc::new(FakeEngine::default());
+        engine.set_put_error(IngestError::Internal("invariant violated".to_string()));
+        let connect = IngestConnect::new(IngestState::new(engine));
+
+        let err = IngestApi::put(&connect, Context::default(), put_request(1))
+            .await
+            .expect_err("fatal put failure should surface");
+
+        assert_eq!(err.code, connectrpc::ErrorCode::Internal);
+        let decoded = decode_connect_error(&err).expect("decode details");
+        assert!(decoded.error_info.is_none());
     }
 
     #[tokio::test]

--- a/server/src/connect.rs
+++ b/server/src/connect.rs
@@ -356,27 +356,35 @@ where
     }
 }
 
-/// Maps a backend's transient write failure to the wire. `INGEST_UNAVAILABLE` is distinct from the
-/// pre-call `WORKER_NOT_READY` gate so operators can tell "probe said not ready" from "the request
-/// itself discovered the backend was down".
-fn ingest_unavailable_error(message: String) -> ConnectError {
+/// Backoff floor advertised to `RetryInfo`-aware clients for transient store conditions.
+const RETRY_HINT_DELAY: std::time::Duration = std::time::Duration::from_secs(1);
+
+/// Attaches the shared transient-retry hint so every "come back soon" response advertises one delay.
+fn with_retry_hint(err: ConnectError) -> ConnectError {
     with_retry_info_detail(
-        with_error_info_detail(
-            ConnectError::unavailable(message),
-            ErrorInfo {
-                reason: "INGEST_UNAVAILABLE".to_string(),
-                domain: "store.ingest".to_string(),
-                ..Default::default()
-            },
-        ),
+        err,
         RetryInfo {
             retry_delay: Some(buffa_types::google::protobuf::Duration::from(
-                std::time::Duration::from_secs(1),
+                RETRY_HINT_DELAY,
             ))
             .into(),
             ..Default::default()
         },
     )
+}
+
+/// Maps a backend's transient write failure to the wire. Shares the `unavailable` wire code with the
+/// pre-call `WORKER_NOT_READY` gate; the two are told apart by `ErrorInfo.reason`, letting operators
+/// distinguish "probe said not ready" from "the request itself discovered the backend was down".
+fn ingest_unavailable_error(message: String) -> ConnectError {
+    with_retry_hint(with_error_info_detail(
+        ConnectError::unavailable(message),
+        ErrorInfo {
+            reason: "INGEST_UNAVAILABLE".to_string(),
+            domain: "store.ingest".to_string(),
+            ..Default::default()
+        },
+    ))
 }
 
 impl<I> IngestApi for IngestConnect<I>
@@ -389,14 +397,14 @@ where
         request: buffa::view::OwnedView<exoware_proto::log::ingest::v1::PutRequestView<'static>>,
     ) -> connectrpc::ServiceResult<ProtoPutResponse> {
         if !self.state.ready.load(Ordering::SeqCst) {
-            return Err(with_error_info_detail(
+            return Err(with_retry_hint(with_error_info_detail(
                 ConnectError::unavailable("ingest is not ready"),
                 ErrorInfo {
                     reason: "WORKER_NOT_READY".to_string(),
                     domain: crate::validate::INGEST_ERROR_DOMAIN.to_string(),
                     ..Default::default()
                 },
-            ));
+            )));
         }
 
         validate::validate_put_request(&request, self.state.limits)?;
@@ -465,16 +473,9 @@ where
     }
 
     fn consistency_not_ready_error(&self, required: u64, current: u64) -> ConnectError {
-        let err = with_retry_info_detail(
-            ConnectError::aborted("minimum consistency token is not yet visible"),
-            RetryInfo {
-                retry_delay: Some(buffa_types::google::protobuf::Duration::from(
-                    std::time::Duration::from_secs(1),
-                ))
-                .into(),
-                ..Default::default()
-            },
-        );
+        let err = with_retry_hint(ConnectError::aborted(
+            "minimum consistency token is not yet visible",
+        ));
         with_query_detail(
             with_error_info_detail(
                 err,
@@ -1857,7 +1858,9 @@ mod tests {
             decoded.error_info.expect("error info").reason,
             "INGEST_UNAVAILABLE"
         );
-        assert!(decoded.retry_info.is_some());
+        let retry_delay = decoded.retry_info.expect("retry info").retry_delay;
+        let retry_delay = retry_delay.as_option().expect("retry delay");
+        assert_eq!((retry_delay.seconds, retry_delay.nanos), (1, 0));
     }
 
     #[tokio::test]
@@ -1873,6 +1876,27 @@ mod tests {
         assert_eq!(err.code, connectrpc::ErrorCode::Internal);
         let decoded = decode_connect_error(&err).expect("decode details");
         assert!(decoded.error_info.is_none());
+    }
+
+    #[tokio::test]
+    async fn put_when_not_ready_keeps_worker_not_ready_reason() {
+        let engine = Arc::new(FakeEngine::default());
+        let state = IngestState::new(engine);
+        state.ready.store(false, Ordering::SeqCst);
+        let connect = IngestConnect::new(state);
+
+        let err = IngestApi::put(&connect, Context::default(), put_request(1))
+            .await
+            .expect_err("not-ready gate should reject");
+
+        // Both the gate and a backend-discovered outage surface `unavailable`; the reason string is
+        // what keeps them distinguishable, so pin it against drift toward `INGEST_UNAVAILABLE`.
+        assert_eq!(err.code, connectrpc::ErrorCode::Unavailable);
+        let decoded = decode_connect_error(&err).expect("decode details");
+        assert_eq!(
+            decoded.error_info.expect("error info").reason,
+            "WORKER_NOT_READY"
+        );
     }
 
     #[tokio::test]

--- a/server/src/connect.rs
+++ b/server/src/connect.rs
@@ -358,33 +358,37 @@ where
 
 /// Backoff floor advertised to `RetryInfo`-aware clients for transient store conditions.
 const RETRY_HINT_DELAY: std::time::Duration = std::time::Duration::from_secs(1);
+/// `ErrorInfo.reason` when the ingest worker has not passed its readiness gate.
+const REASON_WORKER_NOT_READY: &str = "WORKER_NOT_READY";
+/// `ErrorInfo.reason` when the backend discovers a transient ingest write failure.
+const REASON_INGEST_UNAVAILABLE: &str = "INGEST_UNAVAILABLE";
 
-/// Attaches the shared transient-retry hint so every "come back soon" response advertises one delay.
-fn with_retry_hint(err: ConnectError) -> ConnectError {
+/// Attaches an explicit retry hint for "come back soon" responses.
+fn with_retry_hint(err: ConnectError, retry_delay: std::time::Duration) -> ConnectError {
     with_retry_info_detail(
         err,
         RetryInfo {
-            retry_delay: Some(buffa_types::google::protobuf::Duration::from(
-                RETRY_HINT_DELAY,
-            ))
-            .into(),
+            retry_delay: Some(buffa_types::google::protobuf::Duration::from(retry_delay)).into(),
             ..Default::default()
         },
     )
 }
 
-/// Maps a backend's transient write failure to the wire. Shares the `unavailable` wire code with the
-/// pre-call `WORKER_NOT_READY` gate; the two are told apart by `ErrorInfo.reason`, letting operators
-/// distinguish "probe said not ready" from "the request itself discovered the backend was down".
-fn ingest_unavailable_error(message: String) -> ConnectError {
-    with_retry_hint(with_error_info_detail(
-        ConnectError::unavailable(message),
-        ErrorInfo {
-            reason: "INGEST_UNAVAILABLE".to_string(),
-            domain: "store.ingest".to_string(),
-            ..Default::default()
-        },
-    ))
+fn ingest_error_to_connect(err: IngestError) -> ConnectError {
+    match err {
+        IngestError::Unavailable { message } => with_retry_hint(
+            with_error_info_detail(
+                ConnectError::unavailable(message),
+                ErrorInfo {
+                    reason: REASON_INGEST_UNAVAILABLE.to_string(),
+                    domain: crate::validate::INGEST_ERROR_DOMAIN.to_string(),
+                    ..Default::default()
+                },
+            ),
+            RETRY_HINT_DELAY,
+        ),
+        IngestError::Internal { message } => ConnectError::internal(message),
+    }
 }
 
 impl<I> IngestApi for IngestConnect<I>
@@ -397,14 +401,17 @@ where
         request: buffa::view::OwnedView<exoware_proto::log::ingest::v1::PutRequestView<'static>>,
     ) -> connectrpc::ServiceResult<ProtoPutResponse> {
         if !self.state.ready.load(Ordering::SeqCst) {
-            return Err(with_retry_hint(with_error_info_detail(
-                ConnectError::unavailable("ingest is not ready"),
-                ErrorInfo {
-                    reason: "WORKER_NOT_READY".to_string(),
-                    domain: crate::validate::INGEST_ERROR_DOMAIN.to_string(),
-                    ..Default::default()
-                },
-            )));
+            return Err(with_retry_hint(
+                with_error_info_detail(
+                    ConnectError::unavailable("ingest is not ready"),
+                    ErrorInfo {
+                        reason: REASON_WORKER_NOT_READY.to_string(),
+                        domain: crate::validate::INGEST_ERROR_DOMAIN.to_string(),
+                        ..Default::default()
+                    },
+                ),
+                RETRY_HINT_DELAY,
+            ));
         }
 
         validate::validate_put_request(&request, self.state.limits)?;
@@ -422,10 +429,7 @@ where
             .ingest
             .put_batch(batch)
             .await
-            .map_err(|e| match e {
-                IngestError::Unavailable(msg) => ingest_unavailable_error(msg),
-                IngestError::Internal(msg) => ConnectError::internal(msg),
-            })?;
+            .map_err(ingest_error_to_connect)?;
 
         // Advance any attached stream frontier after the write is committed.
         if let Some(notifier) = &self.state.notifier {
@@ -473,9 +477,10 @@ where
     }
 
     fn consistency_not_ready_error(&self, required: u64, current: u64) -> ConnectError {
-        let err = with_retry_hint(ConnectError::aborted(
-            "minimum consistency token is not yet visible",
-        ));
+        let err = with_retry_hint(
+            ConnectError::aborted("minimum consistency token is not yet visible"),
+            RETRY_HINT_DELAY,
+        );
         with_query_detail(
             with_error_info_detail(
                 err,
@@ -1396,10 +1401,9 @@ mod tests {
 
     impl Ingest for FakeEngine {
         async fn put_batch(&self, kvs: Vec<(Bytes, Bytes)>) -> Result<u64, IngestError> {
-            let mut state = self
-                .state
-                .lock()
-                .map_err(|e| IngestError::Internal(e.to_string()))?;
+            let mut state = self.state.lock().map_err(|e| IngestError::Internal {
+                message: e.to_string(),
+            })?;
             if let Some(err) = state.put_error.take() {
                 return Err(err);
             }
@@ -1845,7 +1849,9 @@ mod tests {
     #[tokio::test]
     async fn ingest_unavailable_surfaces_as_unavailable_with_retry_info() {
         let engine = Arc::new(FakeEngine::default());
-        engine.set_put_error(IngestError::Unavailable("backend bouncing".to_string()));
+        engine.set_put_error(IngestError::Unavailable {
+            message: "backend bouncing".to_string(),
+        });
         let connect = IngestConnect::new(IngestState::new(engine));
 
         let err = IngestApi::put(&connect, Context::default(), put_request(1))
@@ -1856,7 +1862,7 @@ mod tests {
         let decoded = decode_connect_error(&err).expect("decode details");
         assert_eq!(
             decoded.error_info.expect("error info").reason,
-            "INGEST_UNAVAILABLE"
+            REASON_INGEST_UNAVAILABLE
         );
         let retry_delay = decoded.retry_info.expect("retry info").retry_delay;
         let retry_delay = retry_delay.as_option().expect("retry delay");
@@ -1866,7 +1872,9 @@ mod tests {
     #[tokio::test]
     async fn ingest_internal_surfaces_as_internal_without_error_info() {
         let engine = Arc::new(FakeEngine::default());
-        engine.set_put_error(IngestError::Internal("invariant violated".to_string()));
+        engine.set_put_error(IngestError::Internal {
+            message: "invariant violated".to_string(),
+        });
         let connect = IngestConnect::new(IngestState::new(engine));
 
         let err = IngestApi::put(&connect, Context::default(), put_request(1))
@@ -1895,7 +1903,7 @@ mod tests {
         let decoded = decode_connect_error(&err).expect("decode details");
         assert_eq!(
             decoded.error_info.expect("error info").reason,
-            "WORKER_NOT_READY"
+            REASON_WORKER_NOT_READY
         );
     }
 

--- a/server/src/engine.rs
+++ b/server/src/engine.rs
@@ -1,7 +1,8 @@
 //! Storage callbacks for the store services.
 //!
-//! Implement the capability traits your component serves. Errors are surfaced to clients as
-//! internal RPC failures (string message only; keep messages safe to expose if you rely on that).
+//! Implement the capability traits your component serves. String errors are surfaced to clients as
+//! internal RPC failures (message only; keep messages safe to expose if you rely on that). `Ingest`
+//! additionally lets a backend mark a write failure transient via [`IngestError`].
 
 use std::collections::HashMap;
 use std::future::Future;
@@ -45,6 +46,30 @@ pub trait Sequence: Send + Sync + 'static {
     fn current_sequence(&self) -> u64;
 }
 
+/// Why an ingest write was not accepted.
+///
+/// The variant picks the wire code, so retryability decided by the backend survives to clients:
+/// transient conditions (a dependency down, overload) must surface as `unavailable`, not `internal`,
+/// which retry policies rightly treat as fatal.
+#[derive(Debug)]
+pub enum IngestError {
+    /// The write cannot currently be accepted; clients may retry with backoff.
+    Unavailable(String),
+    /// The write failed in a way retries will not fix.
+    Internal(String),
+}
+
+impl std::fmt::Display for IngestError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Message only; the wire code carries the retryable/fatal class.
+        match self {
+            IngestError::Unavailable(msg) | IngestError::Internal(msg) => write!(f, "{msg}"),
+        }
+    }
+}
+
+impl std::error::Error for IngestError {}
+
 /// Ingest write capability.
 pub trait Ingest: Send + Sync + 'static {
     /// Persist key-value pairs atomically and return the global sequence number that includes this
@@ -53,7 +78,7 @@ pub trait Ingest: Send + Sync + 'static {
     fn put_batch(
         &self,
         kvs: Vec<(Bytes, Bytes)>,
-    ) -> impl Future<Output = Result<u64, String>> + Send;
+    ) -> impl Future<Output = Result<u64, IngestError>> + Send;
 }
 
 /// Query read capability.

--- a/server/src/engine.rs
+++ b/server/src/engine.rs
@@ -48,18 +48,16 @@ pub trait Sequence: Send + Sync + 'static {
 
 /// Why an ingest write was not accepted.
 ///
-/// The variant picks the wire code, so retryability decided by the backend survives to clients:
-/// transient conditions (a dependency down, overload) should surface as `unavailable`, since
-/// code-based retry policies (load balancers, gRPC clients) typically retry `unavailable` but not
-/// `internal`. `Display` renders the message only; the wire code carries the retryable/fatal class.
+/// Backends choose the variant; the Connect layer maps it to the wire code and retry details.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum IngestError {
     /// The write cannot currently be accepted; clients may retry with backoff.
-    #[error("{0}")]
-    Unavailable(String),
+    #[error("unavailable: {message}")]
+    Unavailable { message: String },
+
     /// The write failed in a way retries will not fix.
-    #[error("{0}")]
-    Internal(String),
+    #[error("internal: {message}")]
+    Internal { message: String },
 }
 
 /// Ingest write capability.

--- a/server/src/engine.rs
+++ b/server/src/engine.rs
@@ -49,26 +49,18 @@ pub trait Sequence: Send + Sync + 'static {
 /// Why an ingest write was not accepted.
 ///
 /// The variant picks the wire code, so retryability decided by the backend survives to clients:
-/// transient conditions (a dependency down, overload) must surface as `unavailable`, not `internal`,
-/// which retry policies rightly treat as fatal.
-#[derive(Debug)]
+/// transient conditions (a dependency down, overload) should surface as `unavailable`, since
+/// code-based retry policies (load balancers, gRPC clients) typically retry `unavailable` but not
+/// `internal`. `Display` renders the message only; the wire code carries the retryable/fatal class.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum IngestError {
     /// The write cannot currently be accepted; clients may retry with backoff.
+    #[error("{0}")]
     Unavailable(String),
     /// The write failed in a way retries will not fix.
+    #[error("{0}")]
     Internal(String),
 }
-
-impl std::fmt::Display for IngestError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        // Message only; the wire code carries the retryable/fatal class.
-        match self {
-            IngestError::Unavailable(msg) | IngestError::Internal(msg) => write!(f, "{msg}"),
-        }
-    }
-}
-
-impl std::error::Error for IngestError {}
 
 /// Ingest write capability.
 pub trait Ingest: Send + Sync + 'static {

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -15,8 +15,8 @@ pub use connect::{
     AppState, CompactState, IngestState, QueryState, StreamState,
 };
 pub use engine::{
-    Ingest, Log, LogBatch, Prune, Query, QueryExtra, RangeScan, RangeScanBatch, Sequence,
-    StoreEngine,
+    Ingest, IngestError, Log, LogBatch, Prune, Query, QueryExtra, RangeScan, RangeScanBatch,
+    Sequence, StoreEngine,
 };
 pub use reduce::RangeError;
 pub use stream::{StreamHub, StreamNotification, StreamNotifier};


### PR DESCRIPTION
Allows ingest implementations to specify between `Unavailable` and `Internal` error types, so that the connect layer can distinguish between them to determine retry or error without needing to be aware of an implementations error strings. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking change to the `Ingest` trait affects every backend implementor, but scope is limited to ingest error typing and RPC mapping with new unit tests.
> 
> **Overview**
> **Ingest backends** now return **`IngestError`** from **`put_batch`** instead of plain strings, with **`Unavailable`** (retryable) and **`Internal`** (not retryable) variants. The **`Ingest`** trait, public exports, and the simulator Rocks writer are updated accordingly.
> 
> The **Connect ingest layer** maps **`IngestError::Unavailable`** to **`unavailable`** with **`ErrorInfo.reason` = `INGEST_UNAVAILABLE`**, plus **`RetryInfo`** (1s delay). **`Internal`** still becomes **`internal`** without ingest-specific error info. **`put`** uses this mapper instead of treating all backend failures as internal.
> 
> Transient **not-ready** and **consistency-not-ready** responses share a **`with_retry_hint`** helper and the same retry delay constant. Tests cover unavailable vs internal mapping and that **`WORKER_NOT_READY`** stays distinct from **`INGEST_UNAVAILABLE`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea43972edf4751ee400ca36af929be636cf5157f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->