### PR TITLE
Better API for store namespaces

### DIFF
--- a/examples/simulator/tests/e2e_connect.rs
+++ b/examples/simulator/tests/e2e_connect.rs
@@ -14,12 +14,12 @@ use exoware_sdk::kv_codec::{
 use exoware_sdk::prune_policy;
 use exoware_sdk::selector::Selector as DomainSelector;
 use exoware_sdk::{
-    connect_compression_registry, PreferZstdHttpClient, RangeMode, RangeReduceOp,
-    RangeReduceRequest, RangeReducerSpec, RetryConfig, StoreClient,
+    connect_compression_registry, PreferZstdHttpClient, PrefixedStoreClient, RangeMode,
+    RangeReduceOp, RangeReduceRequest, RangeReducerSpec, RetryConfig, StoreClient,
 };
 use tempfile::tempdir;
 
-async fn spawn_client() -> (tokio::task::JoinHandle<()>, StoreClient, String) {
+async fn spawn_client() -> (tokio::task::JoinHandle<()>, PrefixedStoreClient, String) {
     let dir = tempdir().expect("tempdir");
     let dir_path = dir.path().to_owned();
     let _dir = dir;
@@ -31,7 +31,7 @@ async fn spawn_client() -> (tokio::task::JoinHandle<()>, StoreClient, String) {
         .retry_config(RetryConfig::disabled())
         .build()
         .expect("build client");
-    (handle, client, url)
+    (handle, PrefixedStoreClient::empty(client), url)
 }
 
 fn key(b: &[u8]) -> Key {
@@ -333,7 +333,7 @@ async fn create_session_with_sequence_reads_at_or_above_floor() {
 #[tokio::test]
 async fn health_endpoint() {
     let (_h, client, _url) = spawn_client().await;
-    assert!(client.health().await.expect("health"));
+    assert!(client.client().health().await.expect("health"));
 }
 
 // -- batch put multiple keys --

--- a/examples/simulator/tests/e2e_stream.rs
+++ b/examples/simulator/tests/e2e_stream.rs
@@ -6,10 +6,10 @@ use exoware_sdk::kv_codec::Utf8;
 use exoware_sdk::prune_policy::{PolicyScope, PrunePolicy, RetainPolicy};
 use exoware_sdk::selector::Selector;
 use exoware_sdk::stream_filter::StreamFilter;
-use exoware_sdk::{RetryConfig, StoreClient};
+use exoware_sdk::{PrefixedStoreClient, RetryConfig, StoreClient};
 use tempfile::tempdir;
 
-async fn spawn_client() -> (tokio::task::JoinHandle<()>, StoreClient) {
+async fn spawn_client() -> (tokio::task::JoinHandle<()>, PrefixedStoreClient) {
     let dir = tempdir().expect("tempdir");
     let dir_path = dir.path().to_owned();
     let _dir = dir;
@@ -21,7 +21,7 @@ async fn spawn_client() -> (tokio::task::JoinHandle<()>, StoreClient) {
         .retry_config(RetryConfig::disabled())
         .build()
         .expect("build client");
-    (handle, client)
+    (handle, PrefixedStoreClient::empty(client))
 }
 
 fn key(family: u16, payload: &[u8]) -> Key {

--- a/integration/tests/multi_instance.rs
+++ b/integration/tests/multi_instance.rs
@@ -21,9 +21,9 @@ use exoware_sdk::proto::PreferZstdHttpClient;
 use exoware_sdk::selector::Selector;
 use exoware_sdk::stream_filter::StreamFilter;
 use exoware_sdk::{
-    Namespace, PrefixedStoreClient, RetryConfig, StoreBatchPublication, StoreBatchUpload,
-    StoreClient, StoreKeyPrefix, StorePublicationFrontierWriter, StoreWriteBatch,
-    StreamSubscription, StreamSubscriptionFrame,
+    PrefixedStoreClient, RetryConfig, StoreBatchPublication, StoreBatchUpload, StoreClient,
+    StoreKeyPrefix, StorePublicationFrontierWriter, StoreWriteBatch, StreamSubscription,
+    StreamSubscriptionFrame,
 };
 use exoware_sql::proto::sql::v1::{
     cell, ServiceClient as SqlServiceClient, SubscribeRequest as SqlSubscribeRequest,
@@ -145,11 +145,11 @@ async fn next_frame(
 }
 
 fn keyless_reader(client: PrefixedStoreClient) -> QmdbReader {
-    QmdbReader::from_prefixed(client, ((0..=10000).into(), ()))
+    QmdbReader::new(client, ((0..=10000).into(), ()))
 }
 
 fn keyless_writer(client: PrefixedStoreClient) -> QmdbWriter {
-    QmdbWriter::from_prefixed(client, WriterState::empty())
+    QmdbWriter::new(client, WriterState::empty())
 }
 
 async fn commit_qmdb_upload(
@@ -347,8 +347,8 @@ async fn raw_prefixes_support_atomic_batch_fetch_range_and_stream() {
 #[tokio::test]
 async fn sql_schemas_are_isolated_by_store_prefix() {
     let (_dir, _server, base) = local_store_client().await;
-    let schema_a = make_sql_schema(base.prefixed(Namespace::Sql.sub(0)));
-    let schema_b = make_sql_schema(base.prefixed(Namespace::Sql.sub(1)));
+    let schema_a = make_sql_schema(base.prefixed(StoreKeyPrefix::new(4, 0).unwrap()));
+    let schema_b = make_sql_schema(base.prefixed(StoreKeyPrefix::new(4, 1).unwrap()));
 
     let mut writer_a = schema_a.batch_writer();
     writer_a
@@ -368,11 +368,11 @@ async fn sql_schemas_are_isolated_by_store_prefix() {
     assert!(seq_b.expect("flush b") > 0);
 
     assert_eq!(
-        query_sql_items(base.prefixed(Namespace::Sql.sub(0))).await,
+        query_sql_items(base.prefixed(StoreKeyPrefix::new(4, 0).unwrap())).await,
         (vec![1, 2], vec![100, 200])
     );
     assert_eq!(
-        query_sql_items(base.prefixed(Namespace::Sql.sub(1))).await,
+        query_sql_items(base.prefixed(StoreKeyPrefix::new(4, 1).unwrap())).await,
         (vec![1, 3], vec![1000, 3000])
     );
 }
@@ -380,8 +380,8 @@ async fn sql_schemas_are_isolated_by_store_prefix() {
 #[tokio::test]
 async fn sql_streaming_is_isolated_by_store_prefix() {
     let (_dir, _server, base) = local_store_client().await;
-    let client_a = base.prefixed(Namespace::Sql.sub(0));
-    let client_b = base.prefixed(Namespace::Sql.sub(1));
+    let client_a = base.prefixed(StoreKeyPrefix::new(4, 0).unwrap());
+    let client_b = base.prefixed(StoreKeyPrefix::new(4, 1).unwrap());
     let (_sql_server_a, sql_url_a) = spawn_sql_service(make_sql_schema(client_a.clone())).await;
     let (_sql_server_b, sql_url_b) = spawn_sql_service(make_sql_schema(client_b.clone())).await;
     let sql_a = sql_rpc_client(&sql_url_a);
@@ -449,7 +449,7 @@ async fn sql_streaming_is_isolated_by_store_prefix() {
 }
 
 fn make_sql_schema(client: PrefixedStoreClient) -> KvSchema {
-    KvSchema::from_prefixed(client)
+    KvSchema::new(client)
         .table(
             "items",
             vec![
@@ -483,8 +483,8 @@ async fn query_sql_items(client: PrefixedStoreClient) -> (Vec<i64>, Vec<i64>) {
 #[tokio::test]
 async fn prefixed_qmdb_writers_handle_concurrent_inflight_batches_per_instance() {
     let (_dir, _server, base) = local_store_client().await;
-    let client_a = base.prefixed(Namespace::Qmdb.sub(0));
-    let client_b = base.prefixed(Namespace::Qmdb.sub(1));
+    let client_a = base.prefixed(StoreKeyPrefix::new(4, 4).unwrap());
+    let client_b = base.prefixed(StoreKeyPrefix::new(4, 5).unwrap());
     let writer_a = Arc::new(keyless_writer(client_a.clone()));
     let writer_b = Arc::new(keyless_writer(client_b.clone()));
 
@@ -567,8 +567,8 @@ async fn prefixed_qmdb_writers_handle_concurrent_inflight_batches_per_instance()
 #[tokio::test]
 async fn prepared_sql_and_qmdb_batches_commit_atomically_with_sequence_receipts() {
     let (_dir, _server, base) = local_store_client().await;
-    let sql_client = base.for_namespace(Namespace::Sql);
-    let qmdb_client = base.for_namespace(Namespace::Qmdb);
+    let sql_client = base.prefixed(StoreKeyPrefix::new(4, 0).unwrap());
+    let qmdb_client = base.prefixed(StoreKeyPrefix::new(4, 4).unwrap());
     let mut sql_writer = make_sql_schema(sql_client.clone()).batch_writer();
     sql_writer
         .insert("items", vec![CellValue::Int64(42), CellValue::Int64(4200)])
@@ -679,8 +679,8 @@ async fn prepared_sql_and_qmdb_batches_commit_atomically_with_sequence_receipts(
 #[tokio::test]
 async fn qmdb_streaming_is_isolated_by_store_prefix() {
     let (_dir, _server, base) = local_store_client().await;
-    let client_a = base.prefixed(Namespace::Qmdb.sub(0));
-    let client_b = base.prefixed(Namespace::Qmdb.sub(1));
+    let client_a = base.prefixed(StoreKeyPrefix::new(4, 4).unwrap());
+    let client_b = base.prefixed(StoreKeyPrefix::new(4, 5).unwrap());
     let (_qmdb_server_a, qmdb_url_a) = spawn_qmdb_service(client_a.clone()).await;
     let (_qmdb_server_b, qmdb_url_b) = spawn_qmdb_service(client_b.clone()).await;
     let qmdb_a = qmdb_rpc_client(&qmdb_url_a);

--- a/integration/tests/multi_instance.rs
+++ b/integration/tests/multi_instance.rs
@@ -158,7 +158,7 @@ async fn commit_qmdb_upload(
     ops: &[QmdbOp],
 ) -> Result<exoware_qmdb::UploadReceipt<QmdbFamily>, QmdbError> {
     let prepared = writer.prepare_upload(ops).await?;
-    writer.commit_upload(commit_client, prepared).await
+    writer.commit_upload(commit_client.client(), prepared).await
 }
 
 fn qops(label: &str, batch: usize) -> Vec<QmdbOp> {
@@ -278,11 +278,17 @@ async fn raw_prefixes_support_atomic_batch_fetch_range_and_stream() {
     let shared = Bytes::from_static(b"shared-key");
     let only_a = Bytes::from_static(b"only-a");
     let mut batch = StoreWriteBatch::new();
-    batch.push(&a, &shared, b"value-a").expect("push a shared");
-    batch.push(&b, &shared, b"value-b").expect("push b shared");
-    batch.push(&a, &only_a, b"value-a2").expect("push a only");
+    batch
+        .push(a.key_prefix(), &shared, b"value-a")
+        .expect("push a shared");
+    batch
+        .push(b.key_prefix(), &shared, b"value-b")
+        .expect("push b shared");
+    batch
+        .push(a.key_prefix(), &only_a, b"value-a2")
+        .expect("push a only");
     let sequence = batch
-        .commit(&unprefixed)
+        .commit(&base)
         .await
         .expect("commit cross-prefix batch");
 
@@ -617,10 +623,7 @@ async fn prepared_sql_and_qmdb_batches_commit_atomically_with_sequence_receipts(
     StoreBatchPublication::stage_publication(&qmdb_writer, &prepared_qmdb_watermark, &mut batch)
         .expect("stage qmdb watermark");
 
-    let sequence = batch
-        .commit(&PrefixedStoreClient::empty(base.clone()))
-        .await
-        .expect("atomic Store commit");
+    let sequence = batch.commit(&base).await.expect("atomic Store commit");
     let sql_receipt =
         StoreBatchUpload::mark_upload_persisted(&sql_writer, prepared_sql, sequence).await;
     let receipt_qmdb_1 =

--- a/integration/tests/multi_instance.rs
+++ b/integration/tests/multi_instance.rs
@@ -153,12 +153,11 @@ fn keyless_writer(client: PrefixedStoreClient) -> QmdbWriter {
 }
 
 async fn commit_qmdb_upload(
-    commit_client: &PrefixedStoreClient,
     writer: &QmdbWriter,
     ops: &[QmdbOp],
 ) -> Result<exoware_qmdb::UploadReceipt<QmdbFamily>, QmdbError> {
     let prepared = writer.prepare_upload(ops).await?;
-    writer.commit_upload(commit_client.client(), prepared).await
+    writer.commit_upload(prepared).await
 }
 
 fn qops(label: &str, batch: usize) -> Vec<QmdbOp> {
@@ -191,7 +190,6 @@ where
 }
 
 async fn drive_qmdb_writer(
-    writer_client: PrefixedStoreClient,
     writer: Arc<QmdbWriter>,
     batches: Vec<Vec<QmdbOp>>,
 ) -> (Vec<QmdbOp>, Vec<exoware_qmdb::UploadReceipt<QmdbFamily>>) {
@@ -199,8 +197,7 @@ async fn drive_qmdb_writer(
     let mut in_flight = FuturesUnordered::new();
     for batch in batches {
         let writer = writer.clone();
-        let client = writer_client.clone();
-        in_flight.push(async move { commit_qmdb_upload(&client, &writer, &batch).await });
+        in_flight.push(async move { commit_qmdb_upload(&writer, &batch).await });
     }
     let mut receipts = Vec::new();
     while let Some(result) = in_flight.next().await {
@@ -494,8 +491,8 @@ async fn prefixed_qmdb_writers_handle_concurrent_inflight_batches_per_instance()
     let total_b: usize = batches_b.iter().map(Vec::len).sum();
 
     let ((expected_a, receipts_a), (expected_b, receipts_b)) = tokio::join!(
-        drive_qmdb_writer(client_a.clone(), writer_a, batches_a),
-        drive_qmdb_writer(client_b.clone(), writer_b, batches_b)
+        drive_qmdb_writer(writer_a, batches_a),
+        drive_qmdb_writer(writer_b, batches_b)
     );
     assert!(
         receipts_a
@@ -698,7 +695,7 @@ async fn qmdb_streaming_is_isolated_by_store_prefix() {
 
     let ops_b = qops("stream-b", 0);
     let writer_b = keyless_writer(client_b.clone());
-    commit_qmdb_upload(&client_b, &writer_b, &ops_b)
+    commit_qmdb_upload(&writer_b, &ops_b)
         .await
         .expect("upload b stream");
     let root_b = keyless_reader(client_b.clone())
@@ -732,7 +729,7 @@ async fn qmdb_streaming_is_isolated_by_store_prefix() {
 
     let ops_a = qops("stream-a", 0);
     let writer_a = keyless_writer(client_a.clone());
-    commit_qmdb_upload(&client_a, &writer_a, &ops_a)
+    commit_qmdb_upload(&writer_a, &ops_a)
         .await
         .expect("upload a stream");
     let root_a = keyless_reader(client_a.clone())

--- a/integration/tests/multi_instance.rs
+++ b/integration/tests/multi_instance.rs
@@ -13,7 +13,7 @@ use datafusion::prelude::SessionContext;
 use exoware_qmdb::proto::qmdb::v1::SubscribeRequest as QmdbSubscribeRequest;
 use exoware_qmdb::{
     keyless_operation_log_connect_stack, KeylessClient, KeylessWriter, OperationLogClient,
-    OperationLogSubscribeProof, QmdbError,
+    OperationLogSubscribeProof, QmdbError, WriterState,
 };
 use exoware_sdk::keys::Key;
 use exoware_sdk::kv_codec::Utf8;
@@ -21,8 +21,9 @@ use exoware_sdk::proto::PreferZstdHttpClient;
 use exoware_sdk::selector::Selector;
 use exoware_sdk::stream_filter::StreamFilter;
 use exoware_sdk::{
-    RetryConfig, StoreBatchPublication, StoreBatchUpload, StoreClient, StoreKeyPrefix,
-    StorePublicationFrontierWriter, StoreWriteBatch, StreamSubscription, StreamSubscriptionFrame,
+    Namespace, PrefixedStoreClient, RetryConfig, StoreBatchPublication, StoreBatchUpload,
+    StoreClient, StoreKeyPrefix, StorePublicationFrontierWriter, StoreWriteBatch,
+    StreamSubscription, StreamSubscriptionFrame,
 };
 use exoware_sql::proto::sql::v1::{
     cell, ServiceClient as SqlServiceClient, SubscribeRequest as SqlSubscribeRequest,
@@ -90,7 +91,7 @@ async fn spawn_sql_service(schema: KvSchema) -> (tokio::task::JoinHandle<()>, St
     (handle, url)
 }
 
-async fn spawn_qmdb_service(client: StoreClient) -> (tokio::task::JoinHandle<()>, String) {
+async fn spawn_qmdb_service(client: PrefixedStoreClient) -> (tokio::task::JoinHandle<()>, String) {
     let reader = Arc::new(keyless_reader(client));
     let app = Router::new()
         .route("/health", get(health))
@@ -143,16 +144,16 @@ async fn next_frame(
         .and_then(|result| result.expect("stream frame"))
 }
 
-fn keyless_reader(client: StoreClient) -> QmdbReader {
-    QmdbReader::from_client(client, ((0..=10000).into(), ()))
+fn keyless_reader(client: PrefixedStoreClient) -> QmdbReader {
+    QmdbReader::from_prefixed(client, ((0..=10000).into(), ()))
 }
 
-fn keyless_writer(client: StoreClient) -> QmdbWriter {
-    QmdbWriter::empty(client)
+fn keyless_writer(client: PrefixedStoreClient) -> QmdbWriter {
+    QmdbWriter::from_prefixed(client, WriterState::empty())
 }
 
 async fn commit_qmdb_upload(
-    commit_client: &StoreClient,
+    commit_client: &PrefixedStoreClient,
     writer: &QmdbWriter,
     ops: &[QmdbOp],
 ) -> Result<exoware_qmdb::UploadReceipt<QmdbFamily>, QmdbError> {
@@ -190,7 +191,7 @@ where
 }
 
 async fn drive_qmdb_writer(
-    writer_client: StoreClient,
+    writer_client: PrefixedStoreClient,
     writer: Arc<QmdbWriter>,
     batches: Vec<Vec<QmdbOp>>,
 ) -> (Vec<QmdbOp>, Vec<exoware_qmdb::UploadReceipt<QmdbFamily>>) {
@@ -258,8 +259,9 @@ fn collect_int64_column(
 #[tokio::test]
 async fn raw_prefixes_support_atomic_batch_fetch_range_and_stream() {
     let (_dir, _server, base) = local_store_client().await;
-    let a = base.with_key_prefix(store_prefix(1));
-    let b = base.with_key_prefix(store_prefix(2));
+    let a = base.prefixed(store_prefix(1));
+    let b = base.prefixed(store_prefix(2));
+    let unprefixed = PrefixedStoreClient::empty(base.clone());
 
     let mut sub_a = a
         .stream()
@@ -280,7 +282,7 @@ async fn raw_prefixes_support_atomic_batch_fetch_range_and_stream() {
     batch.push(&b, &shared, b"value-b").expect("push b shared");
     batch.push(&a, &only_a, b"value-a2").expect("push a only");
     let sequence = batch
-        .commit(&base)
+        .commit(&unprefixed)
         .await
         .expect("commit cross-prefix batch");
 
@@ -293,7 +295,12 @@ async fn raw_prefixes_support_atomic_batch_fetch_range_and_stream() {
         Some(&b"value-b"[..])
     );
     assert!(
-        base.query().get(&shared).await.expect("base get").is_none(),
+        unprefixed
+            .query()
+            .get(&shared)
+            .await
+            .expect("base get")
+            .is_none(),
         "unprefixed client must not see logical prefixed key"
     );
 
@@ -334,8 +341,8 @@ async fn raw_prefixes_support_atomic_batch_fetch_range_and_stream() {
 #[tokio::test]
 async fn sql_schemas_are_isolated_by_store_prefix() {
     let (_dir, _server, base) = local_store_client().await;
-    let schema_a = make_sql_schema(base.with_key_prefix(store_prefix(3)));
-    let schema_b = make_sql_schema(base.with_key_prefix(store_prefix(4)));
+    let schema_a = make_sql_schema(base.prefixed(Namespace::Sql.sub(0)));
+    let schema_b = make_sql_schema(base.prefixed(Namespace::Sql.sub(1)));
 
     let mut writer_a = schema_a.batch_writer();
     writer_a
@@ -355,11 +362,11 @@ async fn sql_schemas_are_isolated_by_store_prefix() {
     assert!(seq_b.expect("flush b") > 0);
 
     assert_eq!(
-        query_sql_items(base.with_key_prefix(store_prefix(3))).await,
+        query_sql_items(base.prefixed(Namespace::Sql.sub(0))).await,
         (vec![1, 2], vec![100, 200])
     );
     assert_eq!(
-        query_sql_items(base.with_key_prefix(store_prefix(4))).await,
+        query_sql_items(base.prefixed(Namespace::Sql.sub(1))).await,
         (vec![1, 3], vec![1000, 3000])
     );
 }
@@ -367,8 +374,8 @@ async fn sql_schemas_are_isolated_by_store_prefix() {
 #[tokio::test]
 async fn sql_streaming_is_isolated_by_store_prefix() {
     let (_dir, _server, base) = local_store_client().await;
-    let client_a = base.with_key_prefix(store_prefix(7));
-    let client_b = base.with_key_prefix(store_prefix(8));
+    let client_a = base.prefixed(Namespace::Sql.sub(0));
+    let client_b = base.prefixed(Namespace::Sql.sub(1));
     let (_sql_server_a, sql_url_a) = spawn_sql_service(make_sql_schema(client_a.clone())).await;
     let (_sql_server_b, sql_url_b) = spawn_sql_service(make_sql_schema(client_b.clone())).await;
     let sql_a = sql_rpc_client(&sql_url_a);
@@ -435,8 +442,8 @@ async fn sql_streaming_is_isolated_by_store_prefix() {
     assert_eq!(row_int64(&frame_a.rows[0], 1), 400);
 }
 
-fn make_sql_schema(client: StoreClient) -> KvSchema {
-    KvSchema::new(client)
+fn make_sql_schema(client: PrefixedStoreClient) -> KvSchema {
+    KvSchema::from_prefixed(client)
         .table(
             "items",
             vec![
@@ -449,7 +456,7 @@ fn make_sql_schema(client: StoreClient) -> KvSchema {
         .expect("sql schema")
 }
 
-async fn query_sql_items(client: StoreClient) -> (Vec<i64>, Vec<i64>) {
+async fn query_sql_items(client: PrefixedStoreClient) -> (Vec<i64>, Vec<i64>) {
     let ctx = SessionContext::new();
     make_sql_schema(client)
         .register_all(&ctx)
@@ -470,8 +477,8 @@ async fn query_sql_items(client: StoreClient) -> (Vec<i64>, Vec<i64>) {
 #[tokio::test]
 async fn prefixed_qmdb_writers_handle_concurrent_inflight_batches_per_instance() {
     let (_dir, _server, base) = local_store_client().await;
-    let client_a = base.with_key_prefix(store_prefix(5));
-    let client_b = base.with_key_prefix(store_prefix(6));
+    let client_a = base.prefixed(Namespace::Qmdb.sub(0));
+    let client_b = base.prefixed(Namespace::Qmdb.sub(1));
     let writer_a = Arc::new(keyless_writer(client_a.clone()));
     let writer_b = Arc::new(keyless_writer(client_b.clone()));
 
@@ -554,8 +561,8 @@ async fn prefixed_qmdb_writers_handle_concurrent_inflight_batches_per_instance()
 #[tokio::test]
 async fn prepared_sql_and_qmdb_batches_commit_atomically_with_sequence_receipts() {
     let (_dir, _server, base) = local_store_client().await;
-    let sql_client = base.with_key_prefix(store_prefix(11));
-    let qmdb_client = base.with_key_prefix(store_prefix(12));
+    let sql_client = base.for_namespace(Namespace::Sql);
+    let qmdb_client = base.for_namespace(Namespace::Qmdb);
     let mut sql_writer = make_sql_schema(sql_client.clone()).batch_writer();
     sql_writer
         .insert("items", vec![CellValue::Int64(42), CellValue::Int64(4200)])
@@ -610,7 +617,10 @@ async fn prepared_sql_and_qmdb_batches_commit_atomically_with_sequence_receipts(
     StoreBatchPublication::stage_publication(&qmdb_writer, &prepared_qmdb_watermark, &mut batch)
         .expect("stage qmdb watermark");
 
-    let sequence = batch.commit(&base).await.expect("atomic Store commit");
+    let sequence = batch
+        .commit(&PrefixedStoreClient::empty(base.clone()))
+        .await
+        .expect("atomic Store commit");
     let sql_receipt =
         StoreBatchUpload::mark_upload_persisted(&sql_writer, prepared_sql, sequence).await;
     let receipt_qmdb_1 =
@@ -666,8 +676,8 @@ async fn prepared_sql_and_qmdb_batches_commit_atomically_with_sequence_receipts(
 #[tokio::test]
 async fn qmdb_streaming_is_isolated_by_store_prefix() {
     let (_dir, _server, base) = local_store_client().await;
-    let client_a = base.with_key_prefix(store_prefix(9));
-    let client_b = base.with_key_prefix(store_prefix(10));
+    let client_a = base.prefixed(Namespace::Qmdb.sub(0));
+    let client_b = base.prefixed(Namespace::Qmdb.sub(1));
     let (_qmdb_server_a, qmdb_url_a) = spawn_qmdb_service(client_a.clone()).await;
     let (_qmdb_server_b, qmdb_url_b) = spawn_qmdb_service(client_b.clone()).await;
     let qmdb_a = qmdb_rpc_client(&qmdb_url_a);

--- a/qmdb/rs/README.md
+++ b/qmdb/rs/README.md
@@ -517,7 +517,7 @@ let writer: Arc<KeylessWriter<mmr::Family, Sha256, Vec<u8>>> =
 
 // Sequential single-instance usage still goes through an explicit Store batch.
 let prepared = writer.prepare_upload(&batch_ops).await?;
-let receipt = writer.commit_upload(&client, prepared).await?;
+let receipt = writer.commit_upload(prepared).await?;
 
 // Pipelined usage — prepare/commit concurrent Store batches up to a bounded depth.
 use futures::stream::{FuturesUnordered, StreamExt};
@@ -527,10 +527,9 @@ for batch in batches {
         in_flight.next().await.unwrap()?;
     }
     let w = writer.clone();
-    let c = client.clone();
     in_flight.push(Box::pin(async move {
         let prepared = w.prepare_upload(&batch).await?;
-        w.commit_upload(&c, prepared).await
+        w.commit_upload(prepared).await
     }));
 }
 while let Some(r) = in_flight.next().await { r?; }

--- a/qmdb/rs/src/bin/qmdb.rs
+++ b/qmdb/rs/src/bin/qmdb.rs
@@ -24,7 +24,7 @@ use exoware_qmdb::{
     ordered_connect_stack, recover_boundary_state, CurrentBoundaryState, OrderedClient,
     OrderedWriter, MAX_OPERATION_SIZE,
 };
-use exoware_sdk::{StoreBatchUpload, StoreClient};
+use exoware_sdk::{Namespace, PrefixedStoreClient, StoreBatchUpload, StoreClient};
 use tower_http::cors::CorsLayer;
 use tracing::info;
 
@@ -70,7 +70,7 @@ async fn health() -> &'static str {
 }
 
 async fn commit_ordered_upload(
-    client: &StoreClient,
+    client: &PrefixedStoreClient,
     writer: &OrderedWriter<DemoFamily, Sha256, Vec<u8>, Vec<u8>, N>,
     ops: &[QmdbOperation<DemoFamily, Vec<u8>, Vec<u8>>],
     boundary: &CurrentBoundaryState<commonware_cryptography::sha256::Digest, N, DemoFamily>,
@@ -248,7 +248,7 @@ async fn seed(
             let (mut previous_ops, mut counter, writer) = if *bounds.end <= 1 {
                 info!("starting from empty local DB");
                 let writer =
-                    OrderedWriter::<DemoFamily, Sha256, Vec<u8>, Vec<u8>, N>::empty(store.clone());
+                    OrderedWriter::<DemoFamily, Sha256, Vec<u8>, Vec<u8>, N>::fresh(store.clone());
                 (
                     Vec::<QmdbOperation<DemoFamily, Vec<u8>, Vec<u8>>>::new(),
                     0u64,
@@ -342,7 +342,13 @@ async fn seed(
                 let boundary = boundary_from_local_db(&db, previous_slice, &cumulative_ops).await;
                 let delta = &cumulative_ops[previous_ops.len()..];
 
-                commit_ordered_upload(&store, &writer, delta, &boundary).await;
+                commit_ordered_upload(
+                    &store.for_namespace(Namespace::Qmdb),
+                    &writer,
+                    delta,
+                    &boundary,
+                )
+                .await;
 
                 let root = reader.current_root_at(latest).await.expect("current root");
                 println!("tip={} root=0x{}", *latest, hex::encode(root.encode()),);

--- a/qmdb/rs/src/bin/qmdb.rs
+++ b/qmdb/rs/src/bin/qmdb.rs
@@ -24,7 +24,7 @@ use exoware_qmdb::{
     ordered_connect_stack, recover_boundary_state, CurrentBoundaryState, OrderedClient,
     OrderedWriter, MAX_OPERATION_SIZE,
 };
-use exoware_sdk::{PrefixedStoreClient, StoreBatchUpload, StoreClient, StoreKeyPrefix};
+use exoware_sdk::{StoreBatchUpload, StoreClient, StoreKeyPrefix};
 use tower_http::cors::CorsLayer;
 use tracing::info;
 
@@ -70,16 +70,12 @@ async fn health() -> &'static str {
 }
 
 async fn commit_ordered_upload(
-    client: &PrefixedStoreClient,
     writer: &OrderedWriter<DemoFamily, Sha256, Vec<u8>, Vec<u8>, N>,
     ops: &[QmdbOperation<DemoFamily, Vec<u8>, Vec<u8>>],
     boundary: &CurrentBoundaryState<commonware_cryptography::sha256::Digest, N, DemoFamily>,
 ) {
     let prepared = writer.prepare_upload(ops, boundary).await.expect("prepare");
-    writer
-        .commit_upload(client.client(), prepared)
-        .await
-        .expect("commit upload");
+    writer.commit_upload(prepared).await.expect("commit upload");
 }
 
 fn op_cfg() -> <QmdbOperation<DemoFamily, Vec<u8>, Vec<u8>> as commonware_codec::Read>::Cfg {
@@ -342,7 +338,7 @@ async fn seed(
                 let boundary = boundary_from_local_db(&db, previous_slice, &cumulative_ops).await;
                 let delta = &cumulative_ops[previous_ops.len()..];
 
-                commit_ordered_upload(&store, &writer, delta, &boundary).await;
+                commit_ordered_upload(&writer, delta, &boundary).await;
 
                 let root = reader.current_root_at(latest).await.expect("current root");
                 println!("tip={} root=0x{}", *latest, hex::encode(root.encode()),);

--- a/qmdb/rs/src/bin/qmdb.rs
+++ b/qmdb/rs/src/bin/qmdb.rs
@@ -24,7 +24,7 @@ use exoware_qmdb::{
     ordered_connect_stack, recover_boundary_state, CurrentBoundaryState, OrderedClient,
     OrderedWriter, MAX_OPERATION_SIZE,
 };
-use exoware_sdk::{Namespace, PrefixedStoreClient, StoreBatchUpload, StoreClient};
+use exoware_sdk::{PrefixedStoreClient, StoreBatchUpload, StoreClient, StoreKeyPrefix};
 use tower_http::cors::CorsLayer;
 use tracing::info;
 
@@ -158,7 +158,7 @@ async fn run(
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let client = Arc::new(
         OrderedClient::<DemoFamily, Sha256, Vec<u8>, Vec<u8>, N>::new(
-            store_url,
+            StoreClient::new(store_url).prefixed(StoreKeyPrefix::identity()),
             op_cfg(),
             update_row_cfg(),
         ),
@@ -193,8 +193,8 @@ async fn seed(
         "starting seed"
     );
 
-    let store = StoreClient::new(store_url);
-    let reader = OrderedClient::<DemoFamily, Sha256, Vec<u8>, Vec<u8>, N>::from_client(
+    let store = StoreClient::new(store_url).prefixed(StoreKeyPrefix::identity());
+    let reader = OrderedClient::<DemoFamily, Sha256, Vec<u8>, Vec<u8>, N>::new(
         store.clone(),
         op_cfg(),
         update_row_cfg(),
@@ -342,13 +342,7 @@ async fn seed(
                 let boundary = boundary_from_local_db(&db, previous_slice, &cumulative_ops).await;
                 let delta = &cumulative_ops[previous_ops.len()..];
 
-                commit_ordered_upload(
-                    &store.for_namespace(Namespace::Qmdb),
-                    &writer,
-                    delta,
-                    &boundary,
-                )
-                .await;
+                commit_ordered_upload(&store, &writer, delta, &boundary).await;
 
                 let root = reader.current_root_at(latest).await.expect("current root");
                 println!("tip={} root=0x{}", *latest, hex::encode(root.encode()),);

--- a/qmdb/rs/src/bin/qmdb.rs
+++ b/qmdb/rs/src/bin/qmdb.rs
@@ -77,7 +77,7 @@ async fn commit_ordered_upload(
 ) {
     let prepared = writer.prepare_upload(ops, boundary).await.expect("prepare");
     writer
-        .commit_upload(client, prepared)
+        .commit_upload(client.client(), prepared)
         .await
         .expect("commit upload");
 }

--- a/qmdb/rs/src/connect.rs
+++ b/qmdb/rs/src/connect.rs
@@ -160,7 +160,7 @@ trait OperationLogBackend: Clone + Send + Sync + 'static {
     /// ops have no logical key).
     const REJECTS_KEY_FILTERS: bool = false;
 
-    fn store_client(&self) -> &exoware_sdk::StoreClient;
+    fn store_client(&self) -> &exoware_sdk::PrefixedStoreClient;
     fn classify_and_filter(
         &self,
     ) -> (
@@ -247,7 +247,7 @@ where
     type Family = F;
     type Digest = H::Digest;
 
-    fn store_client(&self) -> &exoware_sdk::StoreClient {
+    fn store_client(&self) -> &exoware_sdk::PrefixedStoreClient {
         OrderedClient::store_client(self)
     }
 
@@ -301,7 +301,7 @@ where
     type Family = F;
     type Digest = H::Digest;
 
-    fn store_client(&self) -> &exoware_sdk::StoreClient {
+    fn store_client(&self) -> &exoware_sdk::PrefixedStoreClient {
         UnorderedClient::store_client(self)
     }
 
@@ -362,7 +362,7 @@ where
     type Family = F;
     type Digest = H::Digest;
 
-    fn store_client(&self) -> &exoware_sdk::StoreClient {
+    fn store_client(&self) -> &exoware_sdk::PrefixedStoreClient {
         ImmutableClient::store_client(self)
     }
 
@@ -416,7 +416,7 @@ where
     type Digest = H::Digest;
     const REJECTS_KEY_FILTERS: bool = true;
 
-    fn store_client(&self) -> &exoware_sdk::StoreClient {
+    fn store_client(&self) -> &exoware_sdk::PrefixedStoreClient {
         KeylessClient::store_client(self)
     }
 

--- a/qmdb/rs/src/core.rs
+++ b/qmdb/rs/src/core.rs
@@ -12,7 +12,7 @@ use commonware_storage::qmdb::{
     operation::Key as QmdbKey,
 };
 use exoware_sdk::keys::Key;
-use exoware_sdk::{ClientError, RangeMode, SerializableReadSession, StoreClient};
+use exoware_sdk::{ClientError, PrefixedStoreClient, RangeMode, SerializableReadSession};
 
 use crate::codec::{
     decode_digest, decode_operation_location_key, decode_update_location,
@@ -76,7 +76,7 @@ where
 
 #[derive(Clone, Debug)]
 pub(crate) struct HistoricalOpsClientCore<'a, F: Family, D: Digest, K: Codec, V: Codec> {
-    pub(crate) client: &'a StoreClient,
+    pub(crate) client: &'a PrefixedStoreClient,
     pub(crate) _marker: PhantomData<(F, D, K, V)>,
 }
 

--- a/qmdb/rs/src/immutable.rs
+++ b/qmdb/rs/src/immutable.rs
@@ -11,7 +11,7 @@ use commonware_storage::{
     },
 };
 use commonware_utils::Array;
-use exoware_sdk::{SerializableReadSession, StoreClient};
+use exoware_sdk::{Namespace, PrefixedStoreClient, SerializableReadSession, StoreClient};
 
 use crate::auth::AuthenticatedBackendNamespace;
 use crate::auth::{
@@ -72,7 +72,25 @@ where
         Self::from_client(StoreClient::new(url), operation_cfg)
     }
 
+    /// Read client over the canonical [`Namespace::Qmdb`] keyspace (matches the
+    /// writer default). Use [`Self::from_prefixed`] for a co-located QMDB log.
     pub fn from_client(
+        client: StoreClient,
+        operation_cfg: <immutable::Operation<F, K, E> as CodecRead>::Cfg,
+    ) -> Self {
+        Self::from_prefixed(client.for_namespace(Namespace::Qmdb), operation_cfg)
+    }
+
+    /// Read client over a caller-chosen namespace.
+    pub fn from_prefixed(
+        client: PrefixedStoreClient,
+        operation_cfg: <immutable::Operation<F, K, E> as CodecRead>::Cfg,
+    ) -> Self {
+        Self::from_unprefixed(client.into_client(), operation_cfg)
+    }
+
+    /// Read client over a raw, un-namespaced client.
+    pub fn from_unprefixed(
         client: StoreClient,
         operation_cfg: <immutable::Operation<F, K, E> as CodecRead>::Cfg,
     ) -> Self {

--- a/qmdb/rs/src/immutable.rs
+++ b/qmdb/rs/src/immutable.rs
@@ -11,7 +11,7 @@ use commonware_storage::{
     },
 };
 use commonware_utils::Array;
-use exoware_sdk::{Namespace, PrefixedStoreClient, SerializableReadSession, StoreClient};
+use exoware_sdk::{PrefixedStoreClient, SerializableReadSession};
 
 use crate::auth::AuthenticatedBackendNamespace;
 use crate::auth::{
@@ -65,24 +65,8 @@ where
     E: ValueEncoding<Value = V>,
     immutable::Operation<F, K, E>: Encode + Decode + Clone,
 {
+    /// Read client over `client`'s namespace prefix.
     pub fn new(
-        url: &str,
-        operation_cfg: <immutable::Operation<F, K, E> as CodecRead>::Cfg,
-    ) -> Self {
-        Self::from_client(StoreClient::new(url), operation_cfg)
-    }
-
-    /// Read client over the canonical [`Namespace::Qmdb`] keyspace (matches the
-    /// writer default). Use [`Self::from_prefixed`] for a co-located QMDB log.
-    pub fn from_client(
-        client: StoreClient,
-        operation_cfg: <immutable::Operation<F, K, E> as CodecRead>::Cfg,
-    ) -> Self {
-        Self::from_prefixed(client.for_namespace(Namespace::Qmdb), operation_cfg)
-    }
-
-    /// Read client over a caller-chosen namespace.
-    pub fn from_prefixed(
         client: PrefixedStoreClient,
         operation_cfg: <immutable::Operation<F, K, E> as CodecRead>::Cfg,
     ) -> Self {

--- a/qmdb/rs/src/immutable.rs
+++ b/qmdb/rs/src/immutable.rs
@@ -37,7 +37,7 @@ pub struct ImmutableClient<
 > where
     immutable::Operation<F, K, E>: CodecRead,
 {
-    client: StoreClient,
+    client: PrefixedStoreClient,
     operation_cfg: <immutable::Operation<F, K, E> as CodecRead>::Cfg,
     _marker: PhantomData<(F, H, K, E)>,
 }
@@ -86,14 +86,6 @@ where
         client: PrefixedStoreClient,
         operation_cfg: <immutable::Operation<F, K, E> as CodecRead>::Cfg,
     ) -> Self {
-        Self::from_unprefixed(client.into_client(), operation_cfg)
-    }
-
-    /// Read client over a raw, un-namespaced client.
-    pub fn from_unprefixed(
-        client: StoreClient,
-        operation_cfg: <immutable::Operation<F, K, E> as CodecRead>::Cfg,
-    ) -> Self {
         Self {
             client,
             operation_cfg,
@@ -101,7 +93,7 @@ where
         }
     }
 
-    pub(crate) fn store_client(&self) -> &StoreClient {
+    pub(crate) fn store_client(&self) -> &PrefixedStoreClient {
         &self.client
     }
 

--- a/qmdb/rs/src/keyless.rs
+++ b/qmdb/rs/src/keyless.rs
@@ -9,7 +9,7 @@ use commonware_storage::{
         keyless,
     },
 };
-use exoware_sdk::{SerializableReadSession, StoreClient};
+use exoware_sdk::{Namespace, PrefixedStoreClient, SerializableReadSession, StoreClient};
 
 use crate::auth::AuthenticatedBackendNamespace;
 use crate::auth::{
@@ -63,7 +63,25 @@ where
         Self::from_client(StoreClient::new(url), op_cfg)
     }
 
+    /// Read client over the canonical [`Namespace::Qmdb`] keyspace (matches the
+    /// writer default). Use [`Self::from_prefixed`] for a co-located QMDB log.
     pub fn from_client(
+        client: StoreClient,
+        op_cfg: <keyless::Operation<F, E> as CodecRead>::Cfg,
+    ) -> Self {
+        Self::from_prefixed(client.for_namespace(Namespace::Qmdb), op_cfg)
+    }
+
+    /// Read client over a caller-chosen namespace.
+    pub fn from_prefixed(
+        client: PrefixedStoreClient,
+        op_cfg: <keyless::Operation<F, E> as CodecRead>::Cfg,
+    ) -> Self {
+        Self::from_unprefixed(client.into_client(), op_cfg)
+    }
+
+    /// Read client over a raw, un-namespaced client.
+    pub fn from_unprefixed(
         client: StoreClient,
         op_cfg: <keyless::Operation<F, E> as CodecRead>::Cfg,
     ) -> Self {

--- a/qmdb/rs/src/keyless.rs
+++ b/qmdb/rs/src/keyless.rs
@@ -9,7 +9,7 @@ use commonware_storage::{
         keyless,
     },
 };
-use exoware_sdk::{Namespace, PrefixedStoreClient, SerializableReadSession, StoreClient};
+use exoware_sdk::{PrefixedStoreClient, SerializableReadSession};
 
 use crate::auth::AuthenticatedBackendNamespace;
 use crate::auth::{
@@ -59,21 +59,8 @@ where
     E: ValueEncoding<Value = V>,
     keyless::Operation<F, E>: Encode + Decode + Clone,
 {
-    pub fn new(url: &str, op_cfg: <keyless::Operation<F, E> as CodecRead>::Cfg) -> Self {
-        Self::from_client(StoreClient::new(url), op_cfg)
-    }
-
-    /// Read client over the canonical [`Namespace::Qmdb`] keyspace (matches the
-    /// writer default). Use [`Self::from_prefixed`] for a co-located QMDB log.
-    pub fn from_client(
-        client: StoreClient,
-        op_cfg: <keyless::Operation<F, E> as CodecRead>::Cfg,
-    ) -> Self {
-        Self::from_prefixed(client.for_namespace(Namespace::Qmdb), op_cfg)
-    }
-
-    /// Read client over a caller-chosen namespace.
-    pub fn from_prefixed(
+    /// Read client over `client`'s namespace prefix.
+    pub fn new(
         client: PrefixedStoreClient,
         op_cfg: <keyless::Operation<F, E> as CodecRead>::Cfg,
     ) -> Self {

--- a/qmdb/rs/src/keyless.rs
+++ b/qmdb/rs/src/keyless.rs
@@ -32,7 +32,7 @@ pub struct KeylessClient<
 > where
     keyless::Operation<F, E>: CodecRead,
 {
-    client: StoreClient,
+    client: PrefixedStoreClient,
     op_cfg: <keyless::Operation<F, E> as CodecRead>::Cfg,
     _marker: PhantomData<(F, H, E)>,
 }
@@ -77,14 +77,6 @@ where
         client: PrefixedStoreClient,
         op_cfg: <keyless::Operation<F, E> as CodecRead>::Cfg,
     ) -> Self {
-        Self::from_unprefixed(client.into_client(), op_cfg)
-    }
-
-    /// Read client over a raw, un-namespaced client.
-    pub fn from_unprefixed(
-        client: StoreClient,
-        op_cfg: <keyless::Operation<F, E> as CodecRead>::Cfg,
-    ) -> Self {
         Self {
             client,
             op_cfg,
@@ -92,7 +84,7 @@ where
         }
     }
 
-    pub(crate) fn store_client(&self) -> &StoreClient {
+    pub(crate) fn store_client(&self) -> &PrefixedStoreClient {
         &self.client
     }
 

--- a/qmdb/rs/src/ordered.rs
+++ b/qmdb/rs/src/ordered.rs
@@ -115,7 +115,7 @@ pub struct OrderedClient<
 > where
     ordered::Operation<F, K, E>: commonware_codec::Read,
 {
-    client: StoreClient,
+    client: PrefixedStoreClient,
     op_cfg: <ordered::Operation<F, K, E> as commonware_codec::Read>::Cfg,
     update_row_cfg: (K::Cfg, V::Cfg),
     _marker: PhantomData<(F, H, K, E)>,
@@ -217,15 +217,6 @@ where
         op_cfg: <ordered::Operation<F, K, E> as commonware_codec::Read>::Cfg,
         update_row_cfg: (K::Cfg, V::Cfg),
     ) -> Self {
-        Self::from_unprefixed(client.into_client(), op_cfg, update_row_cfg)
-    }
-
-    /// Read client over a raw, un-namespaced client.
-    pub fn from_unprefixed(
-        client: StoreClient,
-        op_cfg: <ordered::Operation<F, K, E> as commonware_codec::Read>::Cfg,
-        update_row_cfg: (K::Cfg, V::Cfg),
-    ) -> Self {
         Self {
             client,
             op_cfg,
@@ -300,7 +291,7 @@ where
         self.core().query_many_at(keys, max_location, self).await
     }
 
-    pub(crate) fn store_client(&self) -> &StoreClient {
+    pub(crate) fn store_client(&self) -> &PrefixedStoreClient {
         &self.client
     }
 

--- a/qmdb/rs/src/ordered.rs
+++ b/qmdb/rs/src/ordered.rs
@@ -20,7 +20,9 @@ use commonware_storage::{
 };
 use commonware_utils::bitmap::Readable as BitmapReadable;
 use exoware_sdk::keys::Key;
-use exoware_sdk::{RangeMode, SerializableReadSession, StoreClient};
+use exoware_sdk::{
+    Namespace, PrefixedStoreClient, RangeMode, SerializableReadSession, StoreClient,
+};
 
 use crate::codec::{
     bitmap_chunk_bits, chunk_index_for_location, clear_below_floor,
@@ -199,7 +201,27 @@ where
         Self::from_client(StoreClient::new(url), op_cfg, update_row_cfg)
     }
 
+    /// Read client over the canonical [`Namespace::Qmdb`] keyspace (matches the
+    /// writer default). Use [`Self::from_prefixed`] for a co-located QMDB log.
     pub fn from_client(
+        client: StoreClient,
+        op_cfg: <ordered::Operation<F, K, E> as commonware_codec::Read>::Cfg,
+        update_row_cfg: (K::Cfg, V::Cfg),
+    ) -> Self {
+        Self::from_prefixed(client.for_namespace(Namespace::Qmdb), op_cfg, update_row_cfg)
+    }
+
+    /// Read client over a caller-chosen namespace.
+    pub fn from_prefixed(
+        client: PrefixedStoreClient,
+        op_cfg: <ordered::Operation<F, K, E> as commonware_codec::Read>::Cfg,
+        update_row_cfg: (K::Cfg, V::Cfg),
+    ) -> Self {
+        Self::from_unprefixed(client.into_client(), op_cfg, update_row_cfg)
+    }
+
+    /// Read client over a raw, un-namespaced client.
+    pub fn from_unprefixed(
         client: StoreClient,
         op_cfg: <ordered::Operation<F, K, E> as commonware_codec::Read>::Cfg,
         update_row_cfg: (K::Cfg, V::Cfg),

--- a/qmdb/rs/src/ordered.rs
+++ b/qmdb/rs/src/ordered.rs
@@ -20,9 +20,7 @@ use commonware_storage::{
 };
 use commonware_utils::bitmap::Readable as BitmapReadable;
 use exoware_sdk::keys::Key;
-use exoware_sdk::{
-    Namespace, PrefixedStoreClient, RangeMode, SerializableReadSession, StoreClient,
-};
+use exoware_sdk::{PrefixedStoreClient, RangeMode, SerializableReadSession};
 
 use crate::codec::{
     bitmap_chunk_bits, chunk_index_for_location, clear_below_floor,
@@ -193,30 +191,8 @@ where
         }
     }
 
+    /// Read client over `client`'s namespace prefix.
     pub fn new(
-        url: &str,
-        op_cfg: <ordered::Operation<F, K, E> as commonware_codec::Read>::Cfg,
-        update_row_cfg: (K::Cfg, V::Cfg),
-    ) -> Self {
-        Self::from_client(StoreClient::new(url), op_cfg, update_row_cfg)
-    }
-
-    /// Read client over the canonical [`Namespace::Qmdb`] keyspace (matches the
-    /// writer default). Use [`Self::from_prefixed`] for a co-located QMDB log.
-    pub fn from_client(
-        client: StoreClient,
-        op_cfg: <ordered::Operation<F, K, E> as commonware_codec::Read>::Cfg,
-        update_row_cfg: (K::Cfg, V::Cfg),
-    ) -> Self {
-        Self::from_prefixed(
-            client.for_namespace(Namespace::Qmdb),
-            op_cfg,
-            update_row_cfg,
-        )
-    }
-
-    /// Read client over a caller-chosen namespace.
-    pub fn from_prefixed(
         client: PrefixedStoreClient,
         op_cfg: <ordered::Operation<F, K, E> as commonware_codec::Read>::Cfg,
         update_row_cfg: (K::Cfg, V::Cfg),

--- a/qmdb/rs/src/ordered.rs
+++ b/qmdb/rs/src/ordered.rs
@@ -208,7 +208,11 @@ where
         op_cfg: <ordered::Operation<F, K, E> as commonware_codec::Read>::Cfg,
         update_row_cfg: (K::Cfg, V::Cfg),
     ) -> Self {
-        Self::from_prefixed(client.for_namespace(Namespace::Qmdb), op_cfg, update_row_cfg)
+        Self::from_prefixed(
+            client.for_namespace(Namespace::Qmdb),
+            op_cfg,
+            update_row_cfg,
+        )
     }
 
     /// Read client over a caller-chosen namespace.

--- a/qmdb/rs/src/subscription.rs
+++ b/qmdb/rs/src/subscription.rs
@@ -4,7 +4,7 @@ use commonware_storage::merkle::{Family, Location};
 use exoware_sdk::keys::Key;
 use exoware_sdk::selector::Selector;
 use exoware_sdk::stream_filter::StreamFilter;
-use exoware_sdk::{StoreClient, StreamSubscription};
+use exoware_sdk::{PrefixedStoreClient, StreamSubscription};
 
 use crate::auth::{
     decode_auth_operation_location, decode_auth_presence_location, decode_auth_watermark_location,
@@ -43,7 +43,7 @@ impl<F: Family> RowClassifier<F> {
 }
 
 pub(crate) async fn open_store_subscription(
-    client: &StoreClient,
+    client: &PrefixedStoreClient,
     filter: StreamFilter,
     since: Option<u64>,
 ) -> Result<StreamSubscription, QmdbError> {

--- a/qmdb/rs/src/unordered.rs
+++ b/qmdb/rs/src/unordered.rs
@@ -14,9 +14,7 @@ use commonware_storage::qmdb::{
 };
 use commonware_utils::bitmap::Readable as BitmapReadable;
 use exoware_sdk::keys::Key;
-use exoware_sdk::{
-    Namespace, PrefixedStoreClient, RangeMode, SerializableReadSession, StoreClient,
-};
+use exoware_sdk::{PrefixedStoreClient, RangeMode, SerializableReadSession};
 
 use crate::codec::{
     bitmap_chunk_bits, chunk_index_for_location, clear_below_floor,
@@ -164,24 +162,8 @@ where
         }
     }
 
+    /// Read client over `client`'s namespace prefix.
     pub fn new(
-        url: &str,
-        op_cfg: <unordered::Operation<F, K, E> as commonware_codec::Read>::Cfg,
-    ) -> Self {
-        Self::from_client(StoreClient::new(url), op_cfg)
-    }
-
-    /// Read client over the canonical [`Namespace::Qmdb`] keyspace (matches the
-    /// writer default). Use [`Self::from_prefixed`] for a co-located QMDB log.
-    pub fn from_client(
-        client: StoreClient,
-        op_cfg: <unordered::Operation<F, K, E> as commonware_codec::Read>::Cfg,
-    ) -> Self {
-        Self::from_prefixed(client.for_namespace(Namespace::Qmdb), op_cfg)
-    }
-
-    /// Read client over a caller-chosen namespace.
-    pub fn from_prefixed(
         client: PrefixedStoreClient,
         op_cfg: <unordered::Operation<F, K, E> as commonware_codec::Read>::Cfg,
     ) -> Self {

--- a/qmdb/rs/src/unordered.rs
+++ b/qmdb/rs/src/unordered.rs
@@ -91,7 +91,7 @@ pub struct UnorderedClient<
 > where
     unordered::Operation<F, K, E>: commonware_codec::Read,
 {
-    client: StoreClient,
+    client: PrefixedStoreClient,
     op_cfg: <unordered::Operation<F, K, E> as commonware_codec::Read>::Cfg,
     _marker: PhantomData<(F, H, K, E)>,
 }
@@ -185,14 +185,6 @@ where
         client: PrefixedStoreClient,
         op_cfg: <unordered::Operation<F, K, E> as commonware_codec::Read>::Cfg,
     ) -> Self {
-        Self::from_unprefixed(client.into_client(), op_cfg)
-    }
-
-    /// Read client over a raw, un-namespaced client.
-    pub fn from_unprefixed(
-        client: StoreClient,
-        op_cfg: <unordered::Operation<F, K, E> as commonware_codec::Read>::Cfg,
-    ) -> Self {
         Self {
             client,
             op_cfg,
@@ -200,7 +192,7 @@ where
         }
     }
 
-    pub(crate) fn store_client(&self) -> &StoreClient {
+    pub(crate) fn store_client(&self) -> &PrefixedStoreClient {
         &self.client
     }
 

--- a/qmdb/rs/src/unordered.rs
+++ b/qmdb/rs/src/unordered.rs
@@ -14,7 +14,9 @@ use commonware_storage::qmdb::{
 };
 use commonware_utils::bitmap::Readable as BitmapReadable;
 use exoware_sdk::keys::Key;
-use exoware_sdk::{RangeMode, SerializableReadSession, StoreClient};
+use exoware_sdk::{
+    Namespace, PrefixedStoreClient, RangeMode, SerializableReadSession, StoreClient,
+};
 
 use crate::codec::{
     bitmap_chunk_bits, chunk_index_for_location, clear_below_floor,
@@ -169,7 +171,25 @@ where
         Self::from_client(StoreClient::new(url), op_cfg)
     }
 
+    /// Read client over the canonical [`Namespace::Qmdb`] keyspace (matches the
+    /// writer default). Use [`Self::from_prefixed`] for a co-located QMDB log.
     pub fn from_client(
+        client: StoreClient,
+        op_cfg: <unordered::Operation<F, K, E> as commonware_codec::Read>::Cfg,
+    ) -> Self {
+        Self::from_prefixed(client.for_namespace(Namespace::Qmdb), op_cfg)
+    }
+
+    /// Read client over a caller-chosen namespace.
+    pub fn from_prefixed(
+        client: PrefixedStoreClient,
+        op_cfg: <unordered::Operation<F, K, E> as commonware_codec::Read>::Cfg,
+    ) -> Self {
+        Self::from_unprefixed(client.into_client(), op_cfg)
+    }
+
+    /// Read client over a raw, un-namespaced client.
+    pub fn from_unprefixed(
         client: StoreClient,
         op_cfg: <unordered::Operation<F, K, E> as commonware_codec::Read>::Cfg,
     ) -> Self {

--- a/qmdb/rs/src/writer/immutable.rs
+++ b/qmdb/rs/src/writer/immutable.rs
@@ -13,8 +13,8 @@ use commonware_storage::qmdb::{
 use commonware_utils::Array;
 use exoware_sdk::keys::Key;
 use exoware_sdk::{
-    Namespace, PrefixedStoreClient, StoreBatchPublication, StoreBatchUpload, StoreClient,
-    StorePublicationFrontierWriter, StoreWriteBatch,
+    PrefixedStoreClient, StoreBatchPublication, StoreBatchUpload, StorePublicationFrontierWriter,
+    StoreWriteBatch,
 };
 use futures::future::BoxFuture;
 
@@ -137,17 +137,9 @@ where
     E: ValueEncoding<Value = V>,
     immutable::Operation<F, K, E>: Encode + Decode + Clone,
 {
-    /// Construct a writer over the canonical [`Namespace::Qmdb`] keyspace from
-    /// caller-supplied frontier state (no store I/O). For more than one QMDB
-    /// log in one Store, use [`Self::from_prefixed`] with distinct
-    /// [`Namespace::sub`] instances.
-    pub fn new(client: StoreClient, state: WriterState<H::Digest, F>) -> Self {
-        Self::from_prefixed(client.for_namespace(Namespace::Qmdb), state)
-    }
-
-    /// Construct a writer over a caller-chosen namespace (e.g. one
-    /// [`Namespace::sub`] per co-located QMDB log).
-    pub fn from_prefixed(client: PrefixedStoreClient, state: WriterState<H::Digest, F>) -> Self {
+    /// Construct a writer over `client`'s namespace prefix from caller-supplied
+    /// frontier state (no store I/O).
+    pub fn new(client: PrefixedStoreClient, state: WriterState<H::Digest, F>) -> Self {
         Self {
             client,
             core: WriterCore::from_cache(Cache::from_writer_state(state)),
@@ -155,9 +147,9 @@ where
         }
     }
 
-    /// Construct a fresh writer over the canonical [`Namespace::Qmdb`] keyspace
-    /// with empty frontier state (no prior published checkpoint).
-    pub fn fresh(client: StoreClient) -> Self {
+    /// Construct a fresh writer over `client`'s namespace prefix with empty
+    /// frontier state (no prior published checkpoint).
+    pub fn fresh(client: PrefixedStoreClient) -> Self {
         Self::new(client, WriterState::empty())
     }
 

--- a/qmdb/rs/src/writer/immutable.rs
+++ b/qmdb/rs/src/writer/immutable.rs
@@ -279,10 +279,7 @@ where
         let Some(prepared) = self.prepare_flush().await? else {
             return Ok(None);
         };
-        Ok(Some(
-            self.commit_publication(self.client.client(), prepared)
-                .await?,
-        ))
+        Ok(Some(self.commit_publication(prepared).await?))
     }
 
     pub async fn flush(&self) -> Result<(), QmdbError> {
@@ -317,6 +314,10 @@ where
     type Prepared = super::PreparedUpload<F>;
     type Receipt = UploadReceipt<F>;
     type Error = QmdbError;
+
+    fn store_client(&self) -> &PrefixedStoreClient {
+        &self.client
+    }
 
     fn stage_upload(
         &self,
@@ -373,6 +374,10 @@ where
     type PreparedPublication = super::PreparedWatermark<F>;
     type PublicationReceipt = PublishedCheckpoint<F>;
     type Error = QmdbError;
+
+    fn store_client(&self) -> &PrefixedStoreClient {
+        &self.client
+    }
 
     fn stage_publication(
         &self,

--- a/qmdb/rs/src/writer/immutable.rs
+++ b/qmdb/rs/src/writer/immutable.rs
@@ -13,8 +13,8 @@ use commonware_storage::qmdb::{
 use commonware_utils::Array;
 use exoware_sdk::keys::Key;
 use exoware_sdk::{
-    StoreBatchPublication, StoreBatchUpload, StoreClient, StorePublicationFrontierWriter,
-    StoreWriteBatch,
+    Namespace, PrefixedStoreClient, StoreBatchPublication, StoreBatchUpload, StoreClient,
+    StorePublicationFrontierWriter, StoreWriteBatch,
 };
 use futures::future::BoxFuture;
 
@@ -137,8 +137,23 @@ where
     E: ValueEncoding<Value = V>,
     immutable::Operation<F, K, E>: Encode + Decode + Clone,
 {
-    /// Construct a writer from caller-supplied frontier state. No store I/O.
+    /// Construct a writer over the canonical [`Namespace::Qmdb`] keyspace from
+    /// caller-supplied frontier state (no store I/O). For more than one QMDB
+    /// log in one Store, use [`Self::prefixed`] with distinct
+    /// [`Namespace::sub`] instances.
     pub fn new(client: StoreClient, state: WriterState<H::Digest, F>) -> Self {
+        Self::prefixed(client.for_namespace(Namespace::Qmdb), state)
+    }
+
+    /// Construct a writer over a caller-chosen namespace (e.g. one
+    /// [`Namespace::sub`] per co-located QMDB log).
+    pub fn prefixed(client: PrefixedStoreClient, state: WriterState<H::Digest, F>) -> Self {
+        Self::unprefixed(client.into_client(), state)
+    }
+
+    /// Construct a writer directly over a raw, un-namespaced client. Escape
+    /// hatch for a Store this writer owns exclusively.
+    pub fn unprefixed(client: StoreClient, state: WriterState<H::Digest, F>) -> Self {
         Self {
             client,
             core: WriterCore::from_cache(Cache::from_writer_state(state)),

--- a/qmdb/rs/src/writer/immutable.rs
+++ b/qmdb/rs/src/writer/immutable.rs
@@ -203,7 +203,7 @@ where
         prepared: &mut super::PreparedUpload<F>,
         batch: &mut StoreWriteBatch,
     ) -> Result<(), QmdbError> {
-        super::stage_rows(&self.client, batch, prepared.rows.drain(..))
+        super::stage_rows(self.client.key_prefix(), batch, prepared.rows.drain(..))
     }
 
     pub async fn mark_upload_persisted(
@@ -265,7 +265,7 @@ where
         prepared: &super::PreparedWatermark<F>,
         batch: &mut StoreWriteBatch,
     ) -> Result<(), QmdbError> {
-        super::stage_watermark(&self.client, batch, prepared)
+        super::stage_watermark(self.client.key_prefix(), batch, prepared)
     }
 
     pub async fn mark_flush_persisted(
@@ -287,7 +287,10 @@ where
         let Some(prepared) = self.prepare_flush().await? else {
             return Ok(None);
         };
-        Ok(Some(self.commit_publication(&self.client, prepared).await?))
+        Ok(Some(
+            self.commit_publication(self.client.client(), prepared)
+                .await?,
+        ))
     }
 
     pub async fn flush(&self) -> Result<(), QmdbError> {

--- a/qmdb/rs/src/writer/immutable.rs
+++ b/qmdb/rs/src/writer/immutable.rs
@@ -121,7 +121,7 @@ pub struct ImmutableWriter<
     V: Codec + Clone + Send + Sync,
     E: ValueEncoding<Value = V> = VariableEncoding<V>,
 > {
-    client: StoreClient,
+    client: PrefixedStoreClient,
     core: WriterCore<H::Digest, F>,
     _marker: PhantomData<(F, K, E)>,
 }
@@ -139,21 +139,15 @@ where
 {
     /// Construct a writer over the canonical [`Namespace::Qmdb`] keyspace from
     /// caller-supplied frontier state (no store I/O). For more than one QMDB
-    /// log in one Store, use [`Self::prefixed`] with distinct
+    /// log in one Store, use [`Self::from_prefixed`] with distinct
     /// [`Namespace::sub`] instances.
     pub fn new(client: StoreClient, state: WriterState<H::Digest, F>) -> Self {
-        Self::prefixed(client.for_namespace(Namespace::Qmdb), state)
+        Self::from_prefixed(client.for_namespace(Namespace::Qmdb), state)
     }
 
     /// Construct a writer over a caller-chosen namespace (e.g. one
     /// [`Namespace::sub`] per co-located QMDB log).
-    pub fn prefixed(client: PrefixedStoreClient, state: WriterState<H::Digest, F>) -> Self {
-        Self::unprefixed(client.into_client(), state)
-    }
-
-    /// Construct a writer directly over a raw, un-namespaced client. Escape
-    /// hatch for a Store this writer owns exclusively.
-    pub fn unprefixed(client: StoreClient, state: WriterState<H::Digest, F>) -> Self {
+    pub fn from_prefixed(client: PrefixedStoreClient, state: WriterState<H::Digest, F>) -> Self {
         Self {
             client,
             core: WriterCore::from_cache(Cache::from_writer_state(state)),
@@ -161,7 +155,9 @@ where
         }
     }
 
-    pub fn empty(client: StoreClient) -> Self {
+    /// Construct a fresh writer over the canonical [`Namespace::Qmdb`] keyspace
+    /// with empty frontier state (no prior published checkpoint).
+    pub fn fresh(client: StoreClient) -> Self {
         Self::new(client, WriterState::empty())
     }
 

--- a/qmdb/rs/src/writer/keyless.rs
+++ b/qmdb/rs/src/writer/keyless.rs
@@ -313,10 +313,7 @@ where
         let Some(prepared) = self.prepare_flush().await? else {
             return Ok(None);
         };
-        Ok(Some(
-            self.commit_publication(self.client.client(), prepared)
-                .await?,
-        ))
+        Ok(Some(self.commit_publication(prepared).await?))
     }
 
     pub async fn flush(&self) -> Result<(), QmdbError> {
@@ -347,6 +344,10 @@ where
     type Prepared = super::PreparedUpload<F>;
     type Receipt = UploadReceipt<F>;
     type Error = QmdbError;
+
+    fn store_client(&self) -> &PrefixedStoreClient {
+        &self.client
+    }
 
     fn stage_upload(
         &self,
@@ -400,6 +401,10 @@ where
     type PreparedPublication = super::PreparedWatermark<F>;
     type PublicationReceipt = PublishedCheckpoint<F>;
     type Error = QmdbError;
+
+    fn store_client(&self) -> &PrefixedStoreClient {
+        &self.client
+    }
 
     fn stage_publication(
         &self,

--- a/qmdb/rs/src/writer/keyless.rs
+++ b/qmdb/rs/src/writer/keyless.rs
@@ -237,7 +237,7 @@ where
         prepared: &mut super::PreparedUpload<F>,
         batch: &mut StoreWriteBatch,
     ) -> Result<(), QmdbError> {
-        super::stage_rows(&self.client, batch, prepared.rows.drain(..))
+        super::stage_rows(self.client.key_prefix(), batch, prepared.rows.drain(..))
     }
 
     pub async fn mark_upload_persisted(
@@ -299,7 +299,7 @@ where
         prepared: &super::PreparedWatermark<F>,
         batch: &mut StoreWriteBatch,
     ) -> Result<(), QmdbError> {
-        super::stage_watermark(&self.client, batch, prepared)
+        super::stage_watermark(self.client.key_prefix(), batch, prepared)
     }
 
     pub async fn mark_flush_persisted(
@@ -321,7 +321,10 @@ where
         let Some(prepared) = self.prepare_flush().await? else {
             return Ok(None);
         };
-        Ok(Some(self.commit_publication(&self.client, prepared).await?))
+        Ok(Some(
+            self.commit_publication(self.client.client(), prepared)
+                .await?,
+        ))
     }
 
     pub async fn flush(&self) -> Result<(), QmdbError> {

--- a/qmdb/rs/src/writer/keyless.rs
+++ b/qmdb/rs/src/writer/keyless.rs
@@ -11,8 +11,8 @@ use commonware_storage::qmdb::{
 };
 use exoware_sdk::keys::Key;
 use exoware_sdk::{
-    Namespace, PrefixedStoreClient, StoreBatchPublication, StoreBatchUpload, StoreClient,
-    StorePublicationFrontierWriter, StoreWriteBatch,
+    PrefixedStoreClient, StoreBatchPublication, StoreBatchUpload, StorePublicationFrontierWriter,
+    StoreWriteBatch,
 };
 use futures::future::BoxFuture;
 
@@ -171,17 +171,9 @@ where
     E: ValueEncoding<Value = V>,
     keyless::Operation<F, E>: Encode,
 {
-    /// Construct a writer over the canonical [`Namespace::Qmdb`] keyspace from
-    /// caller-supplied frontier state (no store I/O). For more than one QMDB
-    /// log in one Store, use [`Self::from_prefixed`] with distinct
-    /// [`Namespace::sub`] instances.
-    pub fn new(client: StoreClient, state: WriterState<H::Digest, F>) -> Self {
-        Self::from_prefixed(client.for_namespace(Namespace::Qmdb), state)
-    }
-
-    /// Construct a writer over a caller-chosen namespace (e.g. one
-    /// [`Namespace::sub`] per co-located QMDB log).
-    pub fn from_prefixed(client: PrefixedStoreClient, state: WriterState<H::Digest, F>) -> Self {
+    /// Construct a writer over `client`'s namespace prefix from caller-supplied
+    /// frontier state (no store I/O).
+    pub fn new(client: PrefixedStoreClient, state: WriterState<H::Digest, F>) -> Self {
         Self {
             client,
             core: WriterCore::from_cache(Cache::from_writer_state(state)),
@@ -189,9 +181,9 @@ where
         }
     }
 
-    /// Construct a fresh writer over the canonical [`Namespace::Qmdb`] keyspace
-    /// with empty frontier state (no prior published checkpoint).
-    pub fn fresh(client: StoreClient) -> Self {
+    /// Construct a fresh writer over `client`'s namespace prefix with empty
+    /// frontier state (no prior published checkpoint).
+    pub fn fresh(client: PrefixedStoreClient) -> Self {
         Self::new(client, WriterState::empty())
     }
 

--- a/qmdb/rs/src/writer/keyless.rs
+++ b/qmdb/rs/src/writer/keyless.rs
@@ -11,8 +11,8 @@ use commonware_storage::qmdb::{
 };
 use exoware_sdk::keys::Key;
 use exoware_sdk::{
-    StoreBatchPublication, StoreBatchUpload, StoreClient, StorePublicationFrontierWriter,
-    StoreWriteBatch,
+    Namespace, PrefixedStoreClient, StoreBatchPublication, StoreBatchUpload, StoreClient,
+    StorePublicationFrontierWriter, StoreWriteBatch,
 };
 use futures::future::BoxFuture;
 
@@ -171,8 +171,23 @@ where
     E: ValueEncoding<Value = V>,
     keyless::Operation<F, E>: Encode,
 {
-    /// Construct a writer from caller-supplied frontier state. No store I/O.
+    /// Construct a writer over the canonical [`Namespace::Qmdb`] keyspace from
+    /// caller-supplied frontier state (no store I/O). For more than one QMDB
+    /// log in one Store, use [`Self::prefixed`] with distinct
+    /// [`Namespace::sub`] instances.
     pub fn new(client: StoreClient, state: WriterState<H::Digest, F>) -> Self {
+        Self::prefixed(client.for_namespace(Namespace::Qmdb), state)
+    }
+
+    /// Construct a writer over a caller-chosen namespace (e.g. one
+    /// [`Namespace::sub`] per co-located QMDB log).
+    pub fn prefixed(client: PrefixedStoreClient, state: WriterState<H::Digest, F>) -> Self {
+        Self::unprefixed(client.into_client(), state)
+    }
+
+    /// Construct a writer directly over a raw, un-namespaced client. Escape
+    /// hatch for a Store this writer owns exclusively.
+    pub fn unprefixed(client: StoreClient, state: WriterState<H::Digest, F>) -> Self {
         Self {
             client,
             core: WriterCore::from_cache(Cache::from_writer_state(state)),

--- a/qmdb/rs/src/writer/keyless.rs
+++ b/qmdb/rs/src/writer/keyless.rs
@@ -158,7 +158,7 @@ pub struct KeylessWriter<
     V: Codec + Clone + Send + Sync,
     E: ValueEncoding<Value = V> = VariableEncoding<V>,
 > {
-    client: StoreClient,
+    client: PrefixedStoreClient,
     core: WriterCore<H::Digest, F>,
     _marker: PhantomData<(F, E)>,
 }
@@ -173,21 +173,15 @@ where
 {
     /// Construct a writer over the canonical [`Namespace::Qmdb`] keyspace from
     /// caller-supplied frontier state (no store I/O). For more than one QMDB
-    /// log in one Store, use [`Self::prefixed`] with distinct
+    /// log in one Store, use [`Self::from_prefixed`] with distinct
     /// [`Namespace::sub`] instances.
     pub fn new(client: StoreClient, state: WriterState<H::Digest, F>) -> Self {
-        Self::prefixed(client.for_namespace(Namespace::Qmdb), state)
+        Self::from_prefixed(client.for_namespace(Namespace::Qmdb), state)
     }
 
     /// Construct a writer over a caller-chosen namespace (e.g. one
     /// [`Namespace::sub`] per co-located QMDB log).
-    pub fn prefixed(client: PrefixedStoreClient, state: WriterState<H::Digest, F>) -> Self {
-        Self::unprefixed(client.into_client(), state)
-    }
-
-    /// Construct a writer directly over a raw, un-namespaced client. Escape
-    /// hatch for a Store this writer owns exclusively.
-    pub fn unprefixed(client: StoreClient, state: WriterState<H::Digest, F>) -> Self {
+    pub fn from_prefixed(client: PrefixedStoreClient, state: WriterState<H::Digest, F>) -> Self {
         Self {
             client,
             core: WriterCore::from_cache(Cache::from_writer_state(state)),
@@ -195,7 +189,9 @@ where
         }
     }
 
-    pub fn empty(client: StoreClient) -> Self {
+    /// Construct a fresh writer over the canonical [`Namespace::Qmdb`] keyspace
+    /// with empty frontier state (no prior published checkpoint).
+    pub fn fresh(client: StoreClient) -> Self {
         Self::new(client, WriterState::empty())
     }
 

--- a/qmdb/rs/src/writer/mod.rs
+++ b/qmdb/rs/src/writer/mod.rs
@@ -33,7 +33,7 @@ pub use unordered::{build_unordered_upload, BuiltUnorderedUpload, UnorderedWrite
 use std::borrow::Borrow;
 
 use commonware_storage::merkle::{Family, Location};
-use exoware_sdk::{keys::Key, IntoStoreWriteValue, PrefixedStoreClient, StoreWriteBatch};
+use exoware_sdk::{keys::Key, IntoStoreWriteValue, StoreKeyPrefix, StoreWriteBatch};
 
 use crate::{PublishedCheckpoint, QmdbError, UploadReceipt};
 
@@ -86,7 +86,7 @@ impl<F: Family> PreparedWatermark<F> {
 }
 
 pub(crate) fn stage_rows<I, K, V>(
-    client: &PrefixedStoreClient,
+    prefix: StoreKeyPrefix,
     batch: &mut StoreWriteBatch,
     rows: I,
 ) -> Result<(), QmdbError>
@@ -99,18 +99,18 @@ where
     let rows = rows.into_iter();
     batch.reserve(rows.len());
     for (key, value) in rows {
-        batch.push(client, key.borrow(), value)?;
+        batch.push(prefix, key.borrow(), value)?;
     }
     Ok(())
 }
 
 pub(crate) fn stage_watermark(
-    client: &PrefixedStoreClient,
+    prefix: StoreKeyPrefix,
     batch: &mut StoreWriteBatch,
     watermark: &PreparedWatermark<impl Family>,
 ) -> Result<(), QmdbError> {
     let (key, value) = &watermark.row;
-    batch.push(client, key, value)?;
+    batch.push(prefix, key, value)?;
     Ok(())
 }
 

--- a/qmdb/rs/src/writer/mod.rs
+++ b/qmdb/rs/src/writer/mod.rs
@@ -33,7 +33,7 @@ pub use unordered::{build_unordered_upload, BuiltUnorderedUpload, UnorderedWrite
 use std::borrow::Borrow;
 
 use commonware_storage::merkle::{Family, Location};
-use exoware_sdk::{keys::Key, IntoStoreWriteValue, StoreClient, StoreWriteBatch};
+use exoware_sdk::{keys::Key, IntoStoreWriteValue, PrefixedStoreClient, StoreWriteBatch};
 
 use crate::{PublishedCheckpoint, QmdbError, UploadReceipt};
 
@@ -86,7 +86,7 @@ impl<F: Family> PreparedWatermark<F> {
 }
 
 pub(crate) fn stage_rows<I, K, V>(
-    client: &StoreClient,
+    client: &PrefixedStoreClient,
     batch: &mut StoreWriteBatch,
     rows: I,
 ) -> Result<(), QmdbError>
@@ -105,7 +105,7 @@ where
 }
 
 pub(crate) fn stage_watermark(
-    client: &StoreClient,
+    client: &PrefixedStoreClient,
     batch: &mut StoreWriteBatch,
     watermark: &PreparedWatermark<impl Family>,
 ) -> Result<(), QmdbError> {

--- a/qmdb/rs/src/writer/ordered.rs
+++ b/qmdb/rs/src/writer/ordered.rs
@@ -42,8 +42,8 @@ use commonware_storage::qmdb::{
 };
 use exoware_sdk::keys::Key;
 use exoware_sdk::{
-    StoreBatchPublication, StoreBatchUpload, StoreClient, StorePublicationFrontierWriter,
-    StoreWriteBatch,
+    Namespace, PrefixedStoreClient, StoreBatchPublication, StoreBatchUpload, StoreClient,
+    StorePublicationFrontierWriter, StoreWriteBatch,
 };
 use futures::future::BoxFuture;
 
@@ -176,8 +176,23 @@ where
     E: ValueEncoding<Value = V>,
     ordered::Operation<F, K, E>: Encode + Decode,
 {
-    /// Construct a writer from caller-supplied frontier state. No store I/O.
+    /// Construct a writer over the canonical [`Namespace::Qmdb`] keyspace from
+    /// caller-supplied frontier state (no store I/O). For more than one QMDB
+    /// log in one Store, use [`Self::prefixed`] with distinct
+    /// [`Namespace::sub`] instances.
     pub fn new(client: StoreClient, state: WriterState<H::Digest, F>) -> Self {
+        Self::prefixed(client.for_namespace(Namespace::Qmdb), state)
+    }
+
+    /// Construct a writer over a caller-chosen namespace (e.g. one
+    /// [`Namespace::sub`] per co-located QMDB log).
+    pub fn prefixed(client: PrefixedStoreClient, state: WriterState<H::Digest, F>) -> Self {
+        Self::unprefixed(client.into_client(), state)
+    }
+
+    /// Construct a writer directly over a raw, un-namespaced client. Escape
+    /// hatch for a Store this writer owns exclusively.
+    pub fn unprefixed(client: StoreClient, state: WriterState<H::Digest, F>) -> Self {
         Self {
             client,
             core: WriterCore::from_cache(Cache::from_writer_state(state)),

--- a/qmdb/rs/src/writer/ordered.rs
+++ b/qmdb/rs/src/writer/ordered.rs
@@ -255,7 +255,7 @@ where
         prepared: &mut super::PreparedUpload<F>,
         batch: &mut StoreWriteBatch,
     ) -> Result<(), QmdbError> {
-        super::stage_rows(&self.client, batch, prepared.rows.drain(..))
+        super::stage_rows(self.client.key_prefix(), batch, prepared.rows.drain(..))
     }
 
     pub async fn mark_upload_persisted(
@@ -317,7 +317,7 @@ where
         prepared: &super::PreparedWatermark<F>,
         batch: &mut StoreWriteBatch,
     ) -> Result<(), QmdbError> {
-        super::stage_watermark(&self.client, batch, prepared)
+        super::stage_watermark(self.client.key_prefix(), batch, prepared)
     }
 
     pub async fn mark_flush_persisted(
@@ -339,7 +339,10 @@ where
         let Some(prepared) = self.prepare_flush().await? else {
             return Ok(None);
         };
-        Ok(Some(self.commit_publication(&self.client, prepared).await?))
+        Ok(Some(
+            self.commit_publication(self.client.client(), prepared)
+                .await?,
+        ))
     }
 
     pub async fn flush(&self) -> Result<(), QmdbError> {

--- a/qmdb/rs/src/writer/ordered.rs
+++ b/qmdb/rs/src/writer/ordered.rs
@@ -161,7 +161,7 @@ pub struct OrderedWriter<
     const N: usize,
     E: ValueEncoding<Value = V> = VariableEncoding<V>,
 > {
-    client: StoreClient,
+    client: PrefixedStoreClient,
     core: WriterCore<H::Digest, F>,
     _marker: PhantomData<(F, K, V, E)>,
 }
@@ -178,21 +178,15 @@ where
 {
     /// Construct a writer over the canonical [`Namespace::Qmdb`] keyspace from
     /// caller-supplied frontier state (no store I/O). For more than one QMDB
-    /// log in one Store, use [`Self::prefixed`] with distinct
+    /// log in one Store, use [`Self::from_prefixed`] with distinct
     /// [`Namespace::sub`] instances.
     pub fn new(client: StoreClient, state: WriterState<H::Digest, F>) -> Self {
-        Self::prefixed(client.for_namespace(Namespace::Qmdb), state)
+        Self::from_prefixed(client.for_namespace(Namespace::Qmdb), state)
     }
 
     /// Construct a writer over a caller-chosen namespace (e.g. one
     /// [`Namespace::sub`] per co-located QMDB log).
-    pub fn prefixed(client: PrefixedStoreClient, state: WriterState<H::Digest, F>) -> Self {
-        Self::unprefixed(client.into_client(), state)
-    }
-
-    /// Construct a writer directly over a raw, un-namespaced client. Escape
-    /// hatch for a Store this writer owns exclusively.
-    pub fn unprefixed(client: StoreClient, state: WriterState<H::Digest, F>) -> Self {
+    pub fn from_prefixed(client: PrefixedStoreClient, state: WriterState<H::Digest, F>) -> Self {
         Self {
             client,
             core: WriterCore::from_cache(Cache::from_writer_state(state)),
@@ -200,7 +194,9 @@ where
         }
     }
 
-    pub fn empty(client: StoreClient) -> Self {
+    /// Construct a fresh writer over the canonical [`Namespace::Qmdb`] keyspace
+    /// with empty frontier state (no prior published checkpoint).
+    pub fn fresh(client: StoreClient) -> Self {
         Self::new(client, WriterState::empty())
     }
 

--- a/qmdb/rs/src/writer/ordered.rs
+++ b/qmdb/rs/src/writer/ordered.rs
@@ -42,8 +42,8 @@ use commonware_storage::qmdb::{
 };
 use exoware_sdk::keys::Key;
 use exoware_sdk::{
-    Namespace, PrefixedStoreClient, StoreBatchPublication, StoreBatchUpload, StoreClient,
-    StorePublicationFrontierWriter, StoreWriteBatch,
+    PrefixedStoreClient, StoreBatchPublication, StoreBatchUpload, StorePublicationFrontierWriter,
+    StoreWriteBatch,
 };
 use futures::future::BoxFuture;
 
@@ -176,17 +176,9 @@ where
     E: ValueEncoding<Value = V>,
     ordered::Operation<F, K, E>: Encode + Decode,
 {
-    /// Construct a writer over the canonical [`Namespace::Qmdb`] keyspace from
-    /// caller-supplied frontier state (no store I/O). For more than one QMDB
-    /// log in one Store, use [`Self::from_prefixed`] with distinct
-    /// [`Namespace::sub`] instances.
-    pub fn new(client: StoreClient, state: WriterState<H::Digest, F>) -> Self {
-        Self::from_prefixed(client.for_namespace(Namespace::Qmdb), state)
-    }
-
-    /// Construct a writer over a caller-chosen namespace (e.g. one
-    /// [`Namespace::sub`] per co-located QMDB log).
-    pub fn from_prefixed(client: PrefixedStoreClient, state: WriterState<H::Digest, F>) -> Self {
+    /// Construct a writer over `client`'s namespace prefix from caller-supplied
+    /// frontier state (no store I/O).
+    pub fn new(client: PrefixedStoreClient, state: WriterState<H::Digest, F>) -> Self {
         Self {
             client,
             core: WriterCore::from_cache(Cache::from_writer_state(state)),
@@ -194,9 +186,9 @@ where
         }
     }
 
-    /// Construct a fresh writer over the canonical [`Namespace::Qmdb`] keyspace
-    /// with empty frontier state (no prior published checkpoint).
-    pub fn fresh(client: StoreClient) -> Self {
+    /// Construct a fresh writer over `client`'s namespace prefix with empty
+    /// frontier state (no prior published checkpoint).
+    pub fn fresh(client: PrefixedStoreClient) -> Self {
         Self::new(client, WriterState::empty())
     }
 

--- a/qmdb/rs/src/writer/ordered.rs
+++ b/qmdb/rs/src/writer/ordered.rs
@@ -331,10 +331,7 @@ where
         let Some(prepared) = self.prepare_flush().await? else {
             return Ok(None);
         };
-        Ok(Some(
-            self.commit_publication(self.client.client(), prepared)
-                .await?,
-        ))
+        Ok(Some(self.commit_publication(prepared).await?))
     }
 
     pub async fn flush(&self) -> Result<(), QmdbError> {
@@ -368,6 +365,10 @@ where
     type Prepared = super::PreparedUpload<F>;
     type Receipt = UploadReceipt<F>;
     type Error = QmdbError;
+
+    fn store_client(&self) -> &PrefixedStoreClient {
+        &self.client
+    }
 
     fn stage_upload(
         &self,
@@ -423,6 +424,10 @@ where
     type PreparedPublication = super::PreparedWatermark<F>;
     type PublicationReceipt = PublishedCheckpoint<F>;
     type Error = QmdbError;
+
+    fn store_client(&self) -> &PrefixedStoreClient {
+        &self.client
+    }
 
     fn stage_publication(
         &self,

--- a/qmdb/rs/src/writer/unordered.rs
+++ b/qmdb/rs/src/writer/unordered.rs
@@ -155,7 +155,7 @@ pub struct UnorderedWriter<
     V: Codec + Clone + Send + Sync,
     E: ValueEncoding<Value = V> = VariableEncoding<V>,
 > {
-    client: StoreClient,
+    client: PrefixedStoreClient,
     core: WriterCore<H::Digest, F>,
     _marker: PhantomData<(F, K, V, E)>,
 }
@@ -172,21 +172,15 @@ where
 {
     /// Construct a writer over the canonical [`Namespace::Qmdb`] keyspace from
     /// caller-supplied frontier state (no store I/O). For more than one QMDB
-    /// log in one Store, use [`Self::prefixed`] with distinct
+    /// log in one Store, use [`Self::from_prefixed`] with distinct
     /// [`Namespace::sub`] instances.
     pub fn new(client: StoreClient, state: WriterState<H::Digest, F>) -> Self {
-        Self::prefixed(client.for_namespace(Namespace::Qmdb), state)
+        Self::from_prefixed(client.for_namespace(Namespace::Qmdb), state)
     }
 
     /// Construct a writer over a caller-chosen namespace (e.g. one
     /// [`Namespace::sub`] per co-located QMDB log).
-    pub fn prefixed(client: PrefixedStoreClient, state: WriterState<H::Digest, F>) -> Self {
-        Self::unprefixed(client.into_client(), state)
-    }
-
-    /// Construct a writer directly over a raw, un-namespaced client. Escape
-    /// hatch for a Store this writer owns exclusively.
-    pub fn unprefixed(client: StoreClient, state: WriterState<H::Digest, F>) -> Self {
+    pub fn from_prefixed(client: PrefixedStoreClient, state: WriterState<H::Digest, F>) -> Self {
         Self {
             client,
             core: WriterCore::from_cache(Cache::from_writer_state(state)),
@@ -194,7 +188,9 @@ where
         }
     }
 
-    pub fn empty(client: StoreClient) -> Self {
+    /// Construct a fresh writer over the canonical [`Namespace::Qmdb`] keyspace
+    /// with empty frontier state (no prior published checkpoint).
+    pub fn fresh(client: StoreClient) -> Self {
         Self::new(client, WriterState::empty())
     }
 

--- a/qmdb/rs/src/writer/unordered.rs
+++ b/qmdb/rs/src/writer/unordered.rs
@@ -15,8 +15,8 @@ use commonware_storage::qmdb::{
 };
 use exoware_sdk::keys::Key;
 use exoware_sdk::{
-    Namespace, PrefixedStoreClient, StoreBatchPublication, StoreBatchUpload, StoreClient,
-    StorePublicationFrontierWriter, StoreWriteBatch,
+    PrefixedStoreClient, StoreBatchPublication, StoreBatchUpload, StorePublicationFrontierWriter,
+    StoreWriteBatch,
 };
 use futures::future::BoxFuture;
 
@@ -170,17 +170,9 @@ where
     E: ValueEncoding<Value = V>,
     unordered::Operation<F, K, E>: Encode,
 {
-    /// Construct a writer over the canonical [`Namespace::Qmdb`] keyspace from
-    /// caller-supplied frontier state (no store I/O). For more than one QMDB
-    /// log in one Store, use [`Self::from_prefixed`] with distinct
-    /// [`Namespace::sub`] instances.
-    pub fn new(client: StoreClient, state: WriterState<H::Digest, F>) -> Self {
-        Self::from_prefixed(client.for_namespace(Namespace::Qmdb), state)
-    }
-
-    /// Construct a writer over a caller-chosen namespace (e.g. one
-    /// [`Namespace::sub`] per co-located QMDB log).
-    pub fn from_prefixed(client: PrefixedStoreClient, state: WriterState<H::Digest, F>) -> Self {
+    /// Construct a writer over `client`'s namespace prefix from caller-supplied
+    /// frontier state (no store I/O).
+    pub fn new(client: PrefixedStoreClient, state: WriterState<H::Digest, F>) -> Self {
         Self {
             client,
             core: WriterCore::from_cache(Cache::from_writer_state(state)),
@@ -188,9 +180,9 @@ where
         }
     }
 
-    /// Construct a fresh writer over the canonical [`Namespace::Qmdb`] keyspace
-    /// with empty frontier state (no prior published checkpoint).
-    pub fn fresh(client: StoreClient) -> Self {
+    /// Construct a fresh writer over `client`'s namespace prefix with empty
+    /// frontier state (no prior published checkpoint).
+    pub fn fresh(client: PrefixedStoreClient) -> Self {
         Self::new(client, WriterState::empty())
     }
 

--- a/qmdb/rs/src/writer/unordered.rs
+++ b/qmdb/rs/src/writer/unordered.rs
@@ -15,8 +15,8 @@ use commonware_storage::qmdb::{
 };
 use exoware_sdk::keys::Key;
 use exoware_sdk::{
-    StoreBatchPublication, StoreBatchUpload, StoreClient, StorePublicationFrontierWriter,
-    StoreWriteBatch,
+    Namespace, PrefixedStoreClient, StoreBatchPublication, StoreBatchUpload, StoreClient,
+    StorePublicationFrontierWriter, StoreWriteBatch,
 };
 use futures::future::BoxFuture;
 
@@ -170,8 +170,23 @@ where
     E: ValueEncoding<Value = V>,
     unordered::Operation<F, K, E>: Encode,
 {
-    /// Construct a writer from caller-supplied frontier state. No store I/O.
+    /// Construct a writer over the canonical [`Namespace::Qmdb`] keyspace from
+    /// caller-supplied frontier state (no store I/O). For more than one QMDB
+    /// log in one Store, use [`Self::prefixed`] with distinct
+    /// [`Namespace::sub`] instances.
     pub fn new(client: StoreClient, state: WriterState<H::Digest, F>) -> Self {
+        Self::prefixed(client.for_namespace(Namespace::Qmdb), state)
+    }
+
+    /// Construct a writer over a caller-chosen namespace (e.g. one
+    /// [`Namespace::sub`] per co-located QMDB log).
+    pub fn prefixed(client: PrefixedStoreClient, state: WriterState<H::Digest, F>) -> Self {
+        Self::unprefixed(client.into_client(), state)
+    }
+
+    /// Construct a writer directly over a raw, un-namespaced client. Escape
+    /// hatch for a Store this writer owns exclusively.
+    pub fn unprefixed(client: StoreClient, state: WriterState<H::Digest, F>) -> Self {
         Self {
             client,
             core: WriterCore::from_cache(Cache::from_writer_state(state)),

--- a/qmdb/rs/src/writer/unordered.rs
+++ b/qmdb/rs/src/writer/unordered.rs
@@ -267,7 +267,7 @@ where
         prepared: &mut super::PreparedUpload<F>,
         batch: &mut StoreWriteBatch,
     ) -> Result<(), QmdbError> {
-        super::stage_rows(&self.client, batch, prepared.rows.drain(..))
+        super::stage_rows(self.client.key_prefix(), batch, prepared.rows.drain(..))
     }
 
     pub async fn mark_upload_persisted(
@@ -329,7 +329,7 @@ where
         prepared: &super::PreparedWatermark<F>,
         batch: &mut StoreWriteBatch,
     ) -> Result<(), QmdbError> {
-        super::stage_watermark(&self.client, batch, prepared)
+        super::stage_watermark(self.client.key_prefix(), batch, prepared)
     }
 
     pub async fn mark_flush_persisted(
@@ -351,7 +351,10 @@ where
         let Some(prepared) = self.prepare_flush().await? else {
             return Ok(None);
         };
-        Ok(Some(self.commit_publication(&self.client, prepared).await?))
+        Ok(Some(
+            self.commit_publication(self.client.client(), prepared)
+                .await?,
+        ))
     }
 
     pub async fn flush(&self) -> Result<(), QmdbError> {

--- a/qmdb/rs/src/writer/unordered.rs
+++ b/qmdb/rs/src/writer/unordered.rs
@@ -343,10 +343,7 @@ where
         let Some(prepared) = self.prepare_flush().await? else {
             return Ok(None);
         };
-        Ok(Some(
-            self.commit_publication(self.client.client(), prepared)
-                .await?,
-        ))
+        Ok(Some(self.commit_publication(prepared).await?))
     }
 
     pub async fn flush(&self) -> Result<(), QmdbError> {
@@ -380,6 +377,10 @@ where
     type Prepared = super::PreparedUpload<F>;
     type Receipt = UploadReceipt<F>;
     type Error = QmdbError;
+
+    fn store_client(&self) -> &PrefixedStoreClient {
+        &self.client
+    }
 
     fn stage_upload(
         &self,
@@ -435,6 +436,10 @@ where
     type PreparedPublication = super::PreparedWatermark<F>;
     type PublicationReceipt = PublishedCheckpoint<F>;
     type Error = QmdbError;
+
+    fn store_client(&self) -> &PrefixedStoreClient {
+        &self.client
+    }
 
     fn stage_publication(
         &self,

--- a/qmdb/rs/tests/common/mod.rs
+++ b/qmdb/rs/tests/common/mod.rs
@@ -34,7 +34,7 @@ use exoware_qmdb::{
     UnorderedWriter, UploadReceipt,
 };
 use exoware_sdk::proto::PreferZstdHttpClient;
-use exoware_sdk::{StoreBatchUpload, StoreClient};
+use exoware_sdk::{PrefixedStoreClient, StoreBatchUpload, StoreClient};
 
 #[allow(dead_code)]
 pub fn merkle_config(prefix: &str, page_cache: CacheRef) -> MerkleConfig<Sequential> {
@@ -184,7 +184,9 @@ where
     keyless::Operation<F, E>: Encode,
 {
     let prepared = writer.prepare_upload(ops).await?;
-    writer.commit_upload(commit_client, prepared).await
+    writer
+        .commit_upload(&PrefixedStoreClient::empty(commit_client.clone()), prepared)
+        .await
 }
 
 #[allow(dead_code)]
@@ -203,7 +205,9 @@ where
     unordered::Operation<F, K, E>: Encode,
 {
     let prepared = writer.prepare_upload(ops).await?;
-    writer.commit_upload(commit_client, prepared).await
+    writer
+        .commit_upload(&PrefixedStoreClient::empty(commit_client.clone()), prepared)
+        .await
 }
 
 #[allow(dead_code)]
@@ -223,7 +227,9 @@ where
     unordered::Operation<F, K, E>: Encode,
 {
     let prepared = writer.prepare_current_upload(ops, current_boundary).await?;
-    writer.commit_upload(commit_client, prepared).await
+    writer
+        .commit_upload(&PrefixedStoreClient::empty(commit_client.clone()), prepared)
+        .await
 }
 
 #[allow(dead_code)]
@@ -243,7 +249,9 @@ where
     ordered::Operation<F, K, E>: Encode + Decode,
 {
     let prepared = writer.prepare_upload(ops, current_boundary).await?;
-    writer.commit_upload(commit_client, prepared).await
+    writer
+        .commit_upload(&PrefixedStoreClient::empty(commit_client.clone()), prepared)
+        .await
 }
 
 #[allow(dead_code)]
@@ -263,7 +271,9 @@ where
     immutable::Operation<F, K, E>: Encode + Decode + Clone,
 {
     let prepared = writer.prepare_upload(ops).await?;
-    writer.commit_upload(commit_client, prepared).await
+    writer
+        .commit_upload(&PrefixedStoreClient::empty(commit_client.clone()), prepared)
+        .await
 }
 
 #[allow(dead_code)]

--- a/qmdb/rs/tests/common/mod.rs
+++ b/qmdb/rs/tests/common/mod.rs
@@ -172,7 +172,6 @@ where
 
 #[allow(dead_code)]
 pub async fn commit_keyless_upload<F, H, V, E>(
-    commit_client: &StoreClient,
     writer: &KeylessWriter<F, H, V, E>,
     ops: &[keyless::Operation<F, E>],
 ) -> Result<UploadReceipt<F>, QmdbError>
@@ -184,12 +183,11 @@ where
     keyless::Operation<F, E>: Encode,
 {
     let prepared = writer.prepare_upload(ops).await?;
-    writer.commit_upload(commit_client, prepared).await
+    writer.commit_upload(prepared).await
 }
 
 #[allow(dead_code)]
 pub async fn commit_unordered_upload<F, H, K, V, E>(
-    commit_client: &StoreClient,
     writer: &UnorderedWriter<F, H, K, V, E>,
     ops: &[unordered::Operation<F, K, E>],
 ) -> Result<UploadReceipt<F>, QmdbError>
@@ -203,12 +201,11 @@ where
     unordered::Operation<F, K, E>: Encode,
 {
     let prepared = writer.prepare_upload(ops).await?;
-    writer.commit_upload(commit_client, prepared).await
+    writer.commit_upload(prepared).await
 }
 
 #[allow(dead_code)]
 pub async fn commit_unordered_current_upload<F, H, K, V, const N: usize, E>(
-    commit_client: &StoreClient,
     writer: &UnorderedWriter<F, H, K, V, E>,
     ops: &[unordered::Operation<F, K, E>],
     current_boundary: &CurrentBoundaryState<H::Digest, N, F>,
@@ -223,12 +220,11 @@ where
     unordered::Operation<F, K, E>: Encode,
 {
     let prepared = writer.prepare_current_upload(ops, current_boundary).await?;
-    writer.commit_upload(commit_client, prepared).await
+    writer.commit_upload(prepared).await
 }
 
 #[allow(dead_code)]
 pub async fn commit_ordered_upload<F, H, K, V, const N: usize, E>(
-    commit_client: &StoreClient,
     writer: &OrderedWriter<F, H, K, V, N, E>,
     ops: &[ordered::Operation<F, K, E>],
     current_boundary: &CurrentBoundaryState<H::Digest, N, F>,
@@ -243,12 +239,11 @@ where
     ordered::Operation<F, K, E>: Encode + Decode,
 {
     let prepared = writer.prepare_upload(ops, current_boundary).await?;
-    writer.commit_upload(commit_client, prepared).await
+    writer.commit_upload(prepared).await
 }
 
 #[allow(dead_code)]
 pub async fn commit_immutable_upload<F, H, K, V, E>(
-    commit_client: &StoreClient,
     writer: &ImmutableWriter<F, H, K, V, E>,
     ops: &[immutable::Operation<F, K, E>],
 ) -> Result<UploadReceipt<F>, QmdbError>
@@ -263,7 +258,7 @@ where
     immutable::Operation<F, K, E>: Encode + Decode + Clone,
 {
     let prepared = writer.prepare_upload(ops).await?;
-    writer.commit_upload(commit_client, prepared).await
+    writer.commit_upload(prepared).await
 }
 
 #[allow(dead_code)]

--- a/qmdb/rs/tests/common/mod.rs
+++ b/qmdb/rs/tests/common/mod.rs
@@ -34,7 +34,7 @@ use exoware_qmdb::{
     UnorderedWriter, UploadReceipt,
 };
 use exoware_sdk::proto::PreferZstdHttpClient;
-use exoware_sdk::{PrefixedStoreClient, StoreBatchUpload, StoreClient};
+use exoware_sdk::{StoreBatchUpload, StoreClient};
 
 #[allow(dead_code)]
 pub fn merkle_config(prefix: &str, page_cache: CacheRef) -> MerkleConfig<Sequential> {
@@ -184,9 +184,7 @@ where
     keyless::Operation<F, E>: Encode,
 {
     let prepared = writer.prepare_upload(ops).await?;
-    writer
-        .commit_upload(&PrefixedStoreClient::empty(commit_client.clone()), prepared)
-        .await
+    writer.commit_upload(commit_client, prepared).await
 }
 
 #[allow(dead_code)]
@@ -205,9 +203,7 @@ where
     unordered::Operation<F, K, E>: Encode,
 {
     let prepared = writer.prepare_upload(ops).await?;
-    writer
-        .commit_upload(&PrefixedStoreClient::empty(commit_client.clone()), prepared)
-        .await
+    writer.commit_upload(commit_client, prepared).await
 }
 
 #[allow(dead_code)]
@@ -227,9 +223,7 @@ where
     unordered::Operation<F, K, E>: Encode,
 {
     let prepared = writer.prepare_current_upload(ops, current_boundary).await?;
-    writer
-        .commit_upload(&PrefixedStoreClient::empty(commit_client.clone()), prepared)
-        .await
+    writer.commit_upload(commit_client, prepared).await
 }
 
 #[allow(dead_code)]
@@ -249,9 +243,7 @@ where
     ordered::Operation<F, K, E>: Encode + Decode,
 {
     let prepared = writer.prepare_upload(ops, current_boundary).await?;
-    writer
-        .commit_upload(&PrefixedStoreClient::empty(commit_client.clone()), prepared)
-        .await
+    writer.commit_upload(commit_client, prepared).await
 }
 
 #[allow(dead_code)]
@@ -271,9 +263,7 @@ where
     immutable::Operation<F, K, E>: Encode + Decode + Clone,
 {
     let prepared = writer.prepare_upload(ops).await?;
-    writer
-        .commit_upload(&PrefixedStoreClient::empty(commit_client.clone()), prepared)
-        .await
+    writer.commit_upload(commit_client, prepared).await
 }
 
 #[allow(dead_code)]

--- a/qmdb/rs/tests/e2e_immutable.rs
+++ b/qmdb/rs/tests/e2e_immutable.rs
@@ -204,7 +204,7 @@ async fn immutable_round_trip() {
     let local = build_local_db().await;
 
     let writer = fresh_writer(client.clone());
-    common::commit_immutable_upload(&client, &writer, &local.operations)
+    common::commit_immutable_upload(&writer, &local.operations)
         .await
         .expect("commit upload");
 
@@ -246,7 +246,7 @@ async fn immutable_fixed_round_trip() {
     let local = build_fixed_local_db().await;
 
     let writer = fresh_fixed_writer(client.clone());
-    common::commit_immutable_upload(&client, &writer, &local.operations)
+    common::commit_immutable_upload(&writer, &local.operations)
         .await
         .expect("commit fixed upload");
 

--- a/qmdb/rs/tests/e2e_immutable.rs
+++ b/qmdb/rs/tests/e2e_immutable.rs
@@ -71,11 +71,11 @@ type FixedTestImmutableWriter = ImmutableWriter<
 >;
 
 fn fresh_writer(c: StoreClient) -> TestImmutableWriter {
-    TestImmutableWriter::empty(c)
+    TestImmutableWriter::fresh(c)
 }
 
 fn fresh_fixed_writer(c: StoreClient) -> FixedTestImmutableWriter {
-    FixedTestImmutableWriter::empty(c)
+    FixedTestImmutableWriter::fresh(c)
 }
 
 struct LocalReference {

--- a/qmdb/rs/tests/e2e_immutable.rs
+++ b/qmdb/rs/tests/e2e_immutable.rs
@@ -18,7 +18,7 @@ use commonware_storage::qmdb::immutable::variable::{
 use commonware_storage::translator::TwoCap;
 use commonware_utils::{sequence::FixedBytes, NZUsize, NZU16, NZU64};
 use exoware_qmdb::{ImmutableClient, ImmutableWriter};
-use exoware_sdk::StoreClient;
+use exoware_sdk::{PrefixedStoreClient, StoreClient};
 
 use common::retry;
 
@@ -53,11 +53,14 @@ type FixedTestImmutableClient = ImmutableClient<
 >;
 
 fn fresh_immutable(c: StoreClient) -> TestImmutableClient {
-    TestImmutableClient::from_client(c, ((), ((0..=10000).into(), ())))
+    TestImmutableClient::new(
+        PrefixedStoreClient::empty(c),
+        ((), ((0..=10000).into(), ())),
+    )
 }
 
 fn fresh_fixed_immutable(c: StoreClient) -> FixedTestImmutableClient {
-    FixedTestImmutableClient::from_client(c, ())
+    FixedTestImmutableClient::new(PrefixedStoreClient::empty(c), ())
 }
 
 type TestImmutableWriter =
@@ -71,11 +74,11 @@ type FixedTestImmutableWriter = ImmutableWriter<
 >;
 
 fn fresh_writer(c: StoreClient) -> TestImmutableWriter {
-    TestImmutableWriter::fresh(c)
+    TestImmutableWriter::fresh(PrefixedStoreClient::empty(c))
 }
 
 fn fresh_fixed_writer(c: StoreClient) -> FixedTestImmutableWriter {
-    FixedTestImmutableWriter::fresh(c)
+    FixedTestImmutableWriter::fresh(PrefixedStoreClient::empty(c))
 }
 
 struct LocalReference {

--- a/qmdb/rs/tests/e2e_immutable_connect.rs
+++ b/qmdb/rs/tests/e2e_immutable_connect.rs
@@ -126,7 +126,7 @@ async fn commit_upload(client: &StoreClient, batch: &LocalBatch) {
         commonware_cryptography::Sha256,
         FixedBytes<32>,
         Vec<u8>,
-    > = ImmutableWriter::empty(client.clone());
+    > = ImmutableWriter::fresh(client.clone());
     common::commit_immutable_upload(client, &writer, &batch.operations)
         .await
         .expect("commit upload");

--- a/qmdb/rs/tests/e2e_immutable_connect.rs
+++ b/qmdb/rs/tests/e2e_immutable_connect.rs
@@ -23,7 +23,7 @@ use exoware_qmdb::{
     OperationLogSubscribeProof, QmdbError,
 };
 use exoware_sdk::proto::PreferZstdHttpClient;
-use exoware_sdk::StoreClient;
+use exoware_sdk::{PrefixedStoreClient, StoreClient};
 
 type Digest = commonware_cryptography::sha256::Digest;
 type LocalDb = Immutable<
@@ -126,7 +126,7 @@ async fn commit_upload(client: &StoreClient, batch: &LocalBatch) {
         commonware_cryptography::Sha256,
         FixedBytes<32>,
         Vec<u8>,
-    > = ImmutableWriter::fresh(client.clone());
+    > = ImmutableWriter::fresh(PrefixedStoreClient::empty(client.clone()));
     common::commit_immutable_upload(client, &writer, &batch.operations)
         .await
         .expect("commit upload");
@@ -140,8 +140,8 @@ async fn immutable_connect_subscribe_emits_verifiable_multi_proof() {
         *local.inactivity_floor > 0,
         "test must not rely on inactivity_floor = 0"
     );
-    let immutable_client = Arc::new(TestImmutableClient::from_client(
-        store_client.clone(),
+    let immutable_client = Arc::new(TestImmutableClient::new(
+        PrefixedStoreClient::empty(store_client.clone()),
         ((), ((0..=10000).into(), ())),
     ));
     let (_qmdb_server, qmdb_url) = spawn_qmdb_server(immutable_client).await;
@@ -186,8 +186,8 @@ async fn immutable_connect_get_operation_range_returns_verifiable_proof() {
     );
     commit_upload(&store_client, &local).await;
 
-    let immutable_client = Arc::new(TestImmutableClient::from_client(
-        store_client.clone(),
+    let immutable_client = Arc::new(TestImmutableClient::new(
+        PrefixedStoreClient::empty(store_client.clone()),
         ((), ((0..=10000).into(), ())),
     ));
     let (_qmdb_server, qmdb_url) = spawn_qmdb_server(immutable_client).await;
@@ -224,8 +224,8 @@ async fn immutable_connect_client_rejects_invalid_streamed_proof() {
     );
     commit_upload(&store_client, &local).await;
 
-    let immutable_client = Arc::new(TestImmutableClient::from_client(
-        store_client.clone(),
+    let immutable_client = Arc::new(TestImmutableClient::new(
+        PrefixedStoreClient::empty(store_client.clone()),
         ((), ((0..=10000).into(), ())),
     ));
     let (_qmdb_server, qmdb_url) = spawn_qmdb_server(immutable_client).await;

--- a/qmdb/rs/tests/e2e_immutable_connect.rs
+++ b/qmdb/rs/tests/e2e_immutable_connect.rs
@@ -127,7 +127,7 @@ async fn commit_upload(client: &StoreClient, batch: &LocalBatch) {
         FixedBytes<32>,
         Vec<u8>,
     > = ImmutableWriter::fresh(PrefixedStoreClient::empty(client.clone()));
-    common::commit_immutable_upload(client, &writer, &batch.operations)
+    common::commit_immutable_upload(&writer, &batch.operations)
         .await
         .expect("commit upload");
 }

--- a/qmdb/rs/tests/e2e_immutable_writer.rs
+++ b/qmdb/rs/tests/e2e_immutable_writer.rs
@@ -143,7 +143,7 @@ async fn sequential_upload_matches_local_root() {
     );
 
     let writer = fresh_writer(client.clone());
-    let receipt = common::commit_immutable_upload(&client, &writer, &local.operations)
+    let receipt = common::commit_immutable_upload(&writer, &local.operations)
         .await
         .expect("upload");
     assert_eq!(receipt.latest_location, local.latest_location);
@@ -190,13 +190,10 @@ async fn pipelined_batches_require_flush_to_catch_up_watermark() {
     let w1 = writer.clone();
     let w2 = writer.clone();
     let w3 = writer.clone();
-    let c1 = client.clone();
-    let c2 = client.clone();
-    let c3 = client.clone();
     let (r1, r2, r3) = tokio::join!(
-        async move { common::commit_immutable_upload(&c1, &w1, &o1).await },
-        async move { common::commit_immutable_upload(&c2, &w2, &o2).await },
-        async move { common::commit_immutable_upload(&c3, &w3, &o3).await }
+        async move { common::commit_immutable_upload(&w1, &o1).await },
+        async move { common::commit_immutable_upload(&w2, &o2).await },
+        async move { common::commit_immutable_upload(&w3, &o3).await }
     );
     let _ = r1.expect("b1");
     let _ = r2.expect("b2");

--- a/qmdb/rs/tests/e2e_immutable_writer.rs
+++ b/qmdb/rs/tests/e2e_immutable_writer.rs
@@ -39,7 +39,7 @@ fn fresh_reader(c: StoreClient) -> TestReader {
 }
 
 fn fresh_writer(c: StoreClient) -> TestWriter {
-    TestWriter::empty(c)
+    TestWriter::fresh(c)
 }
 
 struct LocalReference {

--- a/qmdb/rs/tests/e2e_immutable_writer.rs
+++ b/qmdb/rs/tests/e2e_immutable_writer.rs
@@ -15,7 +15,7 @@ use commonware_storage::qmdb::immutable::variable::{
 use commonware_storage::translator::TwoCap;
 use commonware_utils::{sequence::FixedBytes, NZUsize, NZU16, NZU64};
 use exoware_qmdb::{ImmutableClient, ImmutableWriter};
-use exoware_sdk::StoreClient;
+use exoware_sdk::{PrefixedStoreClient, StoreClient};
 
 use common::retry;
 
@@ -35,11 +35,14 @@ type TestReader = ImmutableClient<mmr::Family, commonware_cryptography::Sha256, 
 type TestWriter = ImmutableWriter<mmr::Family, commonware_cryptography::Sha256, K, V>;
 
 fn fresh_reader(c: StoreClient) -> TestReader {
-    TestReader::from_client(c, ((), ((0..=10000).into(), ())))
+    TestReader::new(
+        PrefixedStoreClient::empty(c),
+        ((), ((0..=10000).into(), ())),
+    )
 }
 
 fn fresh_writer(c: StoreClient) -> TestWriter {
-    TestWriter::fresh(c)
+    TestWriter::fresh(PrefixedStoreClient::empty(c))
 }
 
 struct LocalReference {

--- a/qmdb/rs/tests/e2e_keyless.rs
+++ b/qmdb/rs/tests/e2e_keyless.rs
@@ -47,7 +47,7 @@ fn fresh_keyless<F: Graftable>(c: StoreClient) -> TestKeylessClient<F> {
 }
 
 fn fresh_writer<F: Family>(c: StoreClient) -> TestKeylessWriter<F> {
-    TestKeylessWriter::empty(c)
+    TestKeylessWriter::fresh(c)
 }
 
 fn fresh_fixed_keyless<F: Graftable>(c: StoreClient) -> FixedTestKeylessClient<F>
@@ -58,7 +58,7 @@ where
 }
 
 fn fresh_fixed_writer<F: Family>(c: StoreClient) -> FixedTestKeylessWriter<F> {
-    FixedTestKeylessWriter::empty(c)
+    FixedTestKeylessWriter::fresh(c)
 }
 
 struct LocalReference<F: Family> {

--- a/qmdb/rs/tests/e2e_keyless.rs
+++ b/qmdb/rs/tests/e2e_keyless.rs
@@ -15,7 +15,7 @@ use commonware_storage::qmdb::keyless::fixed::{
 use commonware_storage::qmdb::keyless::variable::{Db as Keyless, Operation as KeylessOperation};
 use commonware_utils::{NZUsize, NZU16, NZU64};
 use exoware_qmdb::{KeylessClient, KeylessWriter};
-use exoware_sdk::StoreClient;
+use exoware_sdk::{PrefixedStoreClient, StoreClient};
 
 use common::retry;
 
@@ -43,22 +43,22 @@ type FixedTestKeylessWriter<F> =
     KeylessWriter<F, commonware_cryptography::Sha256, Digest, FixedEncoding<Digest>>;
 
 fn fresh_keyless<F: Graftable>(c: StoreClient) -> TestKeylessClient<F> {
-    TestKeylessClient::from_client(c, ((0..=10000).into(), ()))
+    TestKeylessClient::new(PrefixedStoreClient::empty(c), ((0..=10000).into(), ()))
 }
 
 fn fresh_writer<F: Family>(c: StoreClient) -> TestKeylessWriter<F> {
-    TestKeylessWriter::fresh(c)
+    TestKeylessWriter::fresh(PrefixedStoreClient::empty(c))
 }
 
 fn fresh_fixed_keyless<F: Graftable>(c: StoreClient) -> FixedTestKeylessClient<F>
 where
     FixedKeylessOperation<F, Digest>: commonware_codec::Read<Cfg = ()>,
 {
-    FixedTestKeylessClient::from_client(c, ())
+    FixedTestKeylessClient::new(PrefixedStoreClient::empty(c), ())
 }
 
 fn fresh_fixed_writer<F: Family>(c: StoreClient) -> FixedTestKeylessWriter<F> {
-    FixedTestKeylessWriter::fresh(c)
+    FixedTestKeylessWriter::fresh(PrefixedStoreClient::empty(c))
 }
 
 struct LocalReference<F: Family> {

--- a/qmdb/rs/tests/e2e_keyless.rs
+++ b/qmdb/rs/tests/e2e_keyless.rs
@@ -196,7 +196,7 @@ where
     let local = build_local_db::<F>().await;
 
     let writer = fresh_writer::<F>(client.clone());
-    common::commit_keyless_upload(&client, &writer, &local.operations)
+    common::commit_keyless_upload(&writer, &local.operations)
         .await
         .expect("commit upload");
 
@@ -267,7 +267,7 @@ async fn keyless_fixed_round_trip() {
     let local = build_fixed_local_db::<mmr::Family>().await;
 
     let writer = fresh_fixed_writer::<mmr::Family>(client.clone());
-    common::commit_keyless_upload(&client, &writer, &local.operations)
+    common::commit_keyless_upload(&writer, &local.operations)
         .await
         .expect("commit fixed upload");
 

--- a/qmdb/rs/tests/e2e_keyless_connect.rs
+++ b/qmdb/rs/tests/e2e_keyless_connect.rs
@@ -123,7 +123,7 @@ fn latest_inactivity_floor(ops: &[BatchOperation]) -> Location<mmr::Family> {
 async fn commit_upload(client: &StoreClient, batch: &LocalBatch) {
     let writer: KeylessWriter<mmr::Family, commonware_cryptography::Sha256, Vec<u8>> =
         KeylessWriter::fresh(PrefixedStoreClient::empty(client.clone()));
-    common::commit_keyless_upload(client, &writer, &batch.operations)
+    common::commit_keyless_upload(&writer, &batch.operations)
         .await
         .expect("commit upload");
 }

--- a/qmdb/rs/tests/e2e_keyless_connect.rs
+++ b/qmdb/rs/tests/e2e_keyless_connect.rs
@@ -122,7 +122,7 @@ fn latest_inactivity_floor(ops: &[BatchOperation]) -> Location<mmr::Family> {
 
 async fn commit_upload(client: &StoreClient, batch: &LocalBatch) {
     let writer: KeylessWriter<mmr::Family, commonware_cryptography::Sha256, Vec<u8>> =
-        KeylessWriter::empty(client.clone());
+        KeylessWriter::fresh(client.clone());
     common::commit_keyless_upload(client, &writer, &batch.operations)
         .await
         .expect("commit upload");

--- a/qmdb/rs/tests/e2e_keyless_connect.rs
+++ b/qmdb/rs/tests/e2e_keyless_connect.rs
@@ -26,7 +26,7 @@ use exoware_qmdb::{
 };
 use exoware_sdk::common::kv::v1::{filter as proto_filter, Filter as ProtoFilter};
 use exoware_sdk::proto::PreferZstdHttpClient;
-use exoware_sdk::StoreClient;
+use exoware_sdk::{PrefixedStoreClient, StoreClient};
 
 type Digest = commonware_cryptography::sha256::Digest;
 type LocalDb = Keyless<
@@ -122,7 +122,7 @@ fn latest_inactivity_floor(ops: &[BatchOperation]) -> Location<mmr::Family> {
 
 async fn commit_upload(client: &StoreClient, batch: &LocalBatch) {
     let writer: KeylessWriter<mmr::Family, commonware_cryptography::Sha256, Vec<u8>> =
-        KeylessWriter::fresh(client.clone());
+        KeylessWriter::fresh(PrefixedStoreClient::empty(client.clone()));
     common::commit_keyless_upload(client, &writer, &batch.operations)
         .await
         .expect("commit upload");
@@ -136,8 +136,8 @@ async fn keyless_connect_subscribe_emits_verifiable_multi_proof() {
         *local.inactivity_floor > 0,
         "test must not rely on inactivity_floor = 0"
     );
-    let keyless_client = Arc::new(TestKeylessClient::from_client(
-        store_client.clone(),
+    let keyless_client = Arc::new(TestKeylessClient::new(
+        PrefixedStoreClient::empty(store_client.clone()),
         ((0..=10000).into(), ()),
     ));
     let (_qmdb_server, qmdb_url) = spawn_qmdb_server(keyless_client).await;
@@ -182,8 +182,8 @@ async fn keyless_connect_get_operation_range_returns_verifiable_proof() {
     );
     commit_upload(&store_client, &local).await;
 
-    let keyless_client = Arc::new(TestKeylessClient::from_client(
-        store_client.clone(),
+    let keyless_client = Arc::new(TestKeylessClient::new(
+        PrefixedStoreClient::empty(store_client.clone()),
         ((0..=10000).into(), ()),
     ));
     let (_qmdb_server, qmdb_url) = spawn_qmdb_server(keyless_client).await;
@@ -216,8 +216,8 @@ async fn keyless_operation_log_sync_resolver_fetches_api_batches() {
     let local = build_local_batch().await;
     commit_upload(&store_client, &local).await;
 
-    let keyless_client = Arc::new(TestKeylessClient::from_client(
-        store_client.clone(),
+    let keyless_client = Arc::new(TestKeylessClient::new(
+        PrefixedStoreClient::empty(store_client.clone()),
         ((0..=10000).into(), ()),
     ));
     let (_qmdb_server, qmdb_url) = spawn_qmdb_server(keyless_client).await;
@@ -266,8 +266,8 @@ async fn keyless_commonware_glue_state_sync_uses_operation_log_resolver() {
     );
     commit_upload(&store_client, &local).await;
 
-    let keyless_client = Arc::new(TestKeylessClient::from_client(
-        store_client.clone(),
+    let keyless_client = Arc::new(TestKeylessClient::new(
+        PrefixedStoreClient::empty(store_client.clone()),
         ((0..=10000).into(), ()),
     ));
     let (_qmdb_server, qmdb_url) = spawn_qmdb_server(keyless_client).await;
@@ -388,8 +388,8 @@ async fn keyless_connect_client_rejects_invalid_streamed_proof() {
     );
     commit_upload(&store_client, &local).await;
 
-    let keyless_client = Arc::new(TestKeylessClient::from_client(
-        store_client.clone(),
+    let keyless_client = Arc::new(TestKeylessClient::new(
+        PrefixedStoreClient::empty(store_client.clone()),
         ((0..=10000).into(), ()),
     ));
     let (_qmdb_server, qmdb_url) = spawn_qmdb_server(keyless_client).await;
@@ -453,8 +453,8 @@ async fn keyless_connect_subscribe_filters_by_value_regex() {
         *local.inactivity_floor > 0,
         "test must not rely on inactivity_floor = 0"
     );
-    let keyless_client = Arc::new(TestKeylessClient::from_client(
-        store_client.clone(),
+    let keyless_client = Arc::new(TestKeylessClient::new(
+        PrefixedStoreClient::empty(store_client.clone()),
         ((0..=10000).into(), ()),
     ));
     let (_qmdb_server, qmdb_url) = spawn_qmdb_server(keyless_client).await;
@@ -506,8 +506,8 @@ async fn keyless_connect_subscribe_rejects_key_filters() {
         *local.inactivity_floor > 0,
         "test must not rely on inactivity_floor = 0"
     );
-    let keyless_client = Arc::new(TestKeylessClient::from_client(
-        store_client.clone(),
+    let keyless_client = Arc::new(TestKeylessClient::new(
+        PrefixedStoreClient::empty(store_client.clone()),
         ((0..=10000).into(), ()),
     ));
     let (_qmdb_server, qmdb_url) = spawn_qmdb_server(keyless_client).await;

--- a/qmdb/rs/tests/e2e_keyless_writer.rs
+++ b/qmdb/rs/tests/e2e_keyless_writer.rs
@@ -151,7 +151,7 @@ async fn sequential_upload_matches_local_root() {
     // This proves the writer produces the same root as the local DB when
     // given the same ops.
     let writer = fresh_writer(client.clone());
-    let receipt = common::commit_keyless_upload(&client, &writer, &writer_ops)
+    let receipt = common::commit_keyless_upload(&writer, &writer_ops)
         .await
         .expect("upload");
     assert_eq!(receipt.latest_location, latest);
@@ -206,7 +206,7 @@ async fn multiple_sequential_batches_each_publish_watermarks_in_band() {
 
     let writer = fresh_writer(client.clone());
 
-    let r1 = common::commit_keyless_upload(&client, &writer, &batch_ops[0])
+    let r1 = common::commit_keyless_upload(&writer, &batch_ops[0])
         .await
         .expect("b1");
     assert_eq!(
@@ -214,7 +214,7 @@ async fn multiple_sequential_batches_each_publish_watermarks_in_band() {
             .map(|checkpoint| checkpoint.location),
         Some(Location::<mmr::Family>::new(3))
     );
-    let r2 = common::commit_keyless_upload(&client, &writer, &batch_ops[1])
+    let r2 = common::commit_keyless_upload(&writer, &batch_ops[1])
         .await
         .expect("b2");
     assert_eq!(
@@ -222,7 +222,7 @@ async fn multiple_sequential_batches_each_publish_watermarks_in_band() {
             .map(|checkpoint| checkpoint.location),
         Some(Location::<mmr::Family>::new(5))
     );
-    let r3 = common::commit_keyless_upload(&client, &writer, &batch_ops[2])
+    let r3 = common::commit_keyless_upload(&writer, &batch_ops[2])
         .await
         .expect("b3");
     assert_eq!(
@@ -275,14 +275,11 @@ async fn pipelined_batches_require_flush_to_catch_up_watermark() {
     let w1 = writer.clone();
     let w2 = writer.clone();
     let w3 = writer.clone();
-    let c1 = client.clone();
-    let c2 = client.clone();
-    let c3 = client.clone();
 
     let (r1, r2, r3) = tokio::join!(
-        async move { common::commit_keyless_upload(&c1, &w1, &o1).await },
-        async move { common::commit_keyless_upload(&c2, &w2, &o2).await },
-        async move { common::commit_keyless_upload(&c3, &w3, &o3).await }
+        async move { common::commit_keyless_upload(&w1, &o1).await },
+        async move { common::commit_keyless_upload(&w2, &o2).await },
+        async move { common::commit_keyless_upload(&w3, &o3).await }
     );
     let r1 = r1.expect("b1");
     let r2 = r2.expect("b2");
@@ -358,9 +355,8 @@ async fn bounded_pipeline_advances_watermark_via_contiguous_acks() {
             }
         }
         let w = writer.clone();
-        let c = client.clone();
         in_flight.push(Box::pin(async move {
-            common::commit_keyless_upload(&c, &w, &batch).await
+            common::commit_keyless_upload(&w, &batch).await
         }));
     }
     while let Some(r) = in_flight.next().await {
@@ -414,7 +410,7 @@ async fn local_proof_resumes_from_existing_store_state() {
     // First "session": upload two ops and flush.
     {
         let writer = fresh_writer(client.clone());
-        let receipt = common::commit_keyless_upload(&client, &writer, &local_ops_two)
+        let receipt = common::commit_keyless_upload(&writer, &local_ops_two)
             .await
             .expect("upload 1");
         assert_eq!(receipt.latest_location, latest_two);
@@ -445,7 +441,7 @@ async fn local_proof_resumes_from_existing_store_state() {
         .expect("writer state from local proof");
         let writer = TestKeylessWriter::new(PrefixedStoreClient::empty(client.clone()), state);
         let remainder = &local_ops_final[local_ops_two.len()..];
-        let receipt = common::commit_keyless_upload(&client, &writer, remainder)
+        let receipt = common::commit_keyless_upload(&writer, remainder)
             .await
             .expect("upload 2");
         assert_eq!(receipt.latest_location, latest_final);

--- a/qmdb/rs/tests/e2e_keyless_writer.rs
+++ b/qmdb/rs/tests/e2e_keyless_writer.rs
@@ -12,7 +12,7 @@ use commonware_storage::merkle::{mmr, Location, Proof};
 use commonware_storage::qmdb::keyless::variable::{Db as Keyless, Operation as KeylessOperation};
 use commonware_utils::{NZUsize, NZU16, NZU64};
 use exoware_qmdb::{KeylessClient, KeylessWriter};
-use exoware_sdk::StoreClient;
+use exoware_sdk::{PrefixedStoreClient, StoreClient};
 
 use common::retry;
 
@@ -28,11 +28,11 @@ type TestKeylessClient = KeylessClient<mmr::Family, commonware_cryptography::Sha
 type TestKeylessWriter = KeylessWriter<mmr::Family, commonware_cryptography::Sha256, Vec<u8>>;
 
 fn fresh_reader(c: StoreClient) -> TestKeylessClient {
-    TestKeylessClient::from_client(c, ((0..=10000).into(), ()))
+    TestKeylessClient::new(PrefixedStoreClient::empty(c), ((0..=10000).into(), ()))
 }
 
 fn fresh_writer(c: StoreClient) -> TestKeylessWriter {
-    TestKeylessWriter::fresh(c)
+    TestKeylessWriter::fresh(PrefixedStoreClient::empty(c))
 }
 
 /// Reference Commonware keyless DB fed the same ops the writer will upload.
@@ -443,7 +443,7 @@ async fn local_proof_resumes_from_existing_store_state() {
             &local_ops_two,
         )
         .expect("writer state from local proof");
-        let writer = TestKeylessWriter::new(client.clone(), state);
+        let writer = TestKeylessWriter::new(PrefixedStoreClient::empty(client.clone()), state);
         let remainder = &local_ops_final[local_ops_two.len()..];
         let receipt = common::commit_keyless_upload(&client, &writer, remainder)
             .await

--- a/qmdb/rs/tests/e2e_keyless_writer.rs
+++ b/qmdb/rs/tests/e2e_keyless_writer.rs
@@ -32,7 +32,7 @@ fn fresh_reader(c: StoreClient) -> TestKeylessClient {
 }
 
 fn fresh_writer(c: StoreClient) -> TestKeylessWriter {
-    TestKeylessWriter::empty(c)
+    TestKeylessWriter::fresh(c)
 }
 
 /// Reference Commonware keyless DB fed the same ops the writer will upload.

--- a/qmdb/rs/tests/e2e_mirror_from_local.rs
+++ b/qmdb/rs/tests/e2e_mirror_from_local.rs
@@ -48,7 +48,7 @@ async fn mirror_keyless_from_local() {
         b"gamma".to_vec(),
     ]])
     .await;
-    let writer: KeylessWriter<mmr::Family, Sha256, Vec<u8>> = KeylessWriter::empty(client.clone());
+    let writer: KeylessWriter<mmr::Family, Sha256, Vec<u8>> = KeylessWriter::fresh(client.clone());
     common::commit_keyless_upload(&client, &writer, &ops1)
         .await
         .expect("upload 1");
@@ -150,7 +150,7 @@ async fn mirror_unordered_from_local() {
     ]])
     .await;
     let writer: UnorderedWriter<mmr::Family, Sha256, Vec<u8>, Vec<u8>> =
-        UnorderedWriter::empty(client.clone());
+        UnorderedWriter::fresh(client.clone());
     common::commit_unordered_upload(&client, &writer, &ops1)
         .await
         .expect("upload 1");
@@ -271,7 +271,7 @@ async fn mirror_immutable_from_local() {
     ]])
     .await;
     let writer: ImmutableWriter<mmr::Family, Sha256, ImmK, Vec<u8>> =
-        ImmutableWriter::empty(client.clone());
+        ImmutableWriter::fresh(client.clone());
     common::commit_immutable_upload(&client, &writer, &ops1)
         .await
         .expect("upload 1");
@@ -435,7 +435,7 @@ async fn mirror_ordered_from_local() {
     )
     .await;
     let writer: OrderedWriter<mmr::Family, Sha256, Vec<u8>, Vec<u8>, N> =
-        OrderedWriter::empty(client.clone());
+        OrderedWriter::fresh(client.clone());
     common::commit_ordered_upload(&client, &writer, &ops1, &boundary1)
         .await
         .expect("upload 1");

--- a/qmdb/rs/tests/e2e_mirror_from_local.rs
+++ b/qmdb/rs/tests/e2e_mirror_from_local.rs
@@ -32,6 +32,7 @@ use exoware_qmdb::{
     KeylessWriter, OrderedClient, OrderedWriter, UnorderedClient, UnorderedWriter, WriterState,
     MAX_OPERATION_SIZE,
 };
+use exoware_sdk::PrefixedStoreClient;
 
 type Digest = commonware_cryptography::sha256::Digest;
 
@@ -48,12 +49,15 @@ async fn mirror_keyless_from_local() {
         b"gamma".to_vec(),
     ]])
     .await;
-    let writer: KeylessWriter<mmr::Family, Sha256, Vec<u8>> = KeylessWriter::fresh(client.clone());
+    let writer: KeylessWriter<mmr::Family, Sha256, Vec<u8>> =
+        KeylessWriter::fresh(PrefixedStoreClient::empty(client.clone()));
     common::commit_keyless_upload(&client, &writer, &ops1)
         .await
         .expect("upload 1");
-    let reader: KeylessClient<mmr::Family, Sha256, Vec<u8>> =
-        KeylessClient::from_client(client.clone(), ((0..=MAX_OPERATION_SIZE).into(), ()));
+    let reader: KeylessClient<mmr::Family, Sha256, Vec<u8>> = KeylessClient::new(
+        PrefixedStoreClient::empty(client.clone()),
+        ((0..=MAX_OPERATION_SIZE).into(), ()),
+    );
     assert_eq!(
         reader.root_at(latest1).await.expect("root_at 1"),
         root1,
@@ -74,7 +78,7 @@ async fn mirror_keyless_from_local() {
     )
     .expect("writer state");
     let writer2: KeylessWriter<mmr::Family, Sha256, Vec<u8>> =
-        KeylessWriter::new(client.clone(), state);
+        KeylessWriter::new(PrefixedStoreClient::empty(client.clone()), state);
     let delta = &ops_total[ops1.len()..];
     common::commit_keyless_upload(&client, &writer2, delta)
         .await
@@ -150,18 +154,17 @@ async fn mirror_unordered_from_local() {
     ]])
     .await;
     let writer: UnorderedWriter<mmr::Family, Sha256, Vec<u8>, Vec<u8>> =
-        UnorderedWriter::fresh(client.clone());
+        UnorderedWriter::fresh(PrefixedStoreClient::empty(client.clone()));
     common::commit_unordered_upload(&client, &writer, &ops1)
         .await
         .expect("upload 1");
-    let reader: UnorderedClient<mmr::Family, Sha256, Vec<u8>, Vec<u8>> =
-        UnorderedClient::from_client(
-            client.clone(),
-            (
-                ((0..=MAX_OPERATION_SIZE).into(), ()),
-                ((0..=MAX_OPERATION_SIZE).into(), ()),
-            ),
-        );
+    let reader: UnorderedClient<mmr::Family, Sha256, Vec<u8>, Vec<u8>> = UnorderedClient::new(
+        PrefixedStoreClient::empty(client.clone()),
+        (
+            ((0..=MAX_OPERATION_SIZE).into(), ()),
+            ((0..=MAX_OPERATION_SIZE).into(), ()),
+        ),
+    );
     assert_eq!(
         reader.root_at(latest1).await.expect("root_at 1"),
         root1,
@@ -187,7 +190,7 @@ async fn mirror_unordered_from_local() {
     )
     .expect("writer state");
     let writer2: UnorderedWriter<mmr::Family, Sha256, Vec<u8>, Vec<u8>> =
-        UnorderedWriter::new(client.clone(), state);
+        UnorderedWriter::new(PrefixedStoreClient::empty(client.clone()), state);
     let delta = &ops_total[ops1.len()..];
     common::commit_unordered_upload(&client, &writer2, delta)
         .await
@@ -271,12 +274,14 @@ async fn mirror_immutable_from_local() {
     ]])
     .await;
     let writer: ImmutableWriter<mmr::Family, Sha256, ImmK, Vec<u8>> =
-        ImmutableWriter::fresh(client.clone());
+        ImmutableWriter::fresh(PrefixedStoreClient::empty(client.clone()));
     common::commit_immutable_upload(&client, &writer, &ops1)
         .await
         .expect("upload 1");
-    let reader: ImmutableClient<mmr::Family, Sha256, ImmK, Vec<u8>> =
-        ImmutableClient::from_client(client.clone(), ((), ((0..=MAX_OPERATION_SIZE).into(), ())));
+    let reader: ImmutableClient<mmr::Family, Sha256, ImmK, Vec<u8>> = ImmutableClient::new(
+        PrefixedStoreClient::empty(client.clone()),
+        ((), ((0..=MAX_OPERATION_SIZE).into(), ())),
+    );
     assert_eq!(
         reader.root_at(latest1).await.expect("root_at 1"),
         root1,
@@ -299,7 +304,7 @@ async fn mirror_immutable_from_local() {
     )
     .expect("writer state");
     let writer2: ImmutableWriter<mmr::Family, Sha256, ImmK, Vec<u8>> =
-        ImmutableWriter::new(client.clone(), state);
+        ImmutableWriter::new(PrefixedStoreClient::empty(client.clone()), state);
     let delta = &ops_total[ops1.len()..];
     common::commit_immutable_upload(&client, &writer2, delta)
         .await
@@ -435,23 +440,22 @@ async fn mirror_ordered_from_local() {
     )
     .await;
     let writer: OrderedWriter<mmr::Family, Sha256, Vec<u8>, Vec<u8>, N> =
-        OrderedWriter::fresh(client.clone());
+        OrderedWriter::fresh(PrefixedStoreClient::empty(client.clone()));
     common::commit_ordered_upload(&client, &writer, &ops1, &boundary1)
         .await
         .expect("upload 1");
 
-    let reader: OrderedClient<mmr::Family, Sha256, Vec<u8>, Vec<u8>, N> =
-        OrderedClient::from_client(
-            client.clone(),
-            (
-                ((0..=MAX_OPERATION_SIZE).into(), ()),
-                ((0..=MAX_OPERATION_SIZE).into(), ()),
-            ),
-            (
-                ((0..=MAX_OPERATION_SIZE).into(), ()),
-                ((0..=MAX_OPERATION_SIZE).into(), ()),
-            ),
-        );
+    let reader: OrderedClient<mmr::Family, Sha256, Vec<u8>, Vec<u8>, N> = OrderedClient::new(
+        PrefixedStoreClient::empty(client.clone()),
+        (
+            ((0..=MAX_OPERATION_SIZE).into(), ()),
+            ((0..=MAX_OPERATION_SIZE).into(), ()),
+        ),
+        (
+            ((0..=MAX_OPERATION_SIZE).into(), ()),
+            ((0..=MAX_OPERATION_SIZE).into(), ()),
+        ),
+    );
     assert_eq!(
         reader.current_root_at(latest1).await.expect("root_at 1"),
         root1,
@@ -479,7 +483,7 @@ async fn mirror_ordered_from_local() {
     )
     .expect("writer state");
     let writer2: OrderedWriter<mmr::Family, Sha256, Vec<u8>, Vec<u8>, N> =
-        OrderedWriter::new(client.clone(), state);
+        OrderedWriter::new(PrefixedStoreClient::empty(client.clone()), state);
     let delta_ops = &ops_total[ops1.len()..];
     common::commit_ordered_upload(&client, &writer2, delta_ops, &boundary_delta)
         .await

--- a/qmdb/rs/tests/e2e_mirror_from_local.rs
+++ b/qmdb/rs/tests/e2e_mirror_from_local.rs
@@ -51,7 +51,7 @@ async fn mirror_keyless_from_local() {
     .await;
     let writer: KeylessWriter<mmr::Family, Sha256, Vec<u8>> =
         KeylessWriter::fresh(PrefixedStoreClient::empty(client.clone()));
-    common::commit_keyless_upload(&client, &writer, &ops1)
+    common::commit_keyless_upload(&writer, &ops1)
         .await
         .expect("upload 1");
     let reader: KeylessClient<mmr::Family, Sha256, Vec<u8>> = KeylessClient::new(
@@ -80,7 +80,7 @@ async fn mirror_keyless_from_local() {
     let writer2: KeylessWriter<mmr::Family, Sha256, Vec<u8>> =
         KeylessWriter::new(PrefixedStoreClient::empty(client.clone()), state);
     let delta = &ops_total[ops1.len()..];
-    common::commit_keyless_upload(&client, &writer2, delta)
+    common::commit_keyless_upload(&writer2, delta)
         .await
         .expect("upload 2");
     assert_eq!(
@@ -155,7 +155,7 @@ async fn mirror_unordered_from_local() {
     .await;
     let writer: UnorderedWriter<mmr::Family, Sha256, Vec<u8>, Vec<u8>> =
         UnorderedWriter::fresh(PrefixedStoreClient::empty(client.clone()));
-    common::commit_unordered_upload(&client, &writer, &ops1)
+    common::commit_unordered_upload(&writer, &ops1)
         .await
         .expect("upload 1");
     let reader: UnorderedClient<mmr::Family, Sha256, Vec<u8>, Vec<u8>> = UnorderedClient::new(
@@ -192,7 +192,7 @@ async fn mirror_unordered_from_local() {
     let writer2: UnorderedWriter<mmr::Family, Sha256, Vec<u8>, Vec<u8>> =
         UnorderedWriter::new(PrefixedStoreClient::empty(client.clone()), state);
     let delta = &ops_total[ops1.len()..];
-    common::commit_unordered_upload(&client, &writer2, delta)
+    common::commit_unordered_upload(&writer2, delta)
         .await
         .expect("upload 2");
     assert_eq!(
@@ -275,7 +275,7 @@ async fn mirror_immutable_from_local() {
     .await;
     let writer: ImmutableWriter<mmr::Family, Sha256, ImmK, Vec<u8>> =
         ImmutableWriter::fresh(PrefixedStoreClient::empty(client.clone()));
-    common::commit_immutable_upload(&client, &writer, &ops1)
+    common::commit_immutable_upload(&writer, &ops1)
         .await
         .expect("upload 1");
     let reader: ImmutableClient<mmr::Family, Sha256, ImmK, Vec<u8>> = ImmutableClient::new(
@@ -306,7 +306,7 @@ async fn mirror_immutable_from_local() {
     let writer2: ImmutableWriter<mmr::Family, Sha256, ImmK, Vec<u8>> =
         ImmutableWriter::new(PrefixedStoreClient::empty(client.clone()), state);
     let delta = &ops_total[ops1.len()..];
-    common::commit_immutable_upload(&client, &writer2, delta)
+    common::commit_immutable_upload(&writer2, delta)
         .await
         .expect("upload 2");
     assert_eq!(
@@ -441,7 +441,7 @@ async fn mirror_ordered_from_local() {
     .await;
     let writer: OrderedWriter<mmr::Family, Sha256, Vec<u8>, Vec<u8>, N> =
         OrderedWriter::fresh(PrefixedStoreClient::empty(client.clone()));
-    common::commit_ordered_upload(&client, &writer, &ops1, &boundary1)
+    common::commit_ordered_upload(&writer, &ops1, &boundary1)
         .await
         .expect("upload 1");
 
@@ -485,7 +485,7 @@ async fn mirror_ordered_from_local() {
     let writer2: OrderedWriter<mmr::Family, Sha256, Vec<u8>, Vec<u8>, N> =
         OrderedWriter::new(PrefixedStoreClient::empty(client.clone()), state);
     let delta_ops = &ops_total[ops1.len()..];
-    common::commit_ordered_upload(&client, &writer2, delta_ops, &boundary_delta)
+    common::commit_ordered_upload(&writer2, delta_ops, &boundary_delta)
         .await
         .expect("upload 2");
     assert_eq!(

--- a/qmdb/rs/tests/e2e_ordered.rs
+++ b/qmdb/rs/tests/e2e_ordered.rs
@@ -22,7 +22,7 @@ use commonware_storage::translator::TwoCap;
 use commonware_utils::{NZUsize, NZU16, NZU64};
 use exoware_qmdb::MAX_OPERATION_SIZE;
 use exoware_qmdb::{recover_boundary_state, CurrentBoundaryState, OrderedClient, OrderedWriter};
-use exoware_sdk::StoreClient;
+use exoware_sdk::{PrefixedStoreClient, StoreClient};
 
 const N: usize = 32;
 type Digest = commonware_cryptography::sha256::Digest;
@@ -107,7 +107,8 @@ where
     BatchOperation<F>:
         commonware_codec::Codec + commonware_codec::Encode + commonware_codec::Decode,
 {
-    let writer: TestOrderedWriter<F> = TestOrderedWriter::fresh(client.clone());
+    let writer: TestOrderedWriter<F> =
+        TestOrderedWriter::fresh(PrefixedStoreClient::empty(client.clone()));
     common::commit_ordered_upload(client, &writer, &local.operations, &local.current_boundary)
         .await
         .expect("commit upload");
@@ -466,8 +467,8 @@ async fn ordered_round_trip() {
 
     mirror_local(&client, &local).await;
 
-    let c = TestOrderedClient::<mmr::Family>::from_client(
-        client.clone(),
+    let c = TestOrderedClient::<mmr::Family>::new(
+        PrefixedStoreClient::empty(client.clone()),
         op_cfg::<mmr::Family>(),
         update_row_cfg(),
     );
@@ -508,8 +509,8 @@ async fn ordered_mmb_round_trip() {
 
     mirror_local(&client, &local).await;
 
-    let c = TestOrderedClient::<mmb::Family>::from_client(
-        client.clone(),
+    let c = TestOrderedClient::<mmb::Family>::new(
+        PrefixedStoreClient::empty(client.clone()),
         op_cfg::<mmb::Family>(),
         update_row_cfg(),
     );
@@ -559,13 +560,16 @@ async fn ordered_mmb_multi_peak_grafted_chunk_round_trip() {
     );
 
     let writer: OrderedWriter<mmb::Family, Sha256, Vec<u8>, Vec<u8>, N> =
-        OrderedWriter::fresh(client.clone());
+        OrderedWriter::fresh(PrefixedStoreClient::empty(client.clone()));
     common::commit_ordered_upload(&client, &writer, &local.operations, &local.current_boundary)
         .await
         .expect("commit upload");
 
-    let c: OrderedClient<mmb::Family, Sha256, Vec<u8>, Vec<u8>, N> =
-        OrderedClient::from_client(client.clone(), op_cfg::<mmb::Family>(), update_row_cfg());
+    let c: OrderedClient<mmb::Family, Sha256, Vec<u8>, Vec<u8>, N> = OrderedClient::new(
+        PrefixedStoreClient::empty(client.clone()),
+        op_cfg::<mmb::Family>(),
+        update_row_cfg(),
+    );
     let current = c
         .current_operation_range_proof(
             local.latest_location,
@@ -682,15 +686,19 @@ async fn assert_incremental_seed_batches_keep_current_proofs_verifiable<F>(
         .await
         .expect("join");
 
-    let writer: TestOrderedWriter<F> = TestOrderedWriter::fresh(client.clone());
+    let writer: TestOrderedWriter<F> =
+        TestOrderedWriter::fresh(PrefixedStoreClient::empty(client.clone()));
     for (delta, boundary) in &uploads {
         common::commit_ordered_upload(&client, &writer, delta, boundary)
             .await
             .expect("commit upload");
     }
 
-    let c: TestOrderedClient<F> =
-        OrderedClient::from_client(client.clone(), op_cfg::<F>(), update_row_cfg());
+    let c: TestOrderedClient<F> = OrderedClient::new(
+        PrefixedStoreClient::empty(client.clone()),
+        op_cfg::<F>(),
+        update_row_cfg(),
+    );
     let key_proof = c
         .key_value_proof_at(latest_location, latest_key.as_slice())
         .await
@@ -775,7 +783,9 @@ async fn ordered_mmb_persistent_interleaved_seed_batches_keep_current_proofs_ver
                     let mut db: LocalDb<mmb::Family> = LocalQmdbDb::init(context.child("db"), cfg)
                         .await
                         .expect("init");
-                    let writer = TestOrderedWriter::<mmb::Family>::fresh(store.clone());
+                    let writer = TestOrderedWriter::<mmb::Family>::fresh(
+                        PrefixedStoreClient::empty(store.clone()),
+                    );
                     let mut previous_ops = Vec::<BatchOperation<mmb::Family>>::new();
                     let mut counter = 0u64;
 
@@ -843,8 +853,11 @@ async fn ordered_mmb_persistent_interleaved_seed_batches_keep_current_proofs_ver
         .await
         .expect("join");
 
-    let c: TestOrderedClient<mmb::Family> =
-        OrderedClient::from_client(client.clone(), op_cfg::<mmb::Family>(), update_row_cfg());
+    let c: TestOrderedClient<mmb::Family> = OrderedClient::new(
+        PrefixedStoreClient::empty(client.clone()),
+        op_cfg::<mmb::Family>(),
+        update_row_cfg(),
+    );
     assert_eq!(
         c.current_root_at(latest_location)
             .await
@@ -875,13 +888,14 @@ async fn ordered_fixed_round_trip() {
     let (_dir, _server, client) = common::local_store_client().await;
     let local = build_fixed_local_db::<mmr::Family>().await;
 
-    let writer: FixedTestOrderedWriter<mmr::Family> = FixedTestOrderedWriter::fresh(client.clone());
+    let writer: FixedTestOrderedWriter<mmr::Family> =
+        FixedTestOrderedWriter::fresh(PrefixedStoreClient::empty(client.clone()));
     common::commit_ordered_upload(&client, &writer, &local.operations, &local.current_boundary)
         .await
         .expect("commit fixed upload");
 
-    let c = FixedTestOrderedClient::<mmr::Family>::from_client(
-        client.clone(),
+    let c = FixedTestOrderedClient::<mmr::Family>::new(
+        PrefixedStoreClient::empty(client.clone()),
         (),
         fixed_update_row_cfg(),
     );
@@ -942,8 +956,8 @@ async fn current_root_at() {
 
     mirror_local(&client, &local).await;
 
-    let c = TestOrderedClient::<mmr::Family>::from_client(
-        client.clone(),
+    let c = TestOrderedClient::<mmr::Family>::new(
+        PrefixedStoreClient::empty(client.clone()),
         op_cfg::<mmr::Family>(),
         update_row_cfg(),
     );
@@ -961,8 +975,8 @@ async fn current_operation_range_proof() {
 
     mirror_local(&client, &local).await;
 
-    let c = TestOrderedClient::<mmr::Family>::from_client(
-        client.clone(),
+    let c = TestOrderedClient::<mmr::Family>::new(
+        PrefixedStoreClient::empty(client.clone()),
         op_cfg::<mmr::Family>(),
         update_row_cfg(),
     );
@@ -984,8 +998,8 @@ async fn key_value_proof() {
 
     mirror_local(&client, &local).await;
 
-    let c = TestOrderedClient::<mmr::Family>::from_client(
-        client.clone(),
+    let c = TestOrderedClient::<mmr::Family>::new(
+        PrefixedStoreClient::empty(client.clone()),
         op_cfg::<mmr::Family>(),
         update_row_cfg(),
     );
@@ -1009,8 +1023,8 @@ async fn multi_proof() {
 
     mirror_local(&client, &local).await;
 
-    let c = TestOrderedClient::<mmr::Family>::from_client(
-        client.clone(),
+    let c = TestOrderedClient::<mmr::Family>::new(
+        PrefixedStoreClient::empty(client.clone()),
         op_cfg::<mmr::Family>(),
         update_row_cfg(),
     );

--- a/qmdb/rs/tests/e2e_ordered.rs
+++ b/qmdb/rs/tests/e2e_ordered.rs
@@ -109,7 +109,7 @@ where
 {
     let writer: TestOrderedWriter<F> =
         TestOrderedWriter::fresh(PrefixedStoreClient::empty(client.clone()));
-    common::commit_ordered_upload(client, &writer, &local.operations, &local.current_boundary)
+    common::commit_ordered_upload(&writer, &local.operations, &local.current_boundary)
         .await
         .expect("commit upload");
 }
@@ -561,7 +561,7 @@ async fn ordered_mmb_multi_peak_grafted_chunk_round_trip() {
 
     let writer: OrderedWriter<mmb::Family, Sha256, Vec<u8>, Vec<u8>, N> =
         OrderedWriter::fresh(PrefixedStoreClient::empty(client.clone()));
-    common::commit_ordered_upload(&client, &writer, &local.operations, &local.current_boundary)
+    common::commit_ordered_upload(&writer, &local.operations, &local.current_boundary)
         .await
         .expect("commit upload");
 
@@ -689,7 +689,7 @@ async fn assert_incremental_seed_batches_keep_current_proofs_verifiable<F>(
     let writer: TestOrderedWriter<F> =
         TestOrderedWriter::fresh(PrefixedStoreClient::empty(client.clone()));
     for (delta, boundary) in &uploads {
-        common::commit_ordered_upload(&client, &writer, delta, boundary)
+        common::commit_ordered_upload(&writer, delta, boundary)
             .await
             .expect("commit upload");
     }
@@ -837,7 +837,7 @@ async fn ordered_mmb_persistent_interleaved_seed_batches_keep_current_proofs_ver
                         let boundary =
                             boundary_from_local_db(&db, previous_slice, &cumulative_ops).await;
                         let delta = cumulative_ops[previous_ops.len()..].to_vec();
-                        common::commit_ordered_upload(&store, &writer, &delta, &boundary)
+                        common::commit_ordered_upload(&writer, &delta, &boundary)
                             .await
                             .expect("commit upload");
                         previous_ops = cumulative_ops;
@@ -890,7 +890,7 @@ async fn ordered_fixed_round_trip() {
 
     let writer: FixedTestOrderedWriter<mmr::Family> =
         FixedTestOrderedWriter::fresh(PrefixedStoreClient::empty(client.clone()));
-    common::commit_ordered_upload(&client, &writer, &local.operations, &local.current_boundary)
+    common::commit_ordered_upload(&writer, &local.operations, &local.current_boundary)
         .await
         .expect("commit fixed upload");
 

--- a/qmdb/rs/tests/e2e_ordered.rs
+++ b/qmdb/rs/tests/e2e_ordered.rs
@@ -107,7 +107,7 @@ where
     BatchOperation<F>:
         commonware_codec::Codec + commonware_codec::Encode + commonware_codec::Decode,
 {
-    let writer: TestOrderedWriter<F> = TestOrderedWriter::empty(client.clone());
+    let writer: TestOrderedWriter<F> = TestOrderedWriter::fresh(client.clone());
     common::commit_ordered_upload(client, &writer, &local.operations, &local.current_boundary)
         .await
         .expect("commit upload");
@@ -559,7 +559,7 @@ async fn ordered_mmb_multi_peak_grafted_chunk_round_trip() {
     );
 
     let writer: OrderedWriter<mmb::Family, Sha256, Vec<u8>, Vec<u8>, N> =
-        OrderedWriter::empty(client.clone());
+        OrderedWriter::fresh(client.clone());
     common::commit_ordered_upload(&client, &writer, &local.operations, &local.current_boundary)
         .await
         .expect("commit upload");
@@ -682,7 +682,7 @@ async fn assert_incremental_seed_batches_keep_current_proofs_verifiable<F>(
         .await
         .expect("join");
 
-    let writer: TestOrderedWriter<F> = TestOrderedWriter::empty(client.clone());
+    let writer: TestOrderedWriter<F> = TestOrderedWriter::fresh(client.clone());
     for (delta, boundary) in &uploads {
         common::commit_ordered_upload(&client, &writer, delta, boundary)
             .await
@@ -775,7 +775,7 @@ async fn ordered_mmb_persistent_interleaved_seed_batches_keep_current_proofs_ver
                     let mut db: LocalDb<mmb::Family> = LocalQmdbDb::init(context.child("db"), cfg)
                         .await
                         .expect("init");
-                    let writer = TestOrderedWriter::<mmb::Family>::empty(store.clone());
+                    let writer = TestOrderedWriter::<mmb::Family>::fresh(store.clone());
                     let mut previous_ops = Vec::<BatchOperation<mmb::Family>>::new();
                     let mut counter = 0u64;
 
@@ -875,7 +875,7 @@ async fn ordered_fixed_round_trip() {
     let (_dir, _server, client) = common::local_store_client().await;
     let local = build_fixed_local_db::<mmr::Family>().await;
 
-    let writer: FixedTestOrderedWriter<mmr::Family> = FixedTestOrderedWriter::empty(client.clone());
+    let writer: FixedTestOrderedWriter<mmr::Family> = FixedTestOrderedWriter::fresh(client.clone());
     common::commit_ordered_upload(&client, &writer, &local.operations, &local.current_boundary)
         .await
         .expect("commit fixed upload");

--- a/qmdb/rs/tests/e2e_ordered_connect.rs
+++ b/qmdb/rs/tests/e2e_ordered_connect.rs
@@ -265,7 +265,7 @@ async fn build_grafted_boundary_local_batch() -> LocalBatch {
 async fn commit_upload(client: &StoreClient, batch: &LocalBatch) {
     let writer: OrderedWriter<mmr::Family, Sha256, Vec<u8>, Vec<u8>, N> =
         OrderedWriter::fresh(PrefixedStoreClient::empty(client.clone()));
-    common::commit_ordered_upload(client, &writer, &batch.operations, &batch.current_boundary)
+    common::commit_ordered_upload(&writer, &batch.operations, &batch.current_boundary)
         .await
         .expect("commit upload");
 }
@@ -424,14 +424,9 @@ async fn ordered_get_after_grafted_boundary_returns_current_key_value_proof() {
     );
     let writer: OrderedWriter<mmr::Family, Sha256, Vec<u8>, Vec<u8>, N> =
         OrderedWriter::fresh(PrefixedStoreClient::empty(store_client.clone()));
-    common::commit_ordered_upload(
-        &store_client,
-        &writer,
-        &local.operations,
-        &local.current_boundary,
-    )
-    .await
-    .expect("commit upload");
+    common::commit_ordered_upload(&writer, &local.operations, &local.current_boundary)
+        .await
+        .expect("commit upload");
 
     let key = b"k-00000400".to_vec();
     let proof = ordered_client

--- a/qmdb/rs/tests/e2e_ordered_connect.rs
+++ b/qmdb/rs/tests/e2e_ordered_connect.rs
@@ -35,7 +35,7 @@ use exoware_qmdb::{
     OrderedConnectClient, OrderedWriter, QmdbError, VerifiedKeyLookup, MAX_OPERATION_SIZE,
 };
 use exoware_sdk::proto::PreferZstdHttpClient;
-use exoware_sdk::StoreClient;
+use exoware_sdk::{PrefixedStoreClient, StoreClient};
 
 const N: usize = 32;
 type Digest = commonware_cryptography::sha256::Digest;
@@ -264,7 +264,7 @@ async fn build_grafted_boundary_local_batch() -> LocalBatch {
 
 async fn commit_upload(client: &StoreClient, batch: &LocalBatch) {
     let writer: OrderedWriter<mmr::Family, Sha256, Vec<u8>, Vec<u8>, N> =
-        OrderedWriter::fresh(client.clone());
+        OrderedWriter::fresh(PrefixedStoreClient::empty(client.clone()));
     common::commit_ordered_upload(client, &writer, &batch.operations, &batch.current_boundary)
         .await
         .expect("commit upload");
@@ -386,8 +386,8 @@ fn tamper_get_many_response(mut response: ProtoGetManyResponse) -> ProtoGetManyR
 async fn ordered_connect_get_returns_current_key_value_proof() {
     let (_dir, _store_server, store_client) = common::local_store_client().await;
     let local = build_local_batch().await;
-    let ordered_client = Arc::new(TestOrderedClient::from_client(
-        store_client.clone(),
+    let ordered_client = Arc::new(TestOrderedClient::new(
+        PrefixedStoreClient::empty(store_client.clone()),
         op_cfg(),
         update_row_cfg(),
     ));
@@ -417,10 +417,13 @@ async fn ordered_connect_get_returns_current_key_value_proof() {
 async fn ordered_get_after_grafted_boundary_returns_current_key_value_proof() {
     let (_dir, _store_server, store_client) = common::local_store_client().await;
     let local = build_grafted_boundary_local_batch().await;
-    let ordered_client =
-        TestOrderedClient::from_client(store_client.clone(), op_cfg(), update_row_cfg());
+    let ordered_client = TestOrderedClient::new(
+        PrefixedStoreClient::empty(store_client.clone()),
+        op_cfg(),
+        update_row_cfg(),
+    );
     let writer: OrderedWriter<mmr::Family, Sha256, Vec<u8>, Vec<u8>, N> =
-        OrderedWriter::fresh(store_client.clone());
+        OrderedWriter::fresh(PrefixedStoreClient::empty(store_client.clone()));
     common::commit_ordered_upload(
         &store_client,
         &writer,
@@ -445,8 +448,8 @@ async fn ordered_get_after_grafted_boundary_returns_current_key_value_proof() {
 async fn ordered_connect_get_many_returns_current_key_lookup_proofs() {
     let (_dir, _store_server, store_client) = common::local_store_client().await;
     let local = build_local_batch().await;
-    let ordered_client = Arc::new(TestOrderedClient::from_client(
-        store_client.clone(),
+    let ordered_client = Arc::new(TestOrderedClient::new(
+        PrefixedStoreClient::empty(store_client.clone()),
         op_cfg(),
         update_row_cfg(),
     ));
@@ -491,8 +494,8 @@ async fn ordered_connect_get_many_returns_current_key_lookup_proofs() {
 async fn ordered_connect_get_many_returns_miss_proofs_and_rejects_duplicates() {
     let (_dir, _store_server, store_client) = common::local_store_client().await;
     let local = build_local_batch().await;
-    let ordered_client = Arc::new(TestOrderedClient::from_client(
-        store_client.clone(),
+    let ordered_client = Arc::new(TestOrderedClient::new(
+        PrefixedStoreClient::empty(store_client.clone()),
         op_cfg(),
         update_row_cfg(),
     ));
@@ -537,8 +540,8 @@ async fn ordered_connect_get_many_returns_miss_proofs_and_rejects_duplicates() {
 async fn ordered_connect_get_range_verifies_complete_empty_and_partial_pages() {
     let (_dir, _store_server, store_client) = common::local_store_client().await;
     let local = build_local_batch().await;
-    let ordered_client = Arc::new(TestOrderedClient::from_client(
-        store_client.clone(),
+    let ordered_client = Arc::new(TestOrderedClient::new(
+        PrefixedStoreClient::empty(store_client.clone()),
         op_cfg(),
         update_row_cfg(),
     ));
@@ -610,8 +613,8 @@ async fn ordered_connect_client_rejects_get_range_boundary_omission() {
     let local = build_local_batch().await;
     commit_upload(&store_client, &local).await;
 
-    let ordered_client = Arc::new(TestOrderedClient::from_client(
-        store_client.clone(),
+    let ordered_client = Arc::new(TestOrderedClient::new(
+        PrefixedStoreClient::empty(store_client.clone()),
         op_cfg(),
         update_row_cfg(),
     ));
@@ -683,8 +686,8 @@ async fn ordered_connect_client_rejects_empty_unbounded_get_range_before_next_ke
     let local = build_local_batch().await;
     commit_upload(&store_client, &local).await;
 
-    let ordered_client = Arc::new(TestOrderedClient::from_client(
-        store_client.clone(),
+    let ordered_client = Arc::new(TestOrderedClient::new(
+        PrefixedStoreClient::empty(store_client.clone()),
         op_cfg(),
         update_row_cfg(),
     ));
@@ -760,8 +763,8 @@ async fn ordered_connect_client_rejects_invalid_get_proof() {
     let local = build_local_batch().await;
     commit_upload(&store_client, &local).await;
 
-    let ordered_client = Arc::new(TestOrderedClient::from_client(
-        store_client.clone(),
+    let ordered_client = Arc::new(TestOrderedClient::new(
+        PrefixedStoreClient::empty(store_client.clone()),
         op_cfg(),
         update_row_cfg(),
     ));
@@ -822,8 +825,8 @@ async fn ordered_connect_client_rejects_invalid_get_many_proof() {
     let local = build_local_batch().await;
     commit_upload(&store_client, &local).await;
 
-    let ordered_client = Arc::new(TestOrderedClient::from_client(
-        store_client.clone(),
+    let ordered_client = Arc::new(TestOrderedClient::new(
+        PrefixedStoreClient::empty(store_client.clone()),
         op_cfg(),
         update_row_cfg(),
     ));
@@ -884,8 +887,8 @@ async fn ordered_connect_client_rejects_get_many_proof_for_different_key() {
     let local = build_local_batch().await;
     commit_upload(&store_client, &local).await;
 
-    let ordered_client = Arc::new(TestOrderedClient::from_client(
-        store_client.clone(),
+    let ordered_client = Arc::new(TestOrderedClient::new(
+        PrefixedStoreClient::empty(store_client.clone()),
         op_cfg(),
         update_row_cfg(),
     ));

--- a/qmdb/rs/tests/e2e_ordered_connect.rs
+++ b/qmdb/rs/tests/e2e_ordered_connect.rs
@@ -264,7 +264,7 @@ async fn build_grafted_boundary_local_batch() -> LocalBatch {
 
 async fn commit_upload(client: &StoreClient, batch: &LocalBatch) {
     let writer: OrderedWriter<mmr::Family, Sha256, Vec<u8>, Vec<u8>, N> =
-        OrderedWriter::empty(client.clone());
+        OrderedWriter::fresh(client.clone());
     common::commit_ordered_upload(client, &writer, &batch.operations, &batch.current_boundary)
         .await
         .expect("commit upload");
@@ -420,7 +420,7 @@ async fn ordered_get_after_grafted_boundary_returns_current_key_value_proof() {
     let ordered_client =
         TestOrderedClient::from_client(store_client.clone(), op_cfg(), update_row_cfg());
     let writer: OrderedWriter<mmr::Family, Sha256, Vec<u8>, Vec<u8>, N> =
-        OrderedWriter::empty(store_client.clone());
+        OrderedWriter::fresh(store_client.clone());
     common::commit_ordered_upload(
         &store_client,
         &writer,

--- a/qmdb/rs/tests/e2e_ordered_prune.rs
+++ b/qmdb/rs/tests/e2e_ordered_prune.rs
@@ -236,7 +236,7 @@ async fn mirror_ordered_prune_past_chunk_zero() {
     // `load_bitmap_chunk` must fold that bit to 0 for the root recomputation
     // to match.
     let writer: OrderedWriter<mmr::Family, Sha256, Vec<u8>, Vec<u8>, N> =
-        OrderedWriter::empty(client.clone());
+        OrderedWriter::fresh(client.clone());
     let reader: OrderedClient<mmr::Family, Sha256, Vec<u8>, Vec<u8>, N> =
         OrderedClient::from_client(
             client.clone(),

--- a/qmdb/rs/tests/e2e_ordered_prune.rs
+++ b/qmdb/rs/tests/e2e_ordered_prune.rs
@@ -29,6 +29,7 @@ use commonware_utils::{NZUsize, NZU16, NZU64};
 use exoware_qmdb::{
     recover_boundary_state, CurrentBoundaryState, OrderedClient, OrderedWriter, MAX_OPERATION_SIZE,
 };
+use exoware_sdk::PrefixedStoreClient;
 
 const N: usize = 32;
 type Digest = commonware_cryptography::sha256::Digest;
@@ -236,19 +237,18 @@ async fn mirror_ordered_prune_past_chunk_zero() {
     // `load_bitmap_chunk` must fold that bit to 0 for the root recomputation
     // to match.
     let writer: OrderedWriter<mmr::Family, Sha256, Vec<u8>, Vec<u8>, N> =
-        OrderedWriter::fresh(client.clone());
-    let reader: OrderedClient<mmr::Family, Sha256, Vec<u8>, Vec<u8>, N> =
-        OrderedClient::from_client(
-            client.clone(),
-            (
-                ((0..=MAX_OPERATION_SIZE).into(), ()),
-                ((0..=MAX_OPERATION_SIZE).into(), ()),
-            ),
-            (
-                ((0..=MAX_OPERATION_SIZE).into(), ()),
-                ((0..=MAX_OPERATION_SIZE).into(), ()),
-            ),
-        );
+        OrderedWriter::fresh(PrefixedStoreClient::empty(client.clone()));
+    let reader: OrderedClient<mmr::Family, Sha256, Vec<u8>, Vec<u8>, N> = OrderedClient::new(
+        PrefixedStoreClient::empty(client.clone()),
+        (
+            ((0..=MAX_OPERATION_SIZE).into(), ()),
+            ((0..=MAX_OPERATION_SIZE).into(), ()),
+        ),
+        (
+            ((0..=MAX_OPERATION_SIZE).into(), ()),
+            ((0..=MAX_OPERATION_SIZE).into(), ()),
+        ),
+    );
 
     for outcome in &batches {
         common::commit_ordered_upload(&client, &writer, &outcome.delta_ops, &outcome.boundary)

--- a/qmdb/rs/tests/e2e_ordered_prune.rs
+++ b/qmdb/rs/tests/e2e_ordered_prune.rs
@@ -251,7 +251,7 @@ async fn mirror_ordered_prune_past_chunk_zero() {
     );
 
     for outcome in &batches {
-        common::commit_ordered_upload(&client, &writer, &outcome.delta_ops, &outcome.boundary)
+        common::commit_ordered_upload(&writer, &outcome.delta_ops, &outcome.boundary)
             .await
             .expect("upload");
         let remote_root = reader

--- a/qmdb/rs/tests/e2e_ordered_range_connect.rs
+++ b/qmdb/rs/tests/e2e_ordered_range_connect.rs
@@ -479,7 +479,7 @@ async fn build_mmb_growing_local_batch() -> MmbGrowingLocalBatch {
 async fn commit_upload(client: &StoreClient, batch: &LocalBatch) {
     let writer: OrderedWriter<mmr::Family, Sha256, Vec<u8>, Vec<u8>, N> =
         OrderedWriter::fresh(PrefixedStoreClient::empty(client.clone()));
-    common::commit_ordered_upload(client, &writer, &batch.operations, &batch.current_boundary)
+    common::commit_ordered_upload(&writer, &batch.operations, &batch.current_boundary)
         .await
         .expect("commit upload");
 }
@@ -487,7 +487,7 @@ async fn commit_upload(client: &StoreClient, batch: &LocalBatch) {
 async fn commit_mmb_upload(client: &StoreClient, batch: &MmbLocalBatch) {
     let writer: OrderedWriter<mmb::Family, Sha256, Vec<u8>, Vec<u8>, N> =
         OrderedWriter::fresh(PrefixedStoreClient::empty(client.clone()));
-    common::commit_ordered_upload(client, &writer, &batch.operations, &batch.current_boundary)
+    common::commit_ordered_upload(&writer, &batch.operations, &batch.current_boundary)
         .await
         .expect("commit upload");
 }

--- a/qmdb/rs/tests/e2e_ordered_range_connect.rs
+++ b/qmdb/rs/tests/e2e_ordered_range_connect.rs
@@ -37,7 +37,7 @@ use exoware_qmdb::{
 };
 use exoware_sdk::common::kv::v1::{filter as proto_filter, Filter as ProtoFilter};
 use exoware_sdk::proto::PreferZstdHttpClient;
-use exoware_sdk::StoreClient;
+use exoware_sdk::{PrefixedStoreClient, StoreClient};
 
 const N: usize = 32;
 const MIN_MMB_OPERATIONS: usize = 10;
@@ -478,7 +478,7 @@ async fn build_mmb_growing_local_batch() -> MmbGrowingLocalBatch {
 
 async fn commit_upload(client: &StoreClient, batch: &LocalBatch) {
     let writer: OrderedWriter<mmr::Family, Sha256, Vec<u8>, Vec<u8>, N> =
-        OrderedWriter::fresh(client.clone());
+        OrderedWriter::fresh(PrefixedStoreClient::empty(client.clone()));
     common::commit_ordered_upload(client, &writer, &batch.operations, &batch.current_boundary)
         .await
         .expect("commit upload");
@@ -486,7 +486,7 @@ async fn commit_upload(client: &StoreClient, batch: &LocalBatch) {
 
 async fn commit_mmb_upload(client: &StoreClient, batch: &MmbLocalBatch) {
     let writer: OrderedWriter<mmb::Family, Sha256, Vec<u8>, Vec<u8>, N> =
-        OrderedWriter::fresh(client.clone());
+        OrderedWriter::fresh(PrefixedStoreClient::empty(client.clone()));
     common::commit_ordered_upload(client, &writer, &batch.operations, &batch.current_boundary)
         .await
         .expect("commit upload");
@@ -498,8 +498,8 @@ async fn ordered_current_operation_range_connect_emits_verifiable_proof() {
     let local = build_local_batch().await;
     commit_upload(&store_client, &local).await;
 
-    let ordered_client = Arc::new(TestOrderedClient::from_client(
-        store_client.clone(),
+    let ordered_client = Arc::new(TestOrderedClient::new(
+        PrefixedStoreClient::empty(store_client.clone()),
         op_cfg(),
         update_row_cfg(),
     ));
@@ -536,8 +536,8 @@ async fn ordered_current_state_sync_from_connect_api_reconstructs_current_db() {
     let local = build_local_batch().await;
     commit_upload(&store_client, &local).await;
 
-    let ordered_client = Arc::new(TestOrderedClient::from_client(
-        store_client.clone(),
+    let ordered_client = Arc::new(TestOrderedClient::new(
+        PrefixedStoreClient::empty(store_client.clone()),
         op_cfg(),
         update_row_cfg(),
     ));
@@ -620,8 +620,8 @@ async fn ordered_mmb_current_state_sync_from_nonzero_connect_api_reconstructs_cu
     let expected_alpha = latest_mmb_value_for_key(&local.operations[start_index..], b"alpha");
     commit_mmb_upload(&store_client, &local).await;
 
-    let ordered_client = Arc::new(MmbTestOrderedClient::from_client(
-        store_client.clone(),
+    let ordered_client = Arc::new(MmbTestOrderedClient::new(
+        PrefixedStoreClient::empty(store_client.clone()),
         mmb_op_cfg(),
         update_row_cfg(),
     ));
@@ -692,8 +692,8 @@ async fn ordered_mmb_sync_resolvers_return_pinned_nodes_for_nonzero_fetches() {
     );
     commit_mmb_upload(&store_client, &local).await;
 
-    let ordered_client = Arc::new(MmbTestOrderedClient::from_client(
-        store_client.clone(),
+    let ordered_client = Arc::new(MmbTestOrderedClient::new(
+        PrefixedStoreClient::empty(store_client.clone()),
         mmb_op_cfg(),
         update_row_cfg(),
     ));
@@ -778,8 +778,8 @@ async fn ordered_mmb_operation_range_client_rejects_missing_nonzero_pinned_nodes
     );
     commit_mmb_upload(&store_client, &local).await;
 
-    let ordered_client = Arc::new(MmbTestOrderedClient::from_client(
-        store_client.clone(),
+    let ordered_client = Arc::new(MmbTestOrderedClient::new(
+        PrefixedStoreClient::empty(store_client.clone()),
         mmb_op_cfg(),
         update_row_cfg(),
     ));
@@ -846,8 +846,8 @@ async fn ordered_mmb_operation_range_client_rejects_extra_nonzero_pinned_node() 
     );
     commit_mmb_upload(&store_client, &local).await;
 
-    let ordered_client = Arc::new(MmbTestOrderedClient::from_client(
-        store_client.clone(),
+    let ordered_client = Arc::new(MmbTestOrderedClient::new(
+        PrefixedStoreClient::empty(store_client.clone()),
         mmb_op_cfg(),
         update_row_cfg(),
     ));
@@ -897,8 +897,8 @@ async fn ordered_mmb_operation_range_client_rejects_zero_start_pinned_nodes() {
     let local = build_mmb_local_batch().await;
     commit_mmb_upload(&store_client, &local).await;
 
-    let ordered_client = Arc::new(MmbTestOrderedClient::from_client(
-        store_client.clone(),
+    let ordered_client = Arc::new(MmbTestOrderedClient::new(
+        PrefixedStoreClient::empty(store_client.clone()),
         mmb_op_cfg(),
         update_row_cfg(),
     ));
@@ -950,8 +950,8 @@ async fn ordered_operation_range_connect_uses_current_root_witness() {
     let local = build_local_batch().await;
     commit_upload(&store_client, &local).await;
 
-    let ordered_client = Arc::new(TestOrderedClient::from_client(
-        store_client.clone(),
+    let ordered_client = Arc::new(TestOrderedClient::new(
+        PrefixedStoreClient::empty(store_client.clone()),
         op_cfg(),
         update_row_cfg(),
     ));
@@ -1079,8 +1079,8 @@ async fn ordered_range_connect_subscribe_emits_verifiable_range_proof() {
         *local.inactivity_floor > 0,
         "test must not rely on inactivity_floor = 0"
     );
-    let ordered_client = Arc::new(TestOrderedClient::from_client(
-        store_client.clone(),
+    let ordered_client = Arc::new(TestOrderedClient::new(
+        PrefixedStoreClient::empty(store_client.clone()),
         op_cfg(),
         update_row_cfg(),
     ));
@@ -1121,8 +1121,8 @@ async fn ordered_range_connect_client_rejects_invalid_streamed_proof() {
     let local = build_local_batch().await;
     commit_upload(&store_client, &local).await;
 
-    let ordered_client = Arc::new(TestOrderedClient::from_client(
-        store_client.clone(),
+    let ordered_client = Arc::new(TestOrderedClient::new(
+        PrefixedStoreClient::empty(store_client.clone()),
         op_cfg(),
         update_row_cfg(),
     ));
@@ -1169,8 +1169,8 @@ async fn ordered_range_connect_client_rejects_invalid_streamed_proof() {
 async fn ordered_range_connect_subscribe_emits_multi_proof_for_matching_keys() {
     let (_dir, _store_server, store_client) = common::local_store_client().await;
     let local = build_local_batch().await;
-    let ordered_client = Arc::new(TestOrderedClient::from_client(
-        store_client.clone(),
+    let ordered_client = Arc::new(TestOrderedClient::new(
+        PrefixedStoreClient::empty(store_client.clone()),
         op_cfg(),
         update_row_cfg(),
     ));
@@ -1212,8 +1212,8 @@ async fn ordered_mmb_range_connect_subscribe_verifies_range_and_multi_proofs() {
         *local.inactivity_floor > 0,
         "test must not rely on inactivity_floor = 0"
     );
-    let ordered_client = Arc::new(MmbTestOrderedClient::from_client(
-        store_client.clone(),
+    let ordered_client = Arc::new(MmbTestOrderedClient::new(
+        PrefixedStoreClient::empty(store_client.clone()),
         mmb_op_cfg(),
         update_row_cfg(),
     ));
@@ -1283,8 +1283,8 @@ async fn ordered_mmb_operation_log_any_sync_from_connect_api_reconstructs_any_db
     let expected_alpha = latest_mmb_value_for_key(&local.operations, b"alpha");
     commit_mmb_upload(&store_client, &local).await;
 
-    let ordered_client = Arc::new(MmbTestOrderedClient::from_client(
-        store_client.clone(),
+    let ordered_client = Arc::new(MmbTestOrderedClient::new(
+        PrefixedStoreClient::empty(store_client.clone()),
         mmb_op_cfg(),
         update_row_cfg(),
     ));
@@ -1356,8 +1356,8 @@ async fn ordered_mmb_operation_log_any_sync_from_nonzero_connect_api_reconstruct
     let expected_alpha = latest_mmb_value_for_key(&local.operations[start_index..], b"alpha");
     commit_mmb_upload(&store_client, &local).await;
 
-    let ordered_client = Arc::new(MmbTestOrderedClient::from_client(
-        store_client.clone(),
+    let ordered_client = Arc::new(MmbTestOrderedClient::new(
+        PrefixedStoreClient::empty(store_client.clone()),
         mmb_op_cfg(),
         update_row_cfg(),
     ));
@@ -1447,8 +1447,8 @@ async fn ordered_mmb_operation_log_any_sync_accepts_target_update_from_growing_b
         latest_mmb_value_for_key(&local.updated.operations[start_index..], b"alpha");
     commit_mmb_upload(&store_client, &local.initial).await;
 
-    let ordered_client = Arc::new(MmbTestOrderedClient::from_client(
-        store_client.clone(),
+    let ordered_client = Arc::new(MmbTestOrderedClient::new(
+        PrefixedStoreClient::empty(store_client.clone()),
         mmb_op_cfg(),
         update_row_cfg(),
     ));
@@ -1539,8 +1539,8 @@ async fn ordered_mmb_operation_log_any_sync_accepts_target_update_from_growing_b
 async fn ordered_range_connect_subscribe_replays_since_cursor() {
     let (_dir, _store_server, store_client) = common::local_store_client().await;
     let local = build_local_batch().await;
-    let ordered_client = Arc::new(TestOrderedClient::from_client(
-        store_client.clone(),
+    let ordered_client = Arc::new(TestOrderedClient::new(
+        PrefixedStoreClient::empty(store_client.clone()),
         op_cfg(),
         update_row_cfg(),
     ));
@@ -1576,8 +1576,8 @@ async fn ordered_range_connect_subscribe_replays_since_cursor() {
 async fn ordered_range_connect_subscribe_matches_prefix_and_regex_filters() {
     let (_dir, _store_server, store_client) = common::local_store_client().await;
     let local = build_local_batch().await;
-    let ordered_client = Arc::new(TestOrderedClient::from_client(
-        store_client.clone(),
+    let ordered_client = Arc::new(TestOrderedClient::new(
+        PrefixedStoreClient::empty(store_client.clone()),
         op_cfg(),
         update_row_cfg(),
     ));
@@ -1632,8 +1632,8 @@ async fn ordered_range_connect_subscribe_matches_prefix_and_regex_filters() {
 async fn ordered_range_connect_subscribe_filters_by_value_regex_without_key() {
     let (_dir, _store_server, store_client) = common::local_store_client().await;
     let local = build_local_batch().await;
-    let ordered_client = Arc::new(TestOrderedClient::from_client(
-        store_client.clone(),
+    let ordered_client = Arc::new(TestOrderedClient::new(
+        PrefixedStoreClient::empty(store_client.clone()),
         op_cfg(),
         update_row_cfg(),
     ));
@@ -1672,8 +1672,8 @@ async fn ordered_range_connect_subscribe_filters_by_value_regex_without_key() {
 async fn ordered_range_connect_subscribe_intersects_key_and_value_filters() {
     let (_dir, _store_server, store_client) = common::local_store_client().await;
     let local = build_local_batch().await;
-    let ordered_client = Arc::new(TestOrderedClient::from_client(
-        store_client.clone(),
+    let ordered_client = Arc::new(TestOrderedClient::new(
+        PrefixedStoreClient::empty(store_client.clone()),
         op_cfg(),
         update_row_cfg(),
     ));

--- a/qmdb/rs/tests/e2e_ordered_range_connect.rs
+++ b/qmdb/rs/tests/e2e_ordered_range_connect.rs
@@ -478,7 +478,7 @@ async fn build_mmb_growing_local_batch() -> MmbGrowingLocalBatch {
 
 async fn commit_upload(client: &StoreClient, batch: &LocalBatch) {
     let writer: OrderedWriter<mmr::Family, Sha256, Vec<u8>, Vec<u8>, N> =
-        OrderedWriter::empty(client.clone());
+        OrderedWriter::fresh(client.clone());
     common::commit_ordered_upload(client, &writer, &batch.operations, &batch.current_boundary)
         .await
         .expect("commit upload");
@@ -486,7 +486,7 @@ async fn commit_upload(client: &StoreClient, batch: &LocalBatch) {
 
 async fn commit_mmb_upload(client: &StoreClient, batch: &MmbLocalBatch) {
     let writer: OrderedWriter<mmb::Family, Sha256, Vec<u8>, Vec<u8>, N> =
-        OrderedWriter::empty(client.clone());
+        OrderedWriter::fresh(client.clone());
     common::commit_ordered_upload(client, &writer, &batch.operations, &batch.current_boundary)
         .await
         .expect("commit upload");

--- a/qmdb/rs/tests/e2e_ordered_writer.rs
+++ b/qmdb/rs/tests/e2e_ordered_writer.rs
@@ -18,7 +18,7 @@ use commonware_utils::{NZUsize, NZU16, NZU64};
 use exoware_qmdb::{
     recover_boundary_state, CurrentBoundaryState, OrderedClient, OrderedWriter, MAX_OPERATION_SIZE,
 };
-use exoware_sdk::StoreClient;
+use exoware_sdk::{PrefixedStoreClient, StoreClient};
 
 use common::retry;
 
@@ -100,11 +100,11 @@ fn update_row_cfg() -> (
 }
 
 fn fresh_reader(c: StoreClient) -> TestReader {
-    TestReader::from_client(c, op_cfg(), update_row_cfg())
+    TestReader::new(PrefixedStoreClient::empty(c), op_cfg(), update_row_cfg())
 }
 
 fn fresh_writer(c: StoreClient) -> TestWriter {
-    TestWriter::fresh(c)
+    TestWriter::fresh(PrefixedStoreClient::empty(c))
 }
 
 struct LocalReference {

--- a/qmdb/rs/tests/e2e_ordered_writer.rs
+++ b/qmdb/rs/tests/e2e_ordered_writer.rs
@@ -185,7 +185,7 @@ async fn sequential_upload_matches_local_root() {
 
     let writer = fresh_writer(client.clone());
     let receipt =
-        common::commit_ordered_upload(&client, &writer, &local.operations, &local.current_boundary)
+        common::commit_ordered_upload(&writer, &local.operations, &local.current_boundary)
             .await
             .expect("upload");
     assert_eq!(receipt.latest_location, local.latest_location);
@@ -238,13 +238,10 @@ async fn pipelined_batches_require_flush_to_catch_up_watermark() {
     let w1 = writer.clone();
     let w2 = writer.clone();
     let w3 = writer.clone();
-    let c1 = client.clone();
-    let c2 = client.clone();
-    let c3 = client.clone();
     let (r1, r2, r3) = tokio::join!(
-        async move { common::commit_ordered_upload(&c1, &w1, &ops1, &after1.current_boundary).await },
-        async move { common::commit_ordered_upload(&c2, &w2, &ops2, &after2.current_boundary).await },
-        async move { common::commit_ordered_upload(&c3, &w3, &ops3, &after3.current_boundary).await }
+        async move { common::commit_ordered_upload(&w1, &ops1, &after1.current_boundary).await },
+        async move { common::commit_ordered_upload(&w2, &ops2, &after2.current_boundary).await },
+        async move { common::commit_ordered_upload(&w3, &ops3, &after3.current_boundary).await }
     );
     let _ = r1.expect("b1");
     let _ = r2.expect("b2");

--- a/qmdb/rs/tests/e2e_ordered_writer.rs
+++ b/qmdb/rs/tests/e2e_ordered_writer.rs
@@ -104,7 +104,7 @@ fn fresh_reader(c: StoreClient) -> TestReader {
 }
 
 fn fresh_writer(c: StoreClient) -> TestWriter {
-    TestWriter::empty(c)
+    TestWriter::fresh(c)
 }
 
 struct LocalReference {

--- a/qmdb/rs/tests/e2e_unordered.rs
+++ b/qmdb/rs/tests/e2e_unordered.rs
@@ -19,6 +19,7 @@ use commonware_storage::qmdb::any::value::FixedEncoding;
 use commonware_storage::translator::TwoCap;
 use commonware_utils::{NZUsize, NZU16, NZU64};
 use exoware_qmdb::{UnorderedClient, UnorderedWriter, MAX_OPERATION_SIZE};
+use exoware_sdk::PrefixedStoreClient;
 
 type Digest = commonware_cryptography::sha256::Digest;
 type BatchProof = Proof<mmr::Family, Digest>;
@@ -198,12 +199,12 @@ async fn unordered_round_trip() {
     let local = build_local_db().await;
 
     let writer: UnorderedWriter<mmr::Family, Sha256, Vec<u8>, Vec<u8>> =
-        UnorderedWriter::fresh(client.clone());
+        UnorderedWriter::fresh(PrefixedStoreClient::empty(client.clone()));
     common::commit_unordered_upload(&client, &writer, &local.operations)
         .await
         .expect("commit upload");
 
-    let c = TestUnorderedClient::from_client(client.clone(), op_cfg());
+    let c = TestUnorderedClient::new(PrefixedStoreClient::empty(client.clone()), op_cfg());
     let watermark = c.writer_location_watermark().await.expect("watermark");
     assert_eq!(watermark, Some(local.latest_location));
 
@@ -240,12 +241,12 @@ async fn unordered_fixed_round_trip() {
     let local = build_fixed_local_db().await;
 
     let writer: UnorderedWriter<mmr::Family, Sha256, Digest, Digest, FixedEncoding<Digest>> =
-        UnorderedWriter::fresh(client.clone());
+        UnorderedWriter::fresh(PrefixedStoreClient::empty(client.clone()));
     common::commit_unordered_upload(&client, &writer, &local.operations)
         .await
         .expect("commit fixed upload");
 
-    let c = FixedTestUnorderedClient::from_client(client.clone(), ());
+    let c = FixedTestUnorderedClient::new(PrefixedStoreClient::empty(client.clone()), ());
     let watermark = c.writer_location_watermark().await.expect("watermark");
     assert_eq!(watermark, Some(local.latest_location));
 

--- a/qmdb/rs/tests/e2e_unordered.rs
+++ b/qmdb/rs/tests/e2e_unordered.rs
@@ -198,7 +198,7 @@ async fn unordered_round_trip() {
     let local = build_local_db().await;
 
     let writer: UnorderedWriter<mmr::Family, Sha256, Vec<u8>, Vec<u8>> =
-        UnorderedWriter::empty(client.clone());
+        UnorderedWriter::fresh(client.clone());
     common::commit_unordered_upload(&client, &writer, &local.operations)
         .await
         .expect("commit upload");
@@ -240,7 +240,7 @@ async fn unordered_fixed_round_trip() {
     let local = build_fixed_local_db().await;
 
     let writer: UnorderedWriter<mmr::Family, Sha256, Digest, Digest, FixedEncoding<Digest>> =
-        UnorderedWriter::empty(client.clone());
+        UnorderedWriter::fresh(client.clone());
     common::commit_unordered_upload(&client, &writer, &local.operations)
         .await
         .expect("commit fixed upload");

--- a/qmdb/rs/tests/e2e_unordered.rs
+++ b/qmdb/rs/tests/e2e_unordered.rs
@@ -200,7 +200,7 @@ async fn unordered_round_trip() {
 
     let writer: UnorderedWriter<mmr::Family, Sha256, Vec<u8>, Vec<u8>> =
         UnorderedWriter::fresh(PrefixedStoreClient::empty(client.clone()));
-    common::commit_unordered_upload(&client, &writer, &local.operations)
+    common::commit_unordered_upload(&writer, &local.operations)
         .await
         .expect("commit upload");
 
@@ -242,7 +242,7 @@ async fn unordered_fixed_round_trip() {
 
     let writer: UnorderedWriter<mmr::Family, Sha256, Digest, Digest, FixedEncoding<Digest>> =
         UnorderedWriter::fresh(PrefixedStoreClient::empty(client.clone()));
-    common::commit_unordered_upload(&client, &writer, &local.operations)
+    common::commit_unordered_upload(&writer, &local.operations)
         .await
         .expect("commit fixed upload");
 

--- a/qmdb/rs/tests/e2e_unordered_connect.rs
+++ b/qmdb/rs/tests/e2e_unordered_connect.rs
@@ -31,7 +31,7 @@ use exoware_qmdb::{
     QmdbError, UnorderedClient, UnorderedConnectClient, UnorderedWriter, MAX_OPERATION_SIZE,
 };
 use exoware_sdk::proto::PreferZstdHttpClient;
-use exoware_sdk::StoreClient;
+use exoware_sdk::{PrefixedStoreClient, StoreClient};
 
 const N: usize = 32;
 type Digest = commonware_cryptography::sha256::Digest;
@@ -431,7 +431,7 @@ async fn build_fixed_local_batch() -> FixedLocalBatch {
 
 async fn commit_upload(client: &StoreClient, batch: &LocalBatch) {
     let writer: UnorderedWriter<mmr::Family, Sha256, Vec<u8>, Vec<u8>> =
-        UnorderedWriter::fresh(client.clone());
+        UnorderedWriter::fresh(PrefixedStoreClient::empty(client.clone()));
     common::commit_unordered_upload(client, &writer, &batch.operations)
         .await
         .expect("commit upload");
@@ -439,7 +439,7 @@ async fn commit_upload(client: &StoreClient, batch: &LocalBatch) {
 
 async fn commit_mmb_upload(client: &StoreClient, batch: &MmbLocalBatch) {
     let writer: UnorderedWriter<mmb::Family, Sha256, Vec<u8>, Vec<u8>> =
-        UnorderedWriter::fresh(client.clone());
+        UnorderedWriter::fresh(PrefixedStoreClient::empty(client.clone()));
     common::commit_unordered_upload(client, &writer, &batch.operations)
         .await
         .expect("commit upload");
@@ -447,7 +447,7 @@ async fn commit_mmb_upload(client: &StoreClient, batch: &MmbLocalBatch) {
 
 async fn commit_fixed_upload(client: &StoreClient, batch: &FixedLocalBatch) {
     let writer: UnorderedWriter<mmr::Family, Sha256, Digest, Vec<u8>> =
-        UnorderedWriter::fresh(client.clone());
+        UnorderedWriter::fresh(PrefixedStoreClient::empty(client.clone()));
     common::commit_unordered_current_upload::<_, _, _, _, N, _>(
         client,
         &writer,
@@ -481,7 +481,10 @@ fn latest_fixed_operation_for_key(
 #[tokio::test]
 async fn unordered_range_stack_does_not_expose_key_lookup_or_ordered_range_services() {
     let (_dir, _store_server, store_client) = common::local_store_client().await;
-    let unordered_client = Arc::new(TestUnorderedClient::from_client(store_client, op_cfg()));
+    let unordered_client = Arc::new(TestUnorderedClient::new(
+        PrefixedStoreClient::empty(store_client),
+        op_cfg(),
+    ));
     let (_qmdb_server, qmdb_url) = spawn_qmdb_range_server(unordered_client).await;
 
     let err = key_lookup_rpc_client(&qmdb_url)
@@ -512,7 +515,10 @@ async fn unordered_connect_get_operation_range_returns_verifiable_proof() {
     let local = build_local_batch().await;
     commit_upload(&store_client, &local).await;
 
-    let unordered_client = Arc::new(TestUnorderedClient::from_client(store_client, op_cfg()));
+    let unordered_client = Arc::new(TestUnorderedClient::new(
+        PrefixedStoreClient::empty(store_client),
+        op_cfg(),
+    ));
     let (_qmdb_server, qmdb_url) = spawn_qmdb_range_server(unordered_client).await;
     let client = validated_client(&qmdb_url);
 
@@ -543,8 +549,8 @@ async fn unordered_connect_get_many_returns_present_key_proofs() {
     let local = build_fixed_local_batch().await;
     commit_fixed_upload(&store_client, &local).await;
 
-    let unordered_client = Arc::new(FixedTestUnorderedClient::from_client(
-        store_client,
+    let unordered_client = Arc::new(FixedTestUnorderedClient::new(
+        PrefixedStoreClient::empty(store_client),
         fixed_op_cfg(),
     ));
     let (_qmdb_server, qmdb_url) = spawn_qmdb_full_server(unordered_client).await;
@@ -593,8 +599,8 @@ async fn unordered_current_operation_range_connect_returns_verifiable_proof() {
     let local = build_fixed_local_batch().await;
     commit_fixed_upload(&store_client, &local).await;
 
-    let unordered_client = Arc::new(FixedTestUnorderedClient::from_client(
-        store_client,
+    let unordered_client = Arc::new(FixedTestUnorderedClient::new(
+        PrefixedStoreClient::empty(store_client),
         fixed_op_cfg(),
     ));
     let (_qmdb_server, qmdb_url) = spawn_qmdb_full_server(unordered_client).await;
@@ -631,8 +637,8 @@ async fn unordered_connect_omits_missing_and_rejects_duplicate_range_and_stale_r
     let local = build_fixed_local_batch().await;
     commit_fixed_upload(&store_client, &local).await;
 
-    let unordered_client = Arc::new(FixedTestUnorderedClient::from_client(
-        store_client,
+    let unordered_client = Arc::new(FixedTestUnorderedClient::new(
+        PrefixedStoreClient::empty(store_client),
         fixed_op_cfg(),
     ));
     let (_qmdb_server, qmdb_url) = spawn_qmdb_full_server(unordered_client).await;
@@ -704,8 +710,8 @@ async fn unordered_connect_subscribe_emits_verifiable_range_proof() {
         *local.inactivity_floor > 0,
         "test must not rely on inactivity_floor = 0"
     );
-    let unordered_client = Arc::new(TestUnorderedClient::from_client(
-        store_client.clone(),
+    let unordered_client = Arc::new(TestUnorderedClient::new(
+        PrefixedStoreClient::empty(store_client.clone()),
         op_cfg(),
     ));
     let (_qmdb_server, qmdb_url) = spawn_qmdb_range_server(unordered_client).await;
@@ -747,8 +753,8 @@ async fn unordered_mmb_connect_subscribe_emits_verifiable_range_proof() {
         *local.inactivity_floor > 0,
         "test must not rely on inactivity_floor = 0"
     );
-    let unordered_client = Arc::new(MmbTestUnorderedClient::from_client(
-        store_client.clone(),
+    let unordered_client = Arc::new(MmbTestUnorderedClient::new(
+        PrefixedStoreClient::empty(store_client.clone()),
         mmb_op_cfg(),
     ));
     let (_qmdb_server, qmdb_url) = spawn_mmb_qmdb_range_server(unordered_client).await;
@@ -788,8 +794,8 @@ async fn unordered_connect_client_rejects_invalid_streamed_proof() {
     let local = build_local_batch().await;
     commit_upload(&store_client, &local).await;
 
-    let unordered_client = Arc::new(TestUnorderedClient::from_client(
-        store_client.clone(),
+    let unordered_client = Arc::new(TestUnorderedClient::new(
+        PrefixedStoreClient::empty(store_client.clone()),
         op_cfg(),
     ));
     let (_qmdb_server, qmdb_url) = spawn_qmdb_range_server(unordered_client).await;

--- a/qmdb/rs/tests/e2e_unordered_connect.rs
+++ b/qmdb/rs/tests/e2e_unordered_connect.rs
@@ -431,7 +431,7 @@ async fn build_fixed_local_batch() -> FixedLocalBatch {
 
 async fn commit_upload(client: &StoreClient, batch: &LocalBatch) {
     let writer: UnorderedWriter<mmr::Family, Sha256, Vec<u8>, Vec<u8>> =
-        UnorderedWriter::empty(client.clone());
+        UnorderedWriter::fresh(client.clone());
     common::commit_unordered_upload(client, &writer, &batch.operations)
         .await
         .expect("commit upload");
@@ -439,7 +439,7 @@ async fn commit_upload(client: &StoreClient, batch: &LocalBatch) {
 
 async fn commit_mmb_upload(client: &StoreClient, batch: &MmbLocalBatch) {
     let writer: UnorderedWriter<mmb::Family, Sha256, Vec<u8>, Vec<u8>> =
-        UnorderedWriter::empty(client.clone());
+        UnorderedWriter::fresh(client.clone());
     common::commit_unordered_upload(client, &writer, &batch.operations)
         .await
         .expect("commit upload");
@@ -447,7 +447,7 @@ async fn commit_mmb_upload(client: &StoreClient, batch: &MmbLocalBatch) {
 
 async fn commit_fixed_upload(client: &StoreClient, batch: &FixedLocalBatch) {
     let writer: UnorderedWriter<mmr::Family, Sha256, Digest, Vec<u8>> =
-        UnorderedWriter::empty(client.clone());
+        UnorderedWriter::fresh(client.clone());
     common::commit_unordered_current_upload::<_, _, _, _, N, _>(
         client,
         &writer,

--- a/qmdb/rs/tests/e2e_unordered_connect.rs
+++ b/qmdb/rs/tests/e2e_unordered_connect.rs
@@ -432,7 +432,7 @@ async fn build_fixed_local_batch() -> FixedLocalBatch {
 async fn commit_upload(client: &StoreClient, batch: &LocalBatch) {
     let writer: UnorderedWriter<mmr::Family, Sha256, Vec<u8>, Vec<u8>> =
         UnorderedWriter::fresh(PrefixedStoreClient::empty(client.clone()));
-    common::commit_unordered_upload(client, &writer, &batch.operations)
+    common::commit_unordered_upload(&writer, &batch.operations)
         .await
         .expect("commit upload");
 }
@@ -440,7 +440,7 @@ async fn commit_upload(client: &StoreClient, batch: &LocalBatch) {
 async fn commit_mmb_upload(client: &StoreClient, batch: &MmbLocalBatch) {
     let writer: UnorderedWriter<mmb::Family, Sha256, Vec<u8>, Vec<u8>> =
         UnorderedWriter::fresh(PrefixedStoreClient::empty(client.clone()));
-    common::commit_unordered_upload(client, &writer, &batch.operations)
+    common::commit_unordered_upload(&writer, &batch.operations)
         .await
         .expect("commit upload");
 }
@@ -449,7 +449,6 @@ async fn commit_fixed_upload(client: &StoreClient, batch: &FixedLocalBatch) {
     let writer: UnorderedWriter<mmr::Family, Sha256, Digest, Vec<u8>> =
         UnorderedWriter::fresh(PrefixedStoreClient::empty(client.clone()));
     common::commit_unordered_current_upload::<_, _, _, _, N, _>(
-        client,
         &writer,
         &batch.operations,
         &batch.current_boundary,

--- a/qmdb/rs/tests/e2e_unordered_writer.rs
+++ b/qmdb/rs/tests/e2e_unordered_writer.rs
@@ -117,7 +117,7 @@ async fn sequential_upload_matches_local_root() {
     .await;
 
     let writer = fresh_writer(client.clone());
-    let receipt = common::commit_unordered_upload(&client, &writer, &local.operations)
+    let receipt = common::commit_unordered_upload(&writer, &local.operations)
         .await
         .expect("upload");
     assert_eq!(receipt.latest_location, local.latest_location);
@@ -159,13 +159,10 @@ async fn pipelined_batches_require_flush_to_catch_up_watermark() {
     let w1 = writer.clone();
     let w2 = writer.clone();
     let w3 = writer.clone();
-    let c1 = client.clone();
-    let c2 = client.clone();
-    let c3 = client.clone();
     let (r1, r2, r3) = tokio::join!(
-        async move { common::commit_unordered_upload(&c1, &w1, &o1).await },
-        async move { common::commit_unordered_upload(&c2, &w2, &o2).await },
-        async move { common::commit_unordered_upload(&c3, &w3, &o3).await }
+        async move { common::commit_unordered_upload(&w1, &o1).await },
+        async move { common::commit_unordered_upload(&w2, &o2).await },
+        async move { common::commit_unordered_upload(&w3, &o3).await }
     );
     let _ = r1.expect("b1");
     let _ = r2.expect("b2");

--- a/qmdb/rs/tests/e2e_unordered_writer.rs
+++ b/qmdb/rs/tests/e2e_unordered_writer.rs
@@ -16,7 +16,7 @@ use commonware_storage::qmdb::any::unordered::variable::Operation as UnorderedQm
 use commonware_storage::translator::TwoCap;
 use commonware_utils::{NZUsize, NZU16, NZU64};
 use exoware_qmdb::{UnorderedClient, UnorderedWriter, MAX_OPERATION_SIZE};
-use exoware_sdk::StoreClient;
+use exoware_sdk::{PrefixedStoreClient, StoreClient};
 
 use common::retry;
 
@@ -43,11 +43,11 @@ fn op_cfg() -> <UnorderedBatchOperation as commonware_codec::Read>::Cfg {
 }
 
 fn fresh_reader(c: StoreClient) -> TestReader {
-    TestReader::from_client(c, op_cfg())
+    TestReader::new(PrefixedStoreClient::empty(c), op_cfg())
 }
 
 fn fresh_writer(c: StoreClient) -> TestWriter {
-    TestWriter::fresh(c)
+    TestWriter::fresh(PrefixedStoreClient::empty(c))
 }
 
 struct LocalReference {

--- a/qmdb/rs/tests/e2e_unordered_writer.rs
+++ b/qmdb/rs/tests/e2e_unordered_writer.rs
@@ -47,7 +47,7 @@ fn fresh_reader(c: StoreClient) -> TestReader {
 }
 
 fn fresh_writer(c: StoreClient) -> TestWriter {
-    TestWriter::empty(c)
+    TestWriter::fresh(c)
 }
 
 struct LocalReference {

--- a/sdk/rs/src/lib.rs
+++ b/sdk/rs/src/lib.rs
@@ -398,7 +398,7 @@ impl PrefixedStoreClient {
                 let scope = match &policy.scope {
                     PolicyScope::Keys(scope) => {
                         let mut scope = scope.clone();
-                        scope.match_key = self.prefix.prefix_match_key(&scope.match_key)?;
+                        scope.selector = self.prefix.prefix_selector(&scope.selector)?;
                         PolicyScope::Keys(scope)
                     }
                     PolicyScope::Sequence => PolicyScope::Sequence,
@@ -416,13 +416,13 @@ impl PrefixedStoreClient {
         &self,
         filter: crate::stream_filter::StreamFilter,
     ) -> Result<crate::stream_filter::StreamFilter, ClientError> {
-        let match_keys = filter
-            .match_keys
+        let selectors = filter
+            .selectors
             .iter()
-            .map(|mk| self.prefix.prefix_stream_match_key(mk))
+            .map(|mk| self.prefix.prefix_stream_selector(mk))
             .collect::<Result<Vec<_>, _>>()?;
         Ok(crate::stream_filter::StreamFilter {
-            match_keys,
+            selectors,
             value_filters: filter.value_filters,
         })
     }
@@ -1998,10 +1998,10 @@ impl StoreClient {
     ) -> Result<StreamSubscription, ClientError> {
         crate::stream_filter::validate_filter(&filter)
             .map_err(|e| ClientError::WireFormat(e.to_string()))?;
-        let match_keys = filter
-            .match_keys
+        let selectors = filter
+            .selectors
             .into_iter()
-            .map(|mk| exoware_proto::store::common::v1::MatchKey {
+            .map(|mk| exoware_proto::common::kv::v1::Selector {
                 reserved_bits: u32::from(mk.reserved_bits),
                 prefix: u32::from(mk.prefix),
                 payload_regex: mk.payload_regex.0,
@@ -2012,21 +2012,21 @@ impl StoreClient {
             .value_filters
             .into_iter()
             .map(|vf| {
-                use crate::stream_filter::BytesFilter;
-                use exoware_proto::store::common::v1::bytes_filter::Kind as ProtoKind;
+                use crate::stream_filter::Filter;
+                use exoware_proto::common::kv::v1::filter::Kind as ProtoKind;
                 let kind = match vf {
-                    BytesFilter::Exact(bytes) => ProtoKind::Exact(bytes),
-                    BytesFilter::Prefix(bytes) => ProtoKind::Prefix(bytes),
-                    BytesFilter::Regex(pattern) => ProtoKind::Regex(pattern),
+                    Filter::Exact(bytes) => ProtoKind::Exact(bytes),
+                    Filter::Prefix(bytes) => ProtoKind::Prefix(bytes),
+                    Filter::Regex(pattern) => ProtoKind::Regex(pattern),
                 };
-                exoware_proto::store::common::v1::BytesFilter {
+                exoware_proto::common::kv::v1::Filter {
                     kind: Some(kind),
                     ..Default::default()
                 }
             })
             .collect();
-        let request = exoware_proto::store::stream::v1::SubscribeRequest {
-            match_keys,
+        let request = exoware_proto::log::stream::v1::SubscribeRequest {
+            selectors,
             value_filters,
             since_sequence_number,
             ..Default::default()
@@ -2034,7 +2034,7 @@ impl StoreClient {
         let config =
             store_connect_client_config(self.stream_uri.clone(), self.connect_request_compression);
         let client =
-            exoware_proto::store::stream::v1::ServiceClient::new(self.connect_http.clone(), config);
+            exoware_proto::log::stream::v1::ServiceClient::new(self.connect_http.clone(), config);
         let stream = client
             .subscribe(request)
             .await
@@ -2053,13 +2053,13 @@ impl StoreClient {
     async fn stream_get_physical(
         &self,
         sequence_number: u64,
-    ) -> Result<Option<exoware_proto::store::stream::v1::GetResponse>, ClientError> {
+    ) -> Result<Option<exoware_proto::log::stream::v1::GetResponse>, ClientError> {
         let config =
             store_connect_client_config(self.stream_uri.clone(), self.connect_request_compression);
         let client =
-            exoware_proto::store::stream::v1::ServiceClient::new(self.connect_http.clone(), config);
+            exoware_proto::log::stream::v1::ServiceClient::new(self.connect_http.clone(), config);
         match client
-            .get(exoware_proto::store::stream::v1::GetRequest {
+            .get(exoware_proto::log::stream::v1::GetRequest {
                 sequence_number,
                 ..Default::default()
             })

--- a/sdk/rs/src/lib.rs
+++ b/sdk/rs/src/lib.rs
@@ -228,6 +228,15 @@ impl StoreKeyPrefix {
         })
     }
 
+    /// The zero-width identity prefix: reserves no bits and maps every logical
+    /// key to itself, so encode/decode/range/match are all no-ops and keys pass
+    /// through un-namespaced.
+    pub const fn identity() -> Self {
+        Self {
+            codec: KeyCodec::new(0, 0),
+        }
+    }
+
     #[inline]
     pub fn reserved_bits(self) -> u8 {
         self.codec.reserved_bits()
@@ -341,12 +350,11 @@ pub const NAMESPACE_INSTANCE_BITS: u8 = 1;
 
 /// Total reserved high bits in *every* namespace key prefix (slot + instance).
 ///
-/// The width is uniform across all namespaces and instances — that uniformity
-/// is what makes the scheme footgun-free: every prefix is the same length, so
-/// distinct prefixes are pairwise prefix-disjoint and no "bare" namespace can
-/// ever be a bit-prefix of one of its own instances. These bits sit *above*
-/// each subsystem's own internal reserved bits; the combined width stays within
-/// the 16-bit budget the codec enforces.
+/// The width is uniform across all namespaces and instances, so distinct
+/// prefixes are pairwise prefix-disjoint: no prefix is a bit-prefix of another,
+/// not even a bare namespace versus its own instances. These bits sit *above*
+/// each subsystem's own reserved bits; the combined width stays within the
+/// codec's 16-bit budget.
 pub const NAMESPACE_RESERVED_BITS: u8 = NAMESPACE_SLOT_BITS + NAMESPACE_INSTANCE_BITS;
 
 /// Canonical key-prefix allocation for the SDK's built-in subsystems when they
@@ -405,50 +413,557 @@ impl Namespace {
     }
 }
 
-/// A [`StoreClient`] guaranteed to carry a [`StoreKeyPrefix`].
+/// The sole logical Store client: a physical [`StoreClient`] paired with a
+/// [`StoreKeyPrefix`] that namespaces every key on the wire.
 ///
-/// Constructable only from a `(client, prefix)` pair, so a value of this type is
-/// *always* namespaced. Subsystem constructors that must not silently share a
-/// raw keyspace take this type instead of a bare [`StoreClient`], turning "did
-/// you namespace?" into a compile-time fact.
+/// `StoreClient` itself is purely physical — it has no notion of a prefix — so
+/// this type is the *only* way to perform namespaced reads and writes. All key
+/// translation (encode on the way out, decode on the way back) lives here.
 ///
-/// Intentionally does **not** `Deref` to [`StoreClient`]: that would re-expose
-/// [`StoreClient::without_key_prefix`] and let callers quietly drop the
-/// guarantee.
+/// Because the prefix can be the zero-width [`StoreKeyPrefix::identity`], this
+/// single type also represents the un-namespaced case; there is no separate
+/// "raw client" surface that could silently skip namespacing.
 #[derive(Clone, Debug)]
 pub struct PrefixedStoreClient {
     client: StoreClient,
+    prefix: StoreKeyPrefix,
 }
 
 impl PrefixedStoreClient {
-    /// Wrap a client with an explicit namespace prefix.
-    pub fn new(mut client: StoreClient, prefix: StoreKeyPrefix) -> Self {
-        // Owned, so set the prefix in place instead of cloning via `with_key_prefix`.
-        client.key_prefix = Some(prefix);
-        Self { client }
+    /// Pair a physical client with an explicit namespace prefix.
+    pub fn new(client: StoreClient, prefix: StoreKeyPrefix) -> Self {
+        Self { client, prefix }
     }
 
-    /// Wrap a client with the canonical prefix for a built-in [`Namespace`].
+    /// Pair a physical client with the canonical prefix for a built-in
+    /// [`Namespace`].
     pub fn for_namespace(client: StoreClient, namespace: Namespace) -> Self {
         Self::new(client, namespace.key_prefix())
     }
 
-    /// The configured key prefix (always present).
-    pub fn key_prefix(&self) -> StoreKeyPrefix {
-        self.client
-            .key_prefix()
-            .expect("PrefixedStoreClient always carries a prefix")
+    /// Pair a physical client with the zero-width [`StoreKeyPrefix::identity`],
+    /// so keys pass through untranslated.
+    pub fn empty(client: StoreClient) -> Self {
+        Self::new(client, StoreKeyPrefix::identity())
     }
 
-    /// Borrow the underlying prefixed client for read/write operations.
+    /// The configured key prefix.
+    pub fn key_prefix(&self) -> StoreKeyPrefix {
+        self.prefix
+    }
+
+    /// Borrow the underlying physical transport. Operations performed directly
+    /// on it are *not* namespaced; prefer the methods on this type.
     pub fn client(&self) -> &StoreClient {
         &self.client
     }
 
-    /// Consume into the underlying (prefixed) client.
-    pub fn into_client(self) -> StoreClient {
-        self.client
+    // --- key translation -----------------------------------------------------
+
+    /// Encode a logical key as it will appear in the physical Store.
+    pub fn encode_store_key(&self, key: &Key) -> Result<Key, ClientError> {
+        Ok(self.prefix.encode_key(key)?)
     }
+
+    /// Decode a physical Store key into this client's logical keyspace.
+    pub fn decode_store_key(&self, key: &Key) -> Result<Key, ClientError> {
+        Ok(self.prefix.decode_key(key)?)
+    }
+
+    fn encode_store_range(&self, start: &Key, end: &Key) -> Result<(Key, Key), ClientError> {
+        Ok(self.prefix.encode_range(start, end)?)
+    }
+
+    fn prefix_prune_policies(
+        &self,
+        policies: &[crate::prune_policy::PrunePolicy],
+    ) -> Result<Vec<crate::prune_policy::PrunePolicy>, ClientError> {
+        policies
+            .iter()
+            .map(|policy| {
+                use crate::prune_policy::{PolicyScope, PrunePolicy};
+                let scope = match &policy.scope {
+                    PolicyScope::Keys(scope) => {
+                        let mut scope = scope.clone();
+                        scope.match_key = self.prefix.prefix_match_key(&scope.match_key)?;
+                        PolicyScope::Keys(scope)
+                    }
+                    PolicyScope::Sequence => PolicyScope::Sequence,
+                };
+                Ok(PrunePolicy {
+                    scope,
+                    retain: policy.retain.clone(),
+                })
+            })
+            .collect::<Result<Vec<_>, StoreKeyPrefixError>>()
+            .map_err(ClientError::from)
+    }
+
+    fn prefix_stream_filter(
+        &self,
+        filter: crate::stream_filter::StreamFilter,
+    ) -> Result<crate::stream_filter::StreamFilter, ClientError> {
+        let match_keys = filter
+            .match_keys
+            .iter()
+            .map(|mk| self.prefix.prefix_stream_match_key(mk))
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(crate::stream_filter::StreamFilter {
+            match_keys,
+            value_filters: filter.value_filters,
+        })
+    }
+
+    fn prefix_reduce_request(
+        &self,
+        request: &DomainRangeReduceRequest,
+    ) -> Result<DomainRangeReduceRequest, ClientError> {
+        let mut request = request.clone();
+        shift_reduce_request_key_offsets(self.prefix.reserved_bits(), &mut request)?;
+        Ok(request)
+    }
+
+    // --- service-grouped accessors -------------------------------------------
+
+    /// Typed access to the `store.ingest.v1` service.
+    pub fn ingest(&self) -> Ingest<'_> {
+        Ingest { c: self }
+    }
+
+    /// Typed access to the `store.query.v1` service.
+    pub fn query(&self) -> Query<'_> {
+        Query { c: self }
+    }
+
+    /// Typed access to the `store.compact.v1` service.
+    pub fn compact(&self) -> Compact<'_> {
+        Compact { c: self }
+    }
+
+    /// Typed access to the `store.stream.v1` service.
+    pub fn stream(&self) -> Stream<'_> {
+        Stream { c: self }
+    }
+
+    /// Create an unseeded serializable read session over this namespace.
+    pub fn create_session(&self) -> SerializableReadSession {
+        self.create_session_with_sequence(0)
+    }
+
+    /// Create a serializable read session pinned to at least `sequence`.
+    pub fn create_session_with_sequence(&self, sequence: u64) -> SerializableReadSession {
+        SerializableReadSession {
+            client: self.clone(),
+            state: Arc::new(SessionState {
+                sequence: Arc::new(AtomicU64::new(sequence)),
+                init_gate: tokio::sync::Mutex::new(()),
+            }),
+        }
+    }
+
+    // --- writes --------------------------------------------------------------
+
+    pub(crate) async fn put(&self, kvs: &[(&Key, &[u8])]) -> Result<u64, ClientError> {
+        let keys = kvs
+            .iter()
+            .map(|(key, _)| self.encode_store_key(key))
+            .collect::<Result<Vec<_>, _>>()?;
+        let prefixed: Vec<(&Key, &[u8])> = keys
+            .iter()
+            .zip(kvs.iter())
+            .map(|(key, (_, value))| (key, *value))
+            .collect();
+        self.client.put_physical(&prefixed).await
+    }
+
+    /// Submit an already-prepared (physical) batch.
+    pub(crate) async fn put_prepared_physical(
+        &self,
+        kvs: &[(Key, Bytes)],
+    ) -> Result<u64, ClientError> {
+        self.client.put_prepared_physical(kvs).await
+    }
+
+    // --- reads ---------------------------------------------------------------
+
+    pub(crate) async fn send_get(
+        &self,
+        key: &Key,
+        min_sequence_number: Option<u64>,
+    ) -> Result<
+        (
+            exoware_proto::query::GetResponse,
+            Option<proto_query::Detail>,
+        ),
+        ClientError,
+    > {
+        self.client
+            .send_get(&self.encode_store_key(key)?, min_sequence_number)
+            .await
+    }
+
+    pub(crate) async fn get(&self, key: &Key) -> Result<Option<Bytes>, ClientError> {
+        self.client.get(&self.encode_store_key(key)?).await
+    }
+
+    pub(crate) async fn get_with_min_sequence_number(
+        &self,
+        key: &Key,
+        min_sequence_number: u64,
+    ) -> Result<Option<Bytes>, ClientError> {
+        self.client
+            .get_with_min_sequence_number(&self.encode_store_key(key)?, min_sequence_number)
+            .await
+    }
+
+    pub(crate) async fn get_many(
+        &self,
+        keys: &[&Key],
+        batch_size: u32,
+    ) -> Result<GetManyStream, ClientError> {
+        self.get_many_internal(keys, batch_size, None, None).await
+    }
+
+    pub(crate) async fn get_many_with_min_sequence_number(
+        &self,
+        keys: &[&Key],
+        batch_size: u32,
+        min_sequence_number: u64,
+    ) -> Result<GetManyStream, ClientError> {
+        self.get_many_internal(keys, batch_size, Some(min_sequence_number), None)
+            .await
+    }
+
+    pub(crate) async fn get_many_internal(
+        &self,
+        keys: &[&Key],
+        batch_size: u32,
+        min_sequence_number: Option<u64>,
+        observed_sequence: Option<Arc<AtomicU64>>,
+    ) -> Result<GetManyStream, ClientError> {
+        let mut proto_keys: Vec<Vec<u8>> = Vec::with_capacity(keys.len());
+        for key in keys {
+            let encoded = self.encode_store_key(key)?;
+            if !is_valid_key_size(encoded.len()) {
+                return Err(ClientError::WireFormat(format!(
+                    "key length {} is outside valid store key range ({}..={})",
+                    encoded.len(),
+                    keys::MIN_KEY_LEN,
+                    MAX_KEY_LEN
+                )));
+            }
+            proto_keys.push(encoded.to_vec());
+        }
+        let mut stream = self
+            .client
+            .get_many_internal(
+                proto_keys,
+                batch_size,
+                min_sequence_number,
+                observed_sequence,
+            )
+            .await?;
+        stream.key_prefix = Some(self.prefix);
+        Ok(stream)
+    }
+
+    pub(crate) async fn range(
+        &self,
+        start: &Key,
+        end: &Key,
+        limit: usize,
+    ) -> Result<Vec<(Key, Bytes)>, ClientError> {
+        self.range_internal(start, end, limit, RangeMode::Forward, None)
+            .await
+    }
+
+    pub(crate) async fn range_with_mode(
+        &self,
+        start: &Key,
+        end: &Key,
+        limit: usize,
+        mode: RangeMode,
+    ) -> Result<Vec<(Key, Bytes)>, ClientError> {
+        self.range_internal(start, end, limit, mode, None).await
+    }
+
+    pub(crate) async fn range_with_min_sequence_number(
+        &self,
+        start: &Key,
+        end: &Key,
+        limit: usize,
+        min_sequence_number: u64,
+    ) -> Result<Vec<(Key, Bytes)>, ClientError> {
+        self.range_internal(
+            start,
+            end,
+            limit,
+            RangeMode::Forward,
+            Some(min_sequence_number),
+        )
+        .await
+    }
+
+    pub(crate) async fn range_with_mode_and_min_sequence_number(
+        &self,
+        start: &Key,
+        end: &Key,
+        limit: usize,
+        mode: RangeMode,
+        min_sequence_number: u64,
+    ) -> Result<Vec<(Key, Bytes)>, ClientError> {
+        self.range_internal(start, end, limit, mode, Some(min_sequence_number))
+            .await
+    }
+
+    async fn range_internal(
+        &self,
+        start: &Key,
+        end: &Key,
+        limit: usize,
+        mode: RangeMode,
+        min_sequence_number: Option<u64>,
+    ) -> Result<Vec<(Key, Bytes)>, ClientError> {
+        self.range_stream_internal(
+            start,
+            end,
+            limit,
+            limit.max(1),
+            mode,
+            RangeStreamReadOptions {
+                min_sequence_number,
+                observed_sequence: None,
+            },
+        )
+        .await?
+        .collect()
+        .await
+    }
+
+    pub(crate) async fn range_stream(
+        &self,
+        start: &Key,
+        end: &Key,
+        limit: usize,
+        batch_size: usize,
+    ) -> Result<RangeStream, ClientError> {
+        self.range_stream_internal(
+            start,
+            end,
+            limit,
+            batch_size,
+            RangeMode::Forward,
+            RangeStreamReadOptions::default(),
+        )
+        .await
+    }
+
+    pub(crate) async fn range_stream_with_mode(
+        &self,
+        start: &Key,
+        end: &Key,
+        limit: usize,
+        batch_size: usize,
+        mode: RangeMode,
+    ) -> Result<RangeStream, ClientError> {
+        self.range_stream_internal(start, end, limit, batch_size, mode, Default::default())
+            .await
+    }
+
+    pub(crate) async fn range_stream_with_min_sequence_number(
+        &self,
+        start: &Key,
+        end: &Key,
+        limit: usize,
+        batch_size: usize,
+        min_sequence_number: u64,
+    ) -> Result<RangeStream, ClientError> {
+        self.range_stream_internal(
+            start,
+            end,
+            limit,
+            batch_size,
+            RangeMode::Forward,
+            RangeStreamReadOptions {
+                min_sequence_number: Some(min_sequence_number),
+                observed_sequence: None,
+            },
+        )
+        .await
+    }
+
+    pub(crate) async fn range_stream_with_mode_and_min_sequence_number(
+        &self,
+        start: &Key,
+        end: &Key,
+        limit: usize,
+        batch_size: usize,
+        mode: RangeMode,
+        min_sequence_number: u64,
+    ) -> Result<RangeStream, ClientError> {
+        self.range_stream_internal(
+            start,
+            end,
+            limit,
+            batch_size,
+            mode,
+            RangeStreamReadOptions {
+                min_sequence_number: Some(min_sequence_number),
+                observed_sequence: None,
+            },
+        )
+        .await
+    }
+
+    pub(crate) async fn range_stream_internal(
+        &self,
+        start: &Key,
+        end: &Key,
+        limit: usize,
+        batch_size: usize,
+        mode: RangeMode,
+        options: RangeStreamReadOptions,
+    ) -> Result<RangeStream, ClientError> {
+        let (start, end) = self.encode_store_range(start, end)?;
+        let mut stream = self
+            .client
+            .range_stream_internal(&start, &end, limit, batch_size, mode, options)
+            .await?;
+        stream.key_prefix = Some(self.prefix);
+        Ok(stream)
+    }
+
+    pub(crate) async fn range_reduce(
+        &self,
+        start: &Key,
+        end: &Key,
+        request: &DomainRangeReduceRequest,
+    ) -> Result<Vec<Option<KvReducedValue>>, ClientError> {
+        let (response, _) = self
+            .range_reduce_response_internal(start, end, request, None)
+            .await?;
+        scalar_reduce_results(response)
+    }
+
+    pub(crate) async fn range_reduce_with_min_sequence_number(
+        &self,
+        start: &Key,
+        end: &Key,
+        request: &DomainRangeReduceRequest,
+        min_sequence_number: u64,
+    ) -> Result<Vec<Option<KvReducedValue>>, ClientError> {
+        let (response, _) = self
+            .range_reduce_response_internal(start, end, request, Some(min_sequence_number))
+            .await?;
+        scalar_reduce_results(response)
+    }
+
+    pub(crate) async fn range_reduce_response(
+        &self,
+        start: &Key,
+        end: &Key,
+        request: &DomainRangeReduceRequest,
+    ) -> Result<exoware_proto::query::ReduceResponse, ClientError> {
+        let (body, _) = self
+            .range_reduce_response_internal(start, end, request, None)
+            .await?;
+        Ok(body)
+    }
+
+    pub(crate) async fn range_reduce_response_with_min_sequence_number(
+        &self,
+        start: &Key,
+        end: &Key,
+        request: &DomainRangeReduceRequest,
+        min_sequence_number: u64,
+    ) -> Result<exoware_proto::query::ReduceResponse, ClientError> {
+        let (body, _) = self
+            .range_reduce_response_internal(start, end, request, Some(min_sequence_number))
+            .await?;
+        Ok(body)
+    }
+
+    pub(crate) async fn range_reduce_response_internal(
+        &self,
+        start: &Key,
+        end: &Key,
+        request: &DomainRangeReduceRequest,
+        min_sequence_number: Option<u64>,
+    ) -> Result<
+        (
+            exoware_proto::query::ReduceResponse,
+            Option<proto_query::Detail>,
+        ),
+        ClientError,
+    > {
+        let (start, end) = self.encode_store_range(start, end)?;
+        let request = self.prefix_reduce_request(request)?;
+        self.client
+            .range_reduce_response_internal(&start, &end, &request, min_sequence_number)
+            .await
+    }
+
+    pub(crate) async fn prune(
+        &self,
+        policies: &[crate::prune_policy::PrunePolicy],
+    ) -> Result<(), ClientError> {
+        let policies = self.prefix_prune_policies(policies)?;
+        self.client.prune(&policies).await
+    }
+
+    pub(crate) async fn subscribe(
+        &self,
+        filter: crate::stream_filter::StreamFilter,
+        since_sequence_number: Option<u64>,
+    ) -> Result<StreamSubscription, ClientError> {
+        // The physical match keys are broadened (payload regex widened) to span
+        // the bit-shifted payload, so always re-apply the caller's predicate
+        // client-side via the compiled logical filter.
+        let logical_filter = Some(ClientStreamFilter::compile(&filter)?);
+        let filter = self.prefix_stream_filter(filter)?;
+        let mut sub = self
+            .client
+            .subscribe_physical(filter, since_sequence_number)
+            .await?;
+        sub.key_prefix = Some(self.prefix);
+        sub.logical_filter = logical_filter;
+        Ok(sub)
+    }
+
+    pub(crate) async fn stream_get(
+        &self,
+        sequence_number: u64,
+    ) -> Result<Option<Vec<(Key, Bytes)>>, ClientError> {
+        let Some(owned) = self.client.stream_get_physical(sequence_number).await? else {
+            return Ok(None);
+        };
+        let mut out = Vec::with_capacity(owned.entries.len());
+        for entry in owned.entries {
+            let key = Bytes::from(entry.key);
+            if !self.prefix.codec.matches(&key) {
+                continue;
+            }
+            out.push((self.decode_store_key(&key)?, entry.value));
+        }
+        Ok(Some(out))
+    }
+}
+
+/// Extract scalar (ungrouped) reduce results from a wire response.
+fn scalar_reduce_results(
+    response: exoware_proto::query::ReduceResponse,
+) -> Result<Vec<Option<KvReducedValue>>, ClientError> {
+    let decoded = proto_to_domain_reduce_response(response).map_err(ClientError::WireFormat)?;
+    if !decoded.groups.is_empty() {
+        return Err(ClientError::WireFormat(
+            "grouped range reduction response returned for scalar request".to_string(),
+        ));
+    }
+    Ok(decoded
+        .results
+        .iter()
+        .map(|result| result.value.clone())
+        .collect())
 }
 
 /// A physical Store write batch assembled from one or more logical clients.
@@ -484,7 +999,7 @@ impl StoreWriteBatch {
 
     pub fn push(
         &mut self,
-        client: &StoreClient,
+        client: &PrefixedStoreClient,
         key: &Key,
         value: impl IntoStoreWriteValue,
     ) -> Result<&mut Self, ClientError> {
@@ -495,7 +1010,7 @@ impl StoreWriteBatch {
         Ok(self)
     }
 
-    pub async fn commit(&self, client: &StoreClient) -> Result<u64, ClientError> {
+    pub async fn commit(&self, client: &PrefixedStoreClient) -> Result<u64, ClientError> {
         client.put_prepared_physical(&self.entries).await
     }
 }
@@ -544,7 +1059,7 @@ pub trait StoreBatchUpload {
 
     fn commit_upload<'a>(
         &'a self,
-        client: &'a StoreClient,
+        client: &'a PrefixedStoreClient,
         prepared: Self::Prepared,
     ) -> BoxFuture<'a, Result<Self::Receipt, Self::Error>>
     where
@@ -618,7 +1133,7 @@ pub trait StoreBatchPublication {
 
     fn commit_publication<'a>(
         &'a self,
-        client: &'a StoreClient,
+        client: &'a PrefixedStoreClient,
         prepared: Self::PreparedPublication,
     ) -> BoxFuture<'a, Result<Self::PublicationReceipt, Self::Error>>
     where
@@ -1220,7 +1735,6 @@ pub struct StoreClientBuilder {
     query_url: Option<String>,
     compact_url: Option<String>,
     stream_url: Option<String>,
-    key_prefix: Option<StoreKeyPrefix>,
     retry_config: RetryConfig,
     connect_request_compression: ConnectRequestCompression,
 }
@@ -1264,12 +1778,6 @@ impl StoreClientBuilder {
     /// Base URL for the stream service (`log.stream.v1.Service`).
     pub fn stream_url(mut self, url: &str) -> Self {
         self.stream_url = Some(trim_connect_base(url));
-        self
-    }
-
-    /// Client-side key namespace applied to all user-key operations.
-    pub fn key_prefix(mut self, prefix: StoreKeyPrefix) -> Self {
-        self.key_prefix = Some(prefix);
         self
     }
 
@@ -1331,7 +1839,6 @@ impl StoreClientBuilder {
             connect_http: ProtoPreferZstdHttpClient::plaintext(),
             retry_config: self.retry_config,
             connect_request_compression: self.connect_request_compression,
-            key_prefix: self.key_prefix,
         })
     }
 }
@@ -1349,7 +1856,6 @@ pub struct StoreClient {
     connect_http: ProtoPreferZstdHttpClient,
     retry_config: RetryConfig,
     connect_request_compression: ConnectRequestCompression,
-    key_prefix: Option<StoreKeyPrefix>,
 }
 
 /// A session that enforces monotonic read consistency via a fixed `min_sequence_number` floor.
@@ -1368,7 +1874,7 @@ pub struct StoreClient {
 /// read, the session is pinned once the first detail-bearing chunk is consumed.
 #[derive(Clone, Debug)]
 pub struct SerializableReadSession {
-    client: StoreClient,
+    client: PrefixedStoreClient,
     state: Arc<SessionState>,
 }
 
@@ -1409,57 +1915,16 @@ impl StoreClient {
             .expect("url sets all service URLs")
     }
 
-    /// Return this client's configured Store key prefix, if any.
-    pub fn key_prefix(&self) -> Option<StoreKeyPrefix> {
-        self.key_prefix
-    }
-
-    /// Clone this client with a client-side Store key prefix.
-    pub fn with_key_prefix(&self, prefix: StoreKeyPrefix) -> Self {
-        let mut out = self.clone();
-        out.key_prefix = Some(prefix);
-        out
-    }
-
-    /// Clone this client without client-side key prefixing.
-    pub fn without_key_prefix(&self) -> Self {
-        let mut out = self.clone();
-        out.key_prefix = None;
-        out
-    }
-
-    /// Clone this client into a [`PrefixedStoreClient`] carrying `prefix`.
+    /// Pair this physical client with `prefix`, yielding the logical
+    /// [`PrefixedStoreClient`] that namespaces every operation.
     pub fn prefixed(&self, prefix: StoreKeyPrefix) -> PrefixedStoreClient {
         PrefixedStoreClient::new(self.clone(), prefix)
     }
 
-    /// Clone this client into a [`PrefixedStoreClient`] using the canonical
-    /// prefix for a built-in [`Namespace`].
+    /// Pair this physical client with the canonical prefix for a built-in
+    /// [`Namespace`].
     pub fn for_namespace(&self, namespace: Namespace) -> PrefixedStoreClient {
         PrefixedStoreClient::for_namespace(self.clone(), namespace)
-    }
-
-    /// Encode a logical key as it will appear in the physical Store.
-    pub fn encode_store_key(&self, key: &Key) -> Result<Key, ClientError> {
-        match self.key_prefix {
-            Some(prefix) => Ok(prefix.encode_key(key)?),
-            None => Ok(key.clone()),
-        }
-    }
-
-    /// Decode a physical Store key into this client's logical keyspace.
-    pub fn decode_store_key(&self, key: &Key) -> Result<Key, ClientError> {
-        match self.key_prefix {
-            Some(prefix) => Ok(prefix.decode_key(key)?),
-            None => Ok(key.clone()),
-        }
-    }
-
-    fn encode_store_range(&self, start: &Key, end: &Key) -> Result<(Key, Key), ClientError> {
-        match self.key_prefix {
-            Some(prefix) => Ok(prefix.encode_range(start, end)?),
-            None => Ok((start.clone(), end.clone())),
-        }
     }
 
     /// Outgoing Connect request body compression (see [`ConnectRequestCompression`]).
@@ -1473,73 +1938,13 @@ impl StoreClient {
         proto_decode_connect_error(err)
     }
 
-    /// Create an unseeded serializable read session.
-    ///
-    /// The first successful unary read fixes the session's sequence floor from
-    /// the server response. Streamed query reads fix that floor once a
-    /// detail-bearing chunk is consumed.
-    pub fn create_session(&self) -> SerializableReadSession {
-        self.create_session_with_sequence(0)
-    }
-
-    /// Create a serializable read session pinned to at least `sequence`.
-    ///
-    /// This is intended for stream-driven read paths that already observed a
-    /// concrete store batch sequence and need follow-up query/proof reads to
-    /// see at least that sequence.
-    pub fn create_session_with_sequence(&self, sequence: u64) -> SerializableReadSession {
-        SerializableReadSession {
-            client: self.clone(),
-            state: Arc::new(SessionState {
-                sequence: Arc::new(AtomicU64::new(sequence)),
-                init_gate: tokio::sync::Mutex::new(()),
-            }),
-        }
-    }
-
-    /// Typed access to the `log.ingest.v1` service.
-    pub fn ingest(&self) -> Ingest<'_> {
-        Ingest { c: self }
-    }
-
-    /// Typed access to the `store.query.v1` service.
-    pub fn query(&self) -> Query<'_> {
-        Query { c: self }
-    }
-
-    /// Typed access to the `store.compact.v1` service.
-    pub fn compact(&self) -> Compact<'_> {
-        Compact { c: self }
-    }
-
-    /// Typed access to the `log.stream.v1` service.
-    pub fn stream(&self) -> Stream<'_> {
-        Stream { c: self }
-    }
-
     /// Submit a KV batch via Connect `Put`.
     ///
     /// On success returns the **store sequence number** from the response. Use it for immediate
     /// `get_with_min_sequence_number` / range calls or to seed
     /// [`Self::create_session_with_sequence`].
     /// If the request succeeds, the server accepts the full batch (count is `kvs.len()`).
-    pub(crate) async fn put(&self, kvs: &[(&Key, &[u8])]) -> Result<u64, ClientError> {
-        if self.key_prefix.is_none() {
-            return self.put_physical(kvs).await;
-        }
-        let mut keys = Vec::with_capacity(kvs.len());
-        for (key, _) in kvs {
-            keys.push(self.encode_store_key(key)?);
-        }
-        let prefixed: Vec<(&Key, &[u8])> = keys
-            .iter()
-            .zip(kvs.iter())
-            .map(|(key, (_, value))| (key, *value))
-            .collect();
-        self.put_physical(&prefixed).await
-    }
-
-    async fn put_physical(&self, kvs: &[(&Key, &[u8])]) -> Result<u64, ClientError> {
+    pub(crate) async fn put_physical(&self, kvs: &[(&Key, &[u8])]) -> Result<u64, ClientError> {
         let mut proto_kvs = Vec::with_capacity(kvs.len());
         for (key, value) in kvs {
             if !is_valid_key_size(key.len()) {
@@ -1616,52 +2021,19 @@ impl StoreClient {
         Ok(response.value)
     }
 
-    pub(crate) async fn get_many(
+    /// Physical `get_many` over already-encoded wire keys. The
+    /// [`PrefixedStoreClient`] wrapper encodes + validates and attaches the
+    /// prefix to the returned stream for decoding.
+    pub(crate) async fn get_many_internal(
         &self,
-        keys: &[&Key],
-        batch_size: u32,
-    ) -> Result<GetManyStream, ClientError> {
-        self.get_many_internal(keys, batch_size, None, None).await
-    }
-
-    pub(crate) async fn get_many_with_min_sequence_number(
-        &self,
-        keys: &[&Key],
-        batch_size: u32,
-        min_sequence_number: u64,
-    ) -> Result<GetManyStream, ClientError> {
-        self.get_many_internal(keys, batch_size, Some(min_sequence_number), None)
-            .await
-    }
-
-    async fn get_many_internal(
-        &self,
-        keys: &[&Key],
+        proto_keys: Vec<Vec<u8>>,
         batch_size: u32,
         min_sequence_number: Option<u64>,
         observed_sequence: Option<Arc<AtomicU64>>,
     ) -> Result<GetManyStream, ClientError> {
-        for key in keys {
-            if !is_valid_key_size(key.len()) {
-                return Err(ClientError::WireFormat(format!(
-                    "key length {} is outside valid store key range ({}..={})",
-                    key.len(),
-                    keys::MIN_KEY_LEN,
-                    MAX_KEY_LEN
-                )));
-            }
-        }
-
         let config =
             store_connect_client_config(self.query_uri.clone(), self.connect_request_compression);
         let client = QueryServiceClient::new(self.connect_http.clone(), config);
-        let proto_keys: Vec<Vec<u8>> = keys
-            .iter()
-            .map(|k| match self.key_prefix {
-                Some(_) => self.encode_store_key(k).map(|key| key.to_vec()),
-                None => Ok(k.to_vec()),
-            })
-            .collect::<Result<Vec<_>, _>>()?;
         let effective_min = self.normalize_min_sequence_number(min_sequence_number);
         let max_attempts = self.retry_config.max_attempts.max(1);
         let mut attempt = 1usize;
@@ -1676,11 +2048,8 @@ impl StoreClient {
                 .await
             {
                 Ok(stream) => {
-                    let mut gms = GetManyStream::from_connect_stream(
-                        stream,
-                        observed_sequence.clone(),
-                        self.key_prefix,
-                    );
+                    let mut gms =
+                        GetManyStream::from_connect_stream(stream, observed_sequence.clone(), None);
                     if let Err(err) = gms.prefetch_first_frame().await {
                         if attempt < max_attempts && is_retryable_error(&err) {
                             let delay = retry_delay_for_error(&err, attempt, self.retry_config);
@@ -1705,203 +2074,6 @@ impl StoreClient {
         }
     }
 
-    /// Key range is inclusive: `start <= key <= end` when `end` is non-empty; empty `end` is
-    /// unbounded above (matches `store.query.v1.RangeRequest`).
-    pub(crate) async fn range(
-        &self,
-        start: &Key,
-        end: &Key,
-        limit: usize,
-    ) -> Result<Vec<(Key, Bytes)>, ClientError> {
-        self.range_internal(start, end, limit, RangeMode::Forward, None)
-            .await
-    }
-
-    /// See [`StoreClient::range`] for `end` semantics.
-    pub(crate) async fn range_with_mode(
-        &self,
-        start: &Key,
-        end: &Key,
-        limit: usize,
-        mode: RangeMode,
-    ) -> Result<Vec<(Key, Bytes)>, ClientError> {
-        self.range_internal(start, end, limit, mode, None).await
-    }
-
-    pub(crate) async fn range_with_min_sequence_number(
-        &self,
-        start: &Key,
-        end: &Key,
-        limit: usize,
-        min_sequence_number: u64,
-    ) -> Result<Vec<(Key, Bytes)>, ClientError> {
-        self.range_internal(
-            start,
-            end,
-            limit,
-            RangeMode::Forward,
-            Some(min_sequence_number),
-        )
-        .await
-    }
-
-    pub(crate) async fn range_with_mode_and_min_sequence_number(
-        &self,
-        start: &Key,
-        end: &Key,
-        limit: usize,
-        mode: RangeMode,
-        min_sequence_number: u64,
-    ) -> Result<Vec<(Key, Bytes)>, ClientError> {
-        self.range_internal(start, end, limit, mode, Some(min_sequence_number))
-            .await
-    }
-
-    pub(crate) async fn range_stream(
-        &self,
-        start: &Key,
-        end: &Key,
-        limit: usize,
-        batch_size: usize,
-    ) -> Result<RangeStream, ClientError> {
-        self.range_stream_internal(
-            start,
-            end,
-            limit,
-            batch_size,
-            RangeMode::Forward,
-            RangeStreamReadOptions::default(),
-        )
-        .await
-    }
-
-    pub(crate) async fn range_stream_with_mode(
-        &self,
-        start: &Key,
-        end: &Key,
-        limit: usize,
-        batch_size: usize,
-        mode: RangeMode,
-    ) -> Result<RangeStream, ClientError> {
-        self.range_stream_internal(start, end, limit, batch_size, mode, Default::default())
-            .await
-    }
-
-    pub(crate) async fn range_stream_with_min_sequence_number(
-        &self,
-        start: &Key,
-        end: &Key,
-        limit: usize,
-        batch_size: usize,
-        min_sequence_number: u64,
-    ) -> Result<RangeStream, ClientError> {
-        self.range_stream_internal(
-            start,
-            end,
-            limit,
-            batch_size,
-            RangeMode::Forward,
-            RangeStreamReadOptions {
-                min_sequence_number: Some(min_sequence_number),
-                observed_sequence: None,
-            },
-        )
-        .await
-    }
-
-    pub(crate) async fn range_stream_with_mode_and_min_sequence_number(
-        &self,
-        start: &Key,
-        end: &Key,
-        limit: usize,
-        batch_size: usize,
-        mode: RangeMode,
-        min_sequence_number: u64,
-    ) -> Result<RangeStream, ClientError> {
-        self.range_stream_internal(
-            start,
-            end,
-            limit,
-            batch_size,
-            mode,
-            RangeStreamReadOptions {
-                min_sequence_number: Some(min_sequence_number),
-                observed_sequence: None,
-            },
-        )
-        .await
-    }
-
-    pub(crate) async fn range_reduce(
-        &self,
-        start: &Key,
-        end: &Key,
-        request: &DomainRangeReduceRequest,
-    ) -> Result<Vec<Option<KvReducedValue>>, ClientError> {
-        let (response, _) = self
-            .range_reduce_response_internal(start, end, request, None)
-            .await?;
-        let decoded = proto_to_domain_reduce_response(response).map_err(ClientError::WireFormat)?;
-        if !decoded.groups.is_empty() {
-            return Err(ClientError::WireFormat(
-                "grouped range reduction response returned for scalar request".to_string(),
-            ));
-        }
-        Ok(decoded
-            .results
-            .iter()
-            .map(|result| result.value.clone())
-            .collect())
-    }
-
-    pub(crate) async fn range_reduce_with_min_sequence_number(
-        &self,
-        start: &Key,
-        end: &Key,
-        request: &DomainRangeReduceRequest,
-        min_sequence_number: u64,
-    ) -> Result<Vec<Option<KvReducedValue>>, ClientError> {
-        let (response, _) = self
-            .range_reduce_response_internal(start, end, request, Some(min_sequence_number))
-            .await?;
-        let decoded = proto_to_domain_reduce_response(response).map_err(ClientError::WireFormat)?;
-        if !decoded.groups.is_empty() {
-            return Err(ClientError::WireFormat(
-                "grouped range reduction response returned for scalar request".to_string(),
-            ));
-        }
-        Ok(decoded
-            .results
-            .iter()
-            .map(|result| result.value.clone())
-            .collect())
-    }
-
-    pub(crate) async fn range_reduce_response(
-        &self,
-        start: &Key,
-        end: &Key,
-        request: &DomainRangeReduceRequest,
-    ) -> Result<exoware_proto::query::ReduceResponse, ClientError> {
-        let (body, _) = self
-            .range_reduce_response_internal(start, end, request, None)
-            .await?;
-        Ok(body)
-    }
-
-    pub(crate) async fn range_reduce_response_with_min_sequence_number(
-        &self,
-        start: &Key,
-        end: &Key,
-        request: &DomainRangeReduceRequest,
-        min_sequence_number: u64,
-    ) -> Result<exoware_proto::query::ReduceResponse, ClientError> {
-        let (body, _) = self
-            .range_reduce_response_internal(start, end, request, Some(min_sequence_number))
-            .await?;
-        Ok(body)
-    }
-
     pub(crate) async fn prune(
         &self,
         policies: &[crate::prune_policy::PrunePolicy],
@@ -1909,15 +2081,102 @@ impl StoreClient {
         let config =
             store_connect_client_config(self.compact_uri.clone(), self.connect_request_compression);
         let client = CompactServiceClient::new(self.connect_http.clone(), config);
-        let policies = self.prefix_prune_policies(policies)?;
         client
             .prune(ProtoPruneRequest {
-                policies: exoware_proto::prune_policies_to_proto(&policies),
+                policies: exoware_proto::prune_policies_to_proto(policies),
                 ..Default::default()
             })
             .await
             .map_err(client_error_from_connect)?;
         Ok(())
+    }
+
+    /// Open a physical subscription over an already-encoded `filter`. The
+    /// returned [`StreamSubscription`] carries no prefix; the logical
+    /// [`PrefixedStoreClient`] wrapper attaches one for decoding.
+    async fn subscribe_physical(
+        &self,
+        filter: crate::stream_filter::StreamFilter,
+        since_sequence_number: Option<u64>,
+    ) -> Result<StreamSubscription, ClientError> {
+        crate::stream_filter::validate_filter(&filter)
+            .map_err(|e| ClientError::WireFormat(e.to_string()))?;
+        let match_keys = filter
+            .match_keys
+            .into_iter()
+            .map(|mk| exoware_proto::store::common::v1::MatchKey {
+                reserved_bits: u32::from(mk.reserved_bits),
+                prefix: u32::from(mk.prefix),
+                payload_regex: mk.payload_regex.0,
+                ..Default::default()
+            })
+            .collect();
+        let value_filters = filter
+            .value_filters
+            .into_iter()
+            .map(|vf| {
+                use crate::stream_filter::BytesFilter;
+                use exoware_proto::store::common::v1::bytes_filter::Kind as ProtoKind;
+                let kind = match vf {
+                    BytesFilter::Exact(bytes) => ProtoKind::Exact(bytes),
+                    BytesFilter::Prefix(bytes) => ProtoKind::Prefix(bytes),
+                    BytesFilter::Regex(pattern) => ProtoKind::Regex(pattern),
+                };
+                exoware_proto::store::common::v1::BytesFilter {
+                    kind: Some(kind),
+                    ..Default::default()
+                }
+            })
+            .collect();
+        let request = exoware_proto::store::stream::v1::SubscribeRequest {
+            match_keys,
+            value_filters,
+            since_sequence_number,
+            ..Default::default()
+        };
+        let config =
+            store_connect_client_config(self.stream_uri.clone(), self.connect_request_compression);
+        let client =
+            exoware_proto::store::stream::v1::ServiceClient::new(self.connect_http.clone(), config);
+        let stream = client
+            .subscribe(request)
+            .await
+            .map_err(client_error_from_connect)?;
+        Ok(StreamSubscription {
+            stream,
+            key_prefix: None,
+            logical_filter: None,
+        })
+    }
+
+    /// Fetch a batch by sequence number, returning the raw owned response
+    /// (physical keys, no decode). `None` collapses the server's
+    /// `BATCH_EVICTED` / `BATCH_NOT_FOUND` errors. The [`PrefixedStoreClient`]
+    /// wrapper consumes the entries in one pass to filter + decode.
+    async fn stream_get_physical(
+        &self,
+        sequence_number: u64,
+    ) -> Result<Option<exoware_proto::store::stream::v1::GetResponse>, ClientError> {
+        let config =
+            store_connect_client_config(self.stream_uri.clone(), self.connect_request_compression);
+        let client =
+            exoware_proto::store::stream::v1::ServiceClient::new(self.connect_http.clone(), config);
+        match client
+            .get(exoware_proto::store::stream::v1::GetRequest {
+                sequence_number,
+                ..Default::default()
+            })
+            .await
+        {
+            Ok(resp) => Ok(Some(resp.into_owned())),
+            Err(err) => {
+                if is_batch_missing_error(&err) {
+                    Ok(None)
+                } else {
+                    Err(client_error_from_connect(err))
+                }
+            }
+        }
     }
 
     pub async fn health(&self) -> Result<bool, ClientError> {
@@ -1961,7 +2220,6 @@ impl StoreClient {
                 MAX_KEY_LEN
             )));
         }
-        let key = self.encode_store_key(key)?;
 
         let config =
             store_connect_client_config(self.query_uri.clone(), self.connect_request_compression);
@@ -1997,30 +2255,6 @@ impl StoreClient {
         self.send_get(key, min_sequence_number).await
     }
 
-    async fn range_internal(
-        &self,
-        start: &Key,
-        end: &Key,
-        limit: usize,
-        mode: RangeMode,
-        min_sequence_number: Option<u64>,
-    ) -> Result<Vec<(Key, Bytes)>, ClientError> {
-        let stream = self
-            .range_stream_internal(
-                start,
-                end,
-                limit,
-                limit.max(1),
-                mode,
-                RangeStreamReadOptions {
-                    min_sequence_number,
-                    observed_sequence: None,
-                },
-            )
-            .await?;
-        stream.collect().await
-    }
-
     async fn range_stream_internal(
         &self,
         start: &Key,
@@ -2040,7 +2274,6 @@ impl StoreClient {
                 "batch_size must be positive".to_string(),
             ));
         }
-        let (start, end) = self.encode_store_range(start, end)?;
 
         let config =
             store_connect_client_config(self.query_uri.clone(), self.connect_request_compression);
@@ -2084,11 +2317,8 @@ impl StoreClient {
                 }
             };
 
-            let mut stream = RangeStream::from_connect_stream(
-                response,
-                options.observed_sequence.clone(),
-                self.key_prefix,
-            );
+            let mut stream =
+                RangeStream::from_connect_stream(response, options.observed_sequence.clone(), None);
             if let Err(err) = stream.prefetch_first_frame().await {
                 if attempt < max_attempts && is_retryable_error(&err) {
                     let delay = retry_delay_for_error(&err, attempt, self.retry_config);
@@ -2125,9 +2355,7 @@ impl StoreClient {
         let config =
             store_connect_client_config(self.query_uri.clone(), self.connect_request_compression);
         let client = QueryServiceClient::new(self.connect_http.clone(), config);
-        let (start, end) = self.encode_store_range(start, end)?;
-        let request = self.prefix_reduce_request(request)?;
-        let proto_params = proto_to_proto_reduce_params(request);
+        let proto_params = proto_to_proto_reduce_params(request.clone());
         let min_sequence_number = self.normalize_min_sequence_number(min_sequence_number);
         let response = self
             .send_with_retry(|| async {
@@ -2145,64 +2373,6 @@ impl StoreClient {
         let owned = response.into_owned();
         let detail = owned.detail.as_option().cloned();
         Ok((owned, detail))
-    }
-
-    fn prefix_prune_policies(
-        &self,
-        policies: &[crate::prune_policy::PrunePolicy],
-    ) -> Result<Vec<crate::prune_policy::PrunePolicy>, ClientError> {
-        let Some(prefix) = self.key_prefix else {
-            return Ok(policies.to_vec());
-        };
-        policies
-            .iter()
-            .map(|policy| {
-                use crate::prune_policy::{PolicyScope, PrunePolicy};
-                let scope = match &policy.scope {
-                    PolicyScope::Keys(scope) => {
-                        let mut scope = scope.clone();
-                        scope.selector = prefix.prefix_selector(&scope.selector)?;
-                        PolicyScope::Keys(scope)
-                    }
-                    PolicyScope::Sequence => PolicyScope::Sequence,
-                };
-                Ok(PrunePolicy {
-                    scope,
-                    retain: policy.retain.clone(),
-                })
-            })
-            .collect::<Result<Vec<_>, StoreKeyPrefixError>>()
-            .map_err(ClientError::from)
-    }
-
-    fn prefix_stream_filter(
-        &self,
-        filter: crate::stream_filter::StreamFilter,
-    ) -> Result<crate::stream_filter::StreamFilter, ClientError> {
-        let Some(prefix) = self.key_prefix else {
-            return Ok(filter);
-        };
-        let selectors = filter
-            .selectors
-            .iter()
-            .map(|mk| prefix.prefix_stream_selector(mk))
-            .collect::<Result<Vec<_>, _>>()?;
-        Ok(crate::stream_filter::StreamFilter {
-            selectors,
-            value_filters: filter.value_filters,
-        })
-    }
-
-    fn prefix_reduce_request(
-        &self,
-        request: &DomainRangeReduceRequest,
-    ) -> Result<DomainRangeReduceRequest, ClientError> {
-        let Some(prefix) = self.key_prefix else {
-            return Ok(request.clone());
-        };
-        let mut request = request.clone();
-        shift_reduce_request_key_offsets(prefix.reserved_bits(), &mut request)?;
-        Ok(request)
     }
 
     async fn send_with_retry<F, Fut, T>(&self, mut make_request: F) -> Result<T, ClientError>
@@ -2295,22 +2465,22 @@ fn shift_field_ref_key_offset(
 
 #[derive(Clone, Copy, Debug)]
 pub struct Ingest<'a> {
-    c: &'a StoreClient,
+    c: &'a PrefixedStoreClient,
 }
 
 #[derive(Clone, Copy, Debug)]
 pub struct Query<'a> {
-    c: &'a StoreClient,
+    c: &'a PrefixedStoreClient,
 }
 
 #[derive(Clone, Copy, Debug)]
 pub struct Compact<'a> {
-    c: &'a StoreClient,
+    c: &'a PrefixedStoreClient,
 }
 
 #[derive(Clone, Copy, Debug)]
 pub struct Stream<'a> {
-    c: &'a StoreClient,
+    c: &'a PrefixedStoreClient,
 }
 
 impl<'a> Ingest<'a> {
@@ -2535,63 +2705,7 @@ impl<'a> Stream<'a> {
         filter: crate::stream_filter::StreamFilter,
         since_sequence_number: Option<u64>,
     ) -> Result<StreamSubscription, ClientError> {
-        let logical_filter = self
-            .c
-            .key_prefix
-            .is_some()
-            .then(|| ClientStreamFilter::compile(&filter))
-            .transpose()?;
-        let filter = self.c.prefix_stream_filter(filter)?;
-        crate::stream_filter::validate_filter(&filter)
-            .map_err(|e| ClientError::WireFormat(e.to_string()))?;
-        let selectors = filter
-            .selectors
-            .into_iter()
-            .map(|mk| exoware_proto::common::kv::v1::Selector {
-                reserved_bits: u32::from(mk.reserved_bits),
-                prefix: u32::from(mk.prefix),
-                payload_regex: mk.payload_regex.0,
-                ..Default::default()
-            })
-            .collect();
-        let value_filters = filter
-            .value_filters
-            .into_iter()
-            .map(|vf| {
-                use crate::stream_filter::Filter;
-                use exoware_proto::common::kv::v1::filter::Kind as ProtoKind;
-                let kind = match vf {
-                    Filter::Exact(bytes) => ProtoKind::Exact(bytes),
-                    Filter::Prefix(bytes) => ProtoKind::Prefix(bytes),
-                    Filter::Regex(pattern) => ProtoKind::Regex(pattern),
-                };
-                exoware_proto::common::kv::v1::Filter {
-                    kind: Some(kind),
-                    ..Default::default()
-                }
-            })
-            .collect();
-        let request = exoware_proto::log::stream::v1::SubscribeRequest {
-            selectors,
-            value_filters,
-            since_sequence_number,
-            ..Default::default()
-        };
-        let config = store_connect_client_config(
-            self.c.stream_uri.clone(),
-            self.c.connect_request_compression,
-        );
-        let client =
-            exoware_proto::log::stream::v1::ServiceClient::new(self.c.connect_http.clone(), config);
-        let stream = client
-            .subscribe(request)
-            .await
-            .map_err(client_error_from_connect)?;
-        Ok(StreamSubscription {
-            stream,
-            key_prefix: self.c.key_prefix,
-            logical_filter,
-        })
+        self.c.subscribe(filter, since_sequence_number).await
     }
 
     /// `log.stream.v1.Service.Get` — `Ok(None)` collapses the server's
@@ -2600,40 +2714,7 @@ impl<'a> Stream<'a> {
         &self,
         sequence_number: u64,
     ) -> Result<Option<Vec<(Key, Bytes)>>, ClientError> {
-        let config = store_connect_client_config(
-            self.c.stream_uri.clone(),
-            self.c.connect_request_compression,
-        );
-        let client =
-            exoware_proto::log::stream::v1::ServiceClient::new(self.c.connect_http.clone(), config);
-        match client
-            .get(exoware_proto::log::stream::v1::GetRequest {
-                sequence_number,
-                ..Default::default()
-            })
-            .await
-        {
-            Ok(resp) => {
-                let owned = resp.into_owned();
-                let mut entries = Vec::with_capacity(owned.entries.len());
-                for entry in owned.entries {
-                    let key = Bytes::from(entry.key);
-                    match self.c.key_prefix {
-                        Some(prefix) if !prefix.codec.matches(&key) => {}
-                        Some(prefix) => entries.push((prefix.decode_key(&key)?, entry.value)),
-                        None => entries.push((key, entry.value)),
-                    }
-                }
-                Ok(Some(entries))
-            }
-            Err(err) => {
-                if is_batch_missing_error(&err) {
-                    Ok(None)
-                } else {
-                    Err(client_error_from_connect(err))
-                }
-            }
-        }
+        self.c.stream_get(sequence_number).await
     }
 }
 
@@ -3039,7 +3120,7 @@ mod tests {
 
     #[test]
     fn create_session_starts_unseeded() {
-        let client = StoreClient::new("http://localhost:10000/");
+        let client = PrefixedStoreClient::empty(StoreClient::new("http://localhost:10000/"));
         let session = client.create_session();
         assert_eq!(session.fixed_sequence(), None);
     }
@@ -3102,7 +3183,7 @@ mod tests {
 
     #[test]
     fn create_session_with_sequence_pins_explicit_floor() {
-        let client = StoreClient::new("http://localhost:10000/");
+        let client = PrefixedStoreClient::empty(StoreClient::new("http://localhost:10000/"));
         let session = client.create_session_with_sequence(27);
         assert_eq!(session.fixed_sequence(), Some(27));
     }
@@ -3162,13 +3243,13 @@ mod tests {
     #[test]
     fn prefixed_store_client_always_carries_its_namespace_prefix() {
         let base = StoreClient::new("http://localhost:8090");
-        assert!(base.key_prefix().is_none());
         let sql = base.for_namespace(Namespace::Sql);
         assert_eq!(sql.key_prefix(), Namespace::Sql.key_prefix());
+        // The logical client encodes through its namespace prefix.
+        let logical = Bytes::from_static(b"row");
         assert_eq!(
-            sql.client().key_prefix(),
-            Some(Namespace::Sql.key_prefix()),
-            "underlying client carries the prefix for all reads/writes",
+            sql.encode_store_key(&logical).unwrap(),
+            Namespace::Sql.key_prefix().encode_key(&logical).unwrap(),
         );
         // A non-default sub instance also threads through.
         let explicit = base.prefixed(Namespace::Qmdb.sub(1));
@@ -3222,9 +3303,9 @@ mod tests {
     fn prefixed_reduce_request_shifts_key_field_offsets() {
         let client = StoreClient::builder()
             .url("http://localhost:10000")
-            .key_prefix(StoreKeyPrefix::new(5, 0b10101).unwrap())
             .build()
-            .unwrap();
+            .unwrap()
+            .prefixed(StoreKeyPrefix::new(5, 0b10101).unwrap());
         let request = DomainRangeReduceRequest {
             reducers: vec![crate::RangeReducerSpec {
                 op: crate::RangeReduceOp::SumField,
@@ -3271,8 +3352,8 @@ mod tests {
     #[test]
     fn store_write_batch_uses_each_clients_prefix() {
         let base = StoreClient::new("http://localhost:10000");
-        let a = base.with_key_prefix(StoreKeyPrefix::new(4, 1).unwrap());
-        let b = base.with_key_prefix(StoreKeyPrefix::new(4, 2).unwrap());
+        let a = base.prefixed(StoreKeyPrefix::new(4, 1).unwrap());
+        let b = base.prefixed(StoreKeyPrefix::new(4, 2).unwrap());
         let key_a = Bytes::from_static(b"a");
         let key_b = Bytes::from_static(b"b");
 
@@ -3282,11 +3363,11 @@ mod tests {
 
         assert_eq!(
             batch.entries[0].0,
-            a.key_prefix().unwrap().encode_key(&key_a).unwrap()
+            a.key_prefix().encode_key(&key_a).unwrap()
         );
         assert_eq!(
             batch.entries[1].0,
-            b.key_prefix().unwrap().encode_key(&key_b).unwrap()
+            b.key_prefix().encode_key(&key_b).unwrap()
         );
     }
 

--- a/sdk/rs/src/lib.rs
+++ b/sdk/rs/src/lib.rs
@@ -413,16 +413,9 @@ impl Namespace {
     }
 }
 
-/// The sole logical Store client: a physical [`StoreClient`] paired with a
-/// [`StoreKeyPrefix`] that namespaces every key on the wire.
-///
-/// `StoreClient` itself is purely physical — it has no notion of a prefix — so
-/// this type is the *only* way to perform namespaced reads and writes. All key
-/// translation (encode on the way out, decode on the way back) lives here.
-///
-/// Because the prefix can be the zero-width [`StoreKeyPrefix::identity`], this
-/// single type also represents the un-namespaced case; there is no separate
-/// "raw client" surface that could silently skip namespacing.
+/// A physical [`StoreClient`] paired with a [`StoreKeyPrefix`] that namespaces
+/// every key on the wire. The prefix can be the zero-width
+/// [`StoreKeyPrefix::identity`], representing the un-namespaced case.
 #[derive(Clone, Debug)]
 pub struct PrefixedStoreClient {
     client: StoreClient,
@@ -574,14 +567,6 @@ impl PrefixedStoreClient {
             .map(|(key, (_, value))| (key, *value))
             .collect();
         self.client.put_physical(&prefixed).await
-    }
-
-    /// Submit an already-prepared (physical) batch.
-    pub(crate) async fn put_prepared_physical(
-        &self,
-        kvs: &[(Key, Bytes)],
-    ) -> Result<u64, ClientError> {
-        self.client.put_prepared_physical(kvs).await
     }
 
     // --- reads ---------------------------------------------------------------
@@ -999,18 +984,16 @@ impl StoreWriteBatch {
 
     pub fn push(
         &mut self,
-        client: &PrefixedStoreClient,
+        prefix: StoreKeyPrefix,
         key: &Key,
         value: impl IntoStoreWriteValue,
     ) -> Result<&mut Self, ClientError> {
-        self.entries.push((
-            client.encode_store_key(key)?,
-            value.into_store_write_value(),
-        ));
+        self.entries
+            .push((prefix.encode_key(key)?, value.into_store_write_value()));
         Ok(self)
     }
 
-    pub async fn commit(&self, client: &PrefixedStoreClient) -> Result<u64, ClientError> {
+    pub async fn commit(&self, client: &StoreClient) -> Result<u64, ClientError> {
         client.put_prepared_physical(&self.entries).await
     }
 }
@@ -1059,7 +1042,7 @@ pub trait StoreBatchUpload {
 
     fn commit_upload<'a>(
         &'a self,
-        client: &'a PrefixedStoreClient,
+        client: &'a StoreClient,
         prepared: Self::Prepared,
     ) -> BoxFuture<'a, Result<Self::Receipt, Self::Error>>
     where
@@ -1133,7 +1116,7 @@ pub trait StoreBatchPublication {
 
     fn commit_publication<'a>(
         &'a self,
-        client: &'a PrefixedStoreClient,
+        client: &'a StoreClient,
         prepared: Self::PreparedPublication,
     ) -> BoxFuture<'a, Result<Self::PublicationReceipt, Self::Error>>
     where
@@ -1942,7 +1925,7 @@ impl StoreClient {
     ///
     /// On success returns the **store sequence number** from the response. Use it for immediate
     /// `get_with_min_sequence_number` / range calls or to seed
-    /// [`Self::create_session_with_sequence`].
+    /// [`PrefixedStoreClient::create_session_with_sequence`].
     /// If the request succeeds, the server accepts the full batch (count is `kvs.len()`).
     pub(crate) async fn put_physical(&self, kvs: &[(&Key, &[u8])]) -> Result<u64, ClientError> {
         let mut proto_kvs = Vec::with_capacity(kvs.len());
@@ -2491,7 +2474,7 @@ impl<'a> Ingest<'a> {
     /// Submit a [`StoreWriteBatch`] that has already been encoded into the
     /// physical Store keyspace.
     pub async fn put_prepared(&self, batch: &StoreWriteBatch) -> Result<u64, ClientError> {
-        batch.commit(self.c).await
+        batch.commit(self.c.client()).await
     }
 }
 
@@ -2722,7 +2705,7 @@ impl SerializableReadSession {
     /// Fixed sequence floor for this session, if one has been established yet.
     ///
     /// Fresh sessions start with `None` unless created via
-    /// [`StoreClient::create_session_with_sequence`]. A first streamed query
+    /// [`PrefixedStoreClient::create_session_with_sequence`]. A first streamed query
     /// read (`get_many`, `range_stream`) sets this once a detail-bearing chunk
     /// is consumed.
     pub fn fixed_sequence(&self) -> Option<u64> {
@@ -3358,8 +3341,8 @@ mod tests {
         let key_b = Bytes::from_static(b"b");
 
         let mut batch = StoreWriteBatch::new();
-        batch.push(&a, &key_a, b"va").unwrap();
-        batch.push(&b, &key_b, b"vb").unwrap();
+        batch.push(a.key_prefix(), &key_a, b"va").unwrap();
+        batch.push(b.key_prefix(), &key_b, b"vb").unwrap();
 
         assert_eq!(
             batch.entries[0].0,

--- a/sdk/rs/src/lib.rs
+++ b/sdk/rs/src/lib.rs
@@ -330,6 +330,127 @@ impl StoreKeyPrefix {
     }
 }
 
+/// Reserved high bits selecting the *subsystem* within a namespace prefix.
+/// Three bits → up to eight subsystems.
+pub const NAMESPACE_SLOT_BITS: u8 = 3;
+
+/// Reserved high bits selecting the *instance* of a subsystem within a
+/// namespace prefix. One bit → up to two instances per subsystem (e.g. QMDB's
+/// account-state and transaction-history operation logs).
+pub const NAMESPACE_INSTANCE_BITS: u8 = 1;
+
+/// Total reserved high bits in *every* namespace key prefix (slot + instance).
+///
+/// The width is uniform across all namespaces and instances — that uniformity
+/// is what makes the scheme footgun-free: every prefix is the same length, so
+/// distinct prefixes are pairwise prefix-disjoint and no "bare" namespace can
+/// ever be a bit-prefix of one of its own instances. These bits sit *above*
+/// each subsystem's own internal reserved bits; the combined width stays within
+/// the 16-bit budget the codec enforces.
+pub const NAMESPACE_RESERVED_BITS: u8 = NAMESPACE_SLOT_BITS + NAMESPACE_INSTANCE_BITS;
+
+/// Canonical key-prefix allocation for the SDK's built-in subsystems when they
+/// co-tenant a single Store.
+///
+/// Co-tenancy is load-bearing: [`StoreWriteBatch`] commits rows from multiple
+/// subsystems in one atomic Store `Put`, so they must share a keyspace to get
+/// cross-subsystem atomicity. This enum is the single source of truth that
+/// keeps their slots from colliding. It is deliberately *not* a runtime
+/// registry — distinct variants of one fixed width are disjoint by construction.
+///
+/// Any subsystem can run more than one instance in a Store via [`Self::sub`];
+/// the bare namespace is exactly [`Self::sub(0)`](Self::sub).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum Namespace {
+    Sql,
+    Simplex,
+    Qmdb,
+}
+
+impl Namespace {
+    /// The subsystem slot stored in the high [`NAMESPACE_SLOT_BITS`].
+    #[inline]
+    const fn slot(self) -> u16 {
+        match self {
+            Namespace::Sql => 0,
+            Namespace::Simplex => 1,
+            Namespace::Qmdb => 2,
+        }
+    }
+
+    /// The canonical [`StoreKeyPrefix`] for this subsystem — its default
+    /// instance, i.e. [`Self::sub(0)`](Self::sub).
+    #[inline]
+    pub const fn key_prefix(self) -> StoreKeyPrefix {
+        self.sub(0)
+    }
+
+    /// The [`StoreKeyPrefix`] for `instance` of this subsystem.
+    ///
+    /// For a consumer that co-locates more than one instance of a subsystem in
+    /// one Store (e.g. QMDB's two operation logs). Every `sub` of every
+    /// namespace is the same fixed width, so they are all pairwise
+    /// prefix-disjoint — a prefix-bounded range scan in one can never observe
+    /// another's keys. `instance` must be less than `2^NAMESPACE_INSTANCE_BITS`.
+    #[inline]
+    pub const fn sub(self, instance: u8) -> StoreKeyPrefix {
+        assert!(
+            (instance as u16) < (1 << NAMESPACE_INSTANCE_BITS),
+            "namespace instance out of range",
+        );
+        let prefix = (self.slot() << NAMESPACE_INSTANCE_BITS) | instance as u16;
+        StoreKeyPrefix {
+            codec: KeyCodec::new(NAMESPACE_RESERVED_BITS, prefix),
+        }
+    }
+}
+
+/// A [`StoreClient`] guaranteed to carry a [`StoreKeyPrefix`].
+///
+/// Constructable only from a `(client, prefix)` pair, so a value of this type is
+/// *always* namespaced. Subsystem constructors that must not silently share a
+/// raw keyspace take this type instead of a bare [`StoreClient`], turning "did
+/// you namespace?" into a compile-time fact.
+///
+/// Intentionally does **not** `Deref` to [`StoreClient`]: that would re-expose
+/// [`StoreClient::without_key_prefix`] and let callers quietly drop the
+/// guarantee.
+#[derive(Clone, Debug)]
+pub struct PrefixedStoreClient {
+    client: StoreClient,
+}
+
+impl PrefixedStoreClient {
+    /// Wrap a client with an explicit namespace prefix.
+    pub fn new(mut client: StoreClient, prefix: StoreKeyPrefix) -> Self {
+        // Owned, so set the prefix in place instead of cloning via `with_key_prefix`.
+        client.key_prefix = Some(prefix);
+        Self { client }
+    }
+
+    /// Wrap a client with the canonical prefix for a built-in [`Namespace`].
+    pub fn for_namespace(client: StoreClient, namespace: Namespace) -> Self {
+        Self::new(client, namespace.key_prefix())
+    }
+
+    /// The configured key prefix (always present).
+    pub fn key_prefix(&self) -> StoreKeyPrefix {
+        self.client
+            .key_prefix()
+            .expect("PrefixedStoreClient always carries a prefix")
+    }
+
+    /// Borrow the underlying prefixed client for read/write operations.
+    pub fn client(&self) -> &StoreClient {
+        &self.client
+    }
+
+    /// Consume into the underlying (prefixed) client.
+    pub fn into_client(self) -> StoreClient {
+        self.client
+    }
+}
+
 /// A physical Store write batch assembled from one or more logical clients.
 ///
 /// Use [`Self::push`] with the specific prefixed client that produced each
@@ -1305,6 +1426,17 @@ impl StoreClient {
         let mut out = self.clone();
         out.key_prefix = None;
         out
+    }
+
+    /// Clone this client into a [`PrefixedStoreClient`] carrying `prefix`.
+    pub fn prefixed(&self, prefix: StoreKeyPrefix) -> PrefixedStoreClient {
+        PrefixedStoreClient::new(self.clone(), prefix)
+    }
+
+    /// Clone this client into a [`PrefixedStoreClient`] using the canonical
+    /// prefix for a built-in [`Namespace`].
+    pub fn for_namespace(&self, namespace: Namespace) -> PrefixedStoreClient {
+        PrefixedStoreClient::for_namespace(self.clone(), namespace)
     }
 
     /// Encode a logical key as it will appear in the physical Store.
@@ -2982,6 +3114,65 @@ mod tests {
         let physical = prefix.encode_key(&logical).unwrap();
         assert!(prefix.codec.matches(&physical));
         assert_eq!(prefix.decode_key(&physical).unwrap(), logical);
+    }
+
+    #[test]
+    fn namespace_prefixes_are_pairwise_disjoint() {
+        // Every leaf prefix: each subsystem's default and its other instance.
+        let all = [
+            Namespace::Sql.sub(0),
+            Namespace::Sql.sub(1),
+            Namespace::Simplex.sub(0),
+            Namespace::Simplex.sub(1),
+            Namespace::Qmdb.sub(0),
+            Namespace::Qmdb.sub(1),
+        ];
+        // A key encoded under one prefix never matches another's codec — so a
+        // prefix-bounded range scan in one can't observe another's keys (this is
+        // the bug being fixed). Uniform width ⇒ no prefix is a bit-prefix of
+        // another, including a subsystem's default vs its own sub(1).
+        let logical = Bytes::from_static(b"\x00\x10whatever-block-meta-or-op-log-key");
+        for (i, pa) in all.iter().enumerate() {
+            let physical = pa.encode_key(&logical).unwrap();
+            assert!(pa.codec.matches(&physical));
+            assert_eq!(pa.decode_key(&physical).unwrap(), logical);
+            for (j, pb) in all.iter().enumerate() {
+                if i == j {
+                    continue;
+                }
+                assert!(
+                    !pb.codec.matches(&physical),
+                    "prefix {j} matched a key encoded under prefix {i}",
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn namespace_default_is_instance_zero_and_all_widths_match() {
+        for ns in [Namespace::Sql, Namespace::Simplex, Namespace::Qmdb] {
+            assert_eq!(ns.key_prefix(), ns.sub(0));
+            assert_eq!(ns.sub(0).reserved_bits(), NAMESPACE_RESERVED_BITS);
+            assert_eq!(ns.sub(1).reserved_bits(), NAMESPACE_RESERVED_BITS);
+            // The two instances differ only in the low instance bit.
+            assert_eq!(ns.sub(0).prefix() ^ ns.sub(1).prefix(), 1);
+        }
+    }
+
+    #[test]
+    fn prefixed_store_client_always_carries_its_namespace_prefix() {
+        let base = StoreClient::new("http://localhost:8090");
+        assert!(base.key_prefix().is_none());
+        let sql = base.for_namespace(Namespace::Sql);
+        assert_eq!(sql.key_prefix(), Namespace::Sql.key_prefix());
+        assert_eq!(
+            sql.client().key_prefix(),
+            Some(Namespace::Sql.key_prefix()),
+            "underlying client carries the prefix for all reads/writes",
+        );
+        // A non-default sub instance also threads through.
+        let explicit = base.prefixed(Namespace::Qmdb.sub(1));
+        assert_eq!(explicit.key_prefix(), Namespace::Qmdb.sub(1));
     }
 
     #[test]

--- a/sdk/rs/src/lib.rs
+++ b/sdk/rs/src/lib.rs
@@ -934,6 +934,8 @@ pub trait StoreBatchUpload {
     type Receipt: Send;
     type Error: std::fmt::Display + Send;
 
+    fn store_client(&self) -> &PrefixedStoreClient;
+
     fn stage_upload(
         &self,
         prepared: &mut Self::Prepared,
@@ -962,7 +964,6 @@ pub trait StoreBatchUpload {
 
     fn commit_upload<'a>(
         &'a self,
-        client: &'a StoreClient,
         prepared: Self::Prepared,
     ) -> BoxFuture<'a, Result<Self::Receipt, Self::Error>>
     where
@@ -979,7 +980,7 @@ pub trait StoreBatchUpload {
                 self.mark_upload_failed(prepared, message).await;
                 return Err(err);
             }
-            match batch.commit(client).await {
+            match batch.commit(self.store_client().client()).await {
                 Ok(sequence_number) => {
                     Ok(self.mark_upload_persisted(prepared, sequence_number).await)
                 }
@@ -1004,6 +1005,10 @@ pub trait StoreBatchPublication {
     type PreparedPublication: Send;
     type PublicationReceipt: Send;
     type Error: std::fmt::Display + Send;
+
+    /// The namespaced client this writer stages and commits through. See
+    /// [`StoreBatchUpload::store_client`].
+    fn store_client(&self) -> &PrefixedStoreClient;
 
     fn stage_publication(
         &self,
@@ -1036,7 +1041,6 @@ pub trait StoreBatchPublication {
 
     fn commit_publication<'a>(
         &'a self,
-        client: &'a StoreClient,
         prepared: Self::PreparedPublication,
     ) -> BoxFuture<'a, Result<Self::PublicationReceipt, Self::Error>>
     where
@@ -1052,7 +1056,7 @@ pub trait StoreBatchPublication {
                 self.mark_publication_failed(prepared, message).await;
                 return Err(err);
             }
-            match batch.commit(client).await {
+            match batch.commit(self.store_client().client()).await {
                 Ok(sequence_number) => Ok(self
                     .mark_publication_persisted(prepared, sequence_number)
                     .await),

--- a/sdk/rs/src/lib.rs
+++ b/sdk/rs/src/lib.rs
@@ -339,80 +339,6 @@ impl StoreKeyPrefix {
     }
 }
 
-/// Reserved high bits selecting the *subsystem* within a namespace prefix.
-/// Three bits → up to eight subsystems.
-pub const NAMESPACE_SLOT_BITS: u8 = 3;
-
-/// Reserved high bits selecting the *instance* of a subsystem within a
-/// namespace prefix. One bit → up to two instances per subsystem (e.g. QMDB's
-/// account-state and transaction-history operation logs).
-pub const NAMESPACE_INSTANCE_BITS: u8 = 1;
-
-/// Total reserved high bits in *every* namespace key prefix (slot + instance).
-///
-/// The width is uniform across all namespaces and instances, so distinct
-/// prefixes are pairwise prefix-disjoint: no prefix is a bit-prefix of another,
-/// not even a bare namespace versus its own instances. These bits sit *above*
-/// each subsystem's own reserved bits; the combined width stays within the
-/// codec's 16-bit budget.
-pub const NAMESPACE_RESERVED_BITS: u8 = NAMESPACE_SLOT_BITS + NAMESPACE_INSTANCE_BITS;
-
-/// Canonical key-prefix allocation for the SDK's built-in subsystems when they
-/// co-tenant a single Store.
-///
-/// Co-tenancy is load-bearing: [`StoreWriteBatch`] commits rows from multiple
-/// subsystems in one atomic Store `Put`, so they must share a keyspace to get
-/// cross-subsystem atomicity. This enum is the single source of truth that
-/// keeps their slots from colliding. It is deliberately *not* a runtime
-/// registry — distinct variants of one fixed width are disjoint by construction.
-///
-/// Any subsystem can run more than one instance in a Store via [`Self::sub`];
-/// the bare namespace is exactly [`Self::sub(0)`](Self::sub).
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub enum Namespace {
-    Sql,
-    Simplex,
-    Qmdb,
-}
-
-impl Namespace {
-    /// The subsystem slot stored in the high [`NAMESPACE_SLOT_BITS`].
-    #[inline]
-    const fn slot(self) -> u16 {
-        match self {
-            Namespace::Sql => 0,
-            Namespace::Simplex => 1,
-            Namespace::Qmdb => 2,
-        }
-    }
-
-    /// The canonical [`StoreKeyPrefix`] for this subsystem — its default
-    /// instance, i.e. [`Self::sub(0)`](Self::sub).
-    #[inline]
-    pub const fn key_prefix(self) -> StoreKeyPrefix {
-        self.sub(0)
-    }
-
-    /// The [`StoreKeyPrefix`] for `instance` of this subsystem.
-    ///
-    /// For a consumer that co-locates more than one instance of a subsystem in
-    /// one Store (e.g. QMDB's two operation logs). Every `sub` of every
-    /// namespace is the same fixed width, so they are all pairwise
-    /// prefix-disjoint — a prefix-bounded range scan in one can never observe
-    /// another's keys. `instance` must be less than `2^NAMESPACE_INSTANCE_BITS`.
-    #[inline]
-    pub const fn sub(self, instance: u8) -> StoreKeyPrefix {
-        assert!(
-            (instance as u16) < (1 << NAMESPACE_INSTANCE_BITS),
-            "namespace instance out of range",
-        );
-        let prefix = (self.slot() << NAMESPACE_INSTANCE_BITS) | instance as u16;
-        StoreKeyPrefix {
-            codec: KeyCodec::new(NAMESPACE_RESERVED_BITS, prefix),
-        }
-    }
-}
-
 /// A physical [`StoreClient`] paired with a [`StoreKeyPrefix`] that namespaces
 /// every key on the wire. The prefix can be the zero-width
 /// [`StoreKeyPrefix::identity`], representing the un-namespaced case.
@@ -426,12 +352,6 @@ impl PrefixedStoreClient {
     /// Pair a physical client with an explicit namespace prefix.
     pub fn new(client: StoreClient, prefix: StoreKeyPrefix) -> Self {
         Self { client, prefix }
-    }
-
-    /// Pair a physical client with the canonical prefix for a built-in
-    /// [`Namespace`].
-    pub fn for_namespace(client: StoreClient, namespace: Namespace) -> Self {
-        Self::new(client, namespace.key_prefix())
     }
 
     /// Pair a physical client with the zero-width [`StoreKeyPrefix::identity`],
@@ -1904,12 +1824,6 @@ impl StoreClient {
         PrefixedStoreClient::new(self.clone(), prefix)
     }
 
-    /// Pair this physical client with the canonical prefix for a built-in
-    /// [`Namespace`].
-    pub fn for_namespace(&self, namespace: Namespace) -> PrefixedStoreClient {
-        PrefixedStoreClient::for_namespace(self.clone(), namespace)
-    }
-
     /// Outgoing Connect request body compression (see [`ConnectRequestCompression`]).
     pub fn connect_request_compression(&self) -> ConnectRequestCompression {
         self.connect_request_compression
@@ -3181,20 +3095,20 @@ mod tests {
     }
 
     #[test]
-    fn namespace_prefixes_are_pairwise_disjoint() {
-        // Every leaf prefix: each subsystem's default and its other instance.
+    fn uniform_width_prefixes_are_pairwise_disjoint() {
+        // Six leaf prefixes sharing one uniform reserved width.
         let all = [
-            Namespace::Sql.sub(0),
-            Namespace::Sql.sub(1),
-            Namespace::Simplex.sub(0),
-            Namespace::Simplex.sub(1),
-            Namespace::Qmdb.sub(0),
-            Namespace::Qmdb.sub(1),
+            StoreKeyPrefix::new(4, 0).unwrap(),
+            StoreKeyPrefix::new(4, 1).unwrap(),
+            StoreKeyPrefix::new(4, 2).unwrap(),
+            StoreKeyPrefix::new(4, 3).unwrap(),
+            StoreKeyPrefix::new(4, 4).unwrap(),
+            StoreKeyPrefix::new(4, 5).unwrap(),
         ];
         // A key encoded under one prefix never matches another's codec — so a
         // prefix-bounded range scan in one can't observe another's keys (this is
         // the bug being fixed). Uniform width ⇒ no prefix is a bit-prefix of
-        // another, including a subsystem's default vs its own sub(1).
+        // another.
         let logical = Bytes::from_static(b"\x00\x10whatever-block-meta-or-op-log-key");
         for (i, pa) in all.iter().enumerate() {
             let physical = pa.encode_key(&logical).unwrap();
@@ -3213,30 +3127,17 @@ mod tests {
     }
 
     #[test]
-    fn namespace_default_is_instance_zero_and_all_widths_match() {
-        for ns in [Namespace::Sql, Namespace::Simplex, Namespace::Qmdb] {
-            assert_eq!(ns.key_prefix(), ns.sub(0));
-            assert_eq!(ns.sub(0).reserved_bits(), NAMESPACE_RESERVED_BITS);
-            assert_eq!(ns.sub(1).reserved_bits(), NAMESPACE_RESERVED_BITS);
-            // The two instances differ only in the low instance bit.
-            assert_eq!(ns.sub(0).prefix() ^ ns.sub(1).prefix(), 1);
-        }
-    }
-
-    #[test]
-    fn prefixed_store_client_always_carries_its_namespace_prefix() {
+    fn prefixed_store_client_always_carries_its_prefix() {
         let base = StoreClient::new("http://localhost:8090");
-        let sql = base.for_namespace(Namespace::Sql);
-        assert_eq!(sql.key_prefix(), Namespace::Sql.key_prefix());
-        // The logical client encodes through its namespace prefix.
+        let prefix = StoreKeyPrefix::new(4, 0).unwrap();
+        let client = base.prefixed(prefix);
+        assert_eq!(client.key_prefix(), prefix);
+        // The logical client encodes through its prefix.
         let logical = Bytes::from_static(b"row");
         assert_eq!(
-            sql.encode_store_key(&logical).unwrap(),
-            Namespace::Sql.key_prefix().encode_key(&logical).unwrap(),
+            client.encode_store_key(&logical).unwrap(),
+            prefix.encode_key(&logical).unwrap(),
         );
-        // A non-default sub instance also threads through.
-        let explicit = base.prefixed(Namespace::Qmdb.sub(1));
-        assert_eq!(explicit.key_prefix(), Namespace::Qmdb.sub(1));
     }
 
     #[test]

--- a/simplex/rs/README.md
+++ b/simplex/rs/README.md
@@ -24,7 +24,9 @@ use exoware_simplex::{Finalized, SimplexClient};
 #   S: commonware_cryptography::certificate::Scheme,
 #   D: commonware_cryptography::Digest,
 # {
-let client = SimplexClient::new(exoware_sdk::StoreClient::new(store_url));
+let client = SimplexClient::new(
+    exoware_sdk::StoreClient::new(store_url).prefixed(exoware_sdk::StoreKeyPrefix::identity()),
+);
 let finalized = Finalized::new(proof, header)?;
 let receipt = client.upload_finalized(&finalized).await?;
 println!("stored at sequence {}", receipt.store_sequence_number);

--- a/simplex/rs/README.md
+++ b/simplex/rs/README.md
@@ -24,7 +24,7 @@ use exoware_simplex::{Finalized, SimplexClient};
 #   S: commonware_cryptography::certificate::Scheme,
 #   D: commonware_cryptography::Digest,
 # {
-let client = SimplexClient::new(store_url);
+let client = SimplexClient::new(exoware_sdk::StoreClient::new(store_url));
 let finalized = Finalized::new(proof, header)?;
 let receipt = client.upload_finalized(&finalized).await?;
 println!("stored at sequence {}", receipt.store_sequence_number);

--- a/simplex/rs/src/bin/simplex.rs
+++ b/simplex/rs/src/bin/simplex.rs
@@ -223,33 +223,34 @@ async fn upload_certificates(
     let block = encode_block_data(&finalized.header, body);
     let notarized_bytes = notarized.encode();
     let finalized_bytes = finalized.encode();
+    let prefix = client.store_client().key_prefix();
     let mut batch = StoreWriteBatch::new();
     batch.push(
-        client.store_client(),
+        prefix,
         &keys::header_by_digest(&finalized.header.digest()),
         header,
     )?;
     batch.push(
-        client.store_client(),
+        prefix,
         &keys::block_by_digest(&finalized.header.digest()),
         block,
     )?;
     batch.push(
-        client.store_client(),
+        prefix,
         &keys::notarization_by_view(notarized.proof.view()),
         notarized_bytes,
     )?;
     batch.push(
-        client.store_client(),
+        prefix,
         &keys::finalization_by_view(finalized.proof.view()),
         finalized_bytes.clone(),
     )?;
     batch.push(
-        client.store_client(),
+        prefix,
         &keys::finalized_by_height(finalized.header.height()),
         finalized_bytes,
     )?;
-    Ok(batch.commit(client.store_client()).await?)
+    Ok(batch.commit(client.store_client().client()).await?)
 }
 
 async fn seed(

--- a/simplex/rs/src/bin/simplex.rs
+++ b/simplex/rs/src/bin/simplex.rs
@@ -19,7 +19,7 @@ use commonware_cryptography::{
 use commonware_math::algebra::Random;
 use commonware_parallel::Sequential;
 use commonware_utils::{ordered::Set, N3f1};
-use exoware_sdk::{StoreClient, StoreWriteBatch};
+use exoware_sdk::{StoreClient, StoreKeyPrefix, StoreWriteBatch};
 use exoware_simplex::{encode_block_data, keys, Finalized, Notarized, SimplexClient};
 use rand::{rngs::StdRng, SeedableRng};
 use tracing::info;
@@ -260,7 +260,8 @@ async fn seed(
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     info!(store_url, interval_secs, "starting simplex seed");
 
-    let client = SimplexClient::new(StoreClient::new(store_url));
+    let client =
+        SimplexClient::new(StoreClient::new(store_url).prefixed(StoreKeyPrefix::identity()));
     let schemes = demo_schemes();
     let verification_material = schemes[0].identity().encode().to_vec();
     let leader = schemes

--- a/simplex/rs/src/bin/simplex.rs
+++ b/simplex/rs/src/bin/simplex.rs
@@ -19,7 +19,7 @@ use commonware_cryptography::{
 use commonware_math::algebra::Random;
 use commonware_parallel::Sequential;
 use commonware_utils::{ordered::Set, N3f1};
-use exoware_sdk::StoreWriteBatch;
+use exoware_sdk::{StoreClient, StoreWriteBatch};
 use exoware_simplex::{encode_block_data, keys, Finalized, Notarized, SimplexClient};
 use rand::{rngs::StdRng, SeedableRng};
 use tracing::info;
@@ -259,7 +259,7 @@ async fn seed(
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     info!(store_url, interval_secs, "starting simplex seed");
 
-    let client = SimplexClient::new(store_url);
+    let client = SimplexClient::new(StoreClient::new(store_url));
     let schemes = demo_schemes();
     let verification_material = schemes[0].identity().encode().to_vec();
     let leader = schemes

--- a/simplex/rs/src/client.rs
+++ b/simplex/rs/src/client.rs
@@ -187,7 +187,7 @@ impl SimplexClient {
             return Err(SimplexError::EmptyUpload);
         }
         for entry in prepared.entries() {
-            batch.push(&self.client, &entry.key, entry.value.clone())?;
+            batch.push(self.client.key_prefix(), &entry.key, entry.value.clone())?;
         }
         Ok(())
     }
@@ -210,7 +210,7 @@ impl SimplexClient {
         B: Block,
     {
         let prepared = self.prepare_header(header);
-        self.commit_upload(&self.client, prepared).await
+        self.commit_upload(self.client.client(), prepared).await
     }
 
     pub async fn upload_block<B>(
@@ -222,7 +222,7 @@ impl SimplexClient {
         B: Block,
     {
         let prepared = self.prepare_block(header, body);
-        self.commit_upload(&self.client, prepared).await
+        self.commit_upload(self.client.client(), prepared).await
     }
 
     pub async fn upload_notarized<B, S, D>(
@@ -235,7 +235,7 @@ impl SimplexClient {
         D: Digest,
     {
         let prepared = self.prepare_notarized(notarized)?;
-        self.commit_upload(&self.client, prepared).await
+        self.commit_upload(self.client.client(), prepared).await
     }
 
     pub async fn upload_finalized<B, S, D>(
@@ -248,7 +248,7 @@ impl SimplexClient {
         D: Digest,
     {
         let prepared = self.prepare_finalized(finalized)?;
-        self.commit_upload(&self.client, prepared).await
+        self.commit_upload(self.client.client(), prepared).await
     }
 
     pub async fn get_header_raw<D: Digest>(

--- a/simplex/rs/src/client.rs
+++ b/simplex/rs/src/client.rs
@@ -74,33 +74,26 @@ impl PreparedUpload {
 /// - finalized `{ proof, header }` bytes by header height
 #[derive(Clone, Debug)]
 pub struct SimplexClient {
-    client: StoreClient,
+    client: PrefixedStoreClient,
 }
 
 impl SimplexClient {
     /// Build a client over the canonical [`Namespace::Simplex`] keyspace — the
-    /// safe default when the Store is co-tenanted with SQL/QMDB. Use
-    /// [`Self::unprefixed`] only for a Store simplex owns exclusively.
+    /// safe default when the Store is co-tenanted with SQL/QMDB.
     pub fn new(client: StoreClient) -> Self {
-        Self::prefixed(client.for_namespace(Namespace::Simplex))
+        Self::from_prefixed(client.for_namespace(Namespace::Simplex))
     }
 
     /// Build a client over a caller-chosen namespace.
-    pub fn prefixed(client: PrefixedStoreClient) -> Self {
-        Self::unprefixed(client.into_client())
-    }
-
-    /// Build a client over a raw, un-namespaced client — escape hatch for a
-    /// Store simplex owns exclusively.
-    pub fn unprefixed(client: StoreClient) -> Self {
+    pub fn from_prefixed(client: PrefixedStoreClient) -> Self {
         Self { client }
     }
 
-    pub fn store_client(&self) -> &StoreClient {
+    pub fn store_client(&self) -> &PrefixedStoreClient {
         &self.client
     }
 
-    pub fn into_store_client(self) -> StoreClient {
+    pub fn into_store_client(self) -> PrefixedStoreClient {
         self.client
     }
 

--- a/simplex/rs/src/client.rs
+++ b/simplex/rs/src/client.rs
@@ -3,10 +3,7 @@ use commonware_codec::{Decode, Encode};
 use commonware_consensus::{Block, Viewable};
 use commonware_cryptography::{certificate, Digest};
 use exoware_sdk::keys::Key;
-use exoware_sdk::{
-    ClientError, Namespace, PrefixedStoreClient, RangeMode, StoreBatchUpload, StoreClient,
-    StoreWriteBatch,
-};
+use exoware_sdk::{ClientError, PrefixedStoreClient, RangeMode, StoreBatchUpload, StoreWriteBatch};
 use futures::future::BoxFuture;
 
 use crate::error::SimplexError;
@@ -78,14 +75,8 @@ pub struct SimplexClient {
 }
 
 impl SimplexClient {
-    /// Build a client over the canonical [`Namespace::Simplex`] keyspace — the
-    /// safe default when the Store is co-tenanted with SQL/QMDB.
-    pub fn new(client: StoreClient) -> Self {
-        Self::from_prefixed(client.for_namespace(Namespace::Simplex))
-    }
-
-    /// Build a client over a caller-chosen namespace.
-    pub fn from_prefixed(client: PrefixedStoreClient) -> Self {
+    /// Build a client over `client`'s namespace prefix.
+    pub fn new(client: PrefixedStoreClient) -> Self {
         Self { client }
     }
 

--- a/simplex/rs/src/client.rs
+++ b/simplex/rs/src/client.rs
@@ -3,7 +3,10 @@ use commonware_codec::{Decode, Encode};
 use commonware_consensus::{Block, Viewable};
 use commonware_cryptography::{certificate, Digest};
 use exoware_sdk::keys::Key;
-use exoware_sdk::{ClientError, RangeMode, StoreBatchUpload, StoreClient, StoreWriteBatch};
+use exoware_sdk::{
+    ClientError, Namespace, PrefixedStoreClient, RangeMode, StoreBatchUpload, StoreClient,
+    StoreWriteBatch,
+};
 use futures::future::BoxFuture;
 
 use crate::error::SimplexError;
@@ -75,11 +78,21 @@ pub struct SimplexClient {
 }
 
 impl SimplexClient {
-    pub fn new(store_url: &str) -> Self {
-        Self::from_client(StoreClient::new(store_url))
+    /// Build a client over the canonical [`Namespace::Simplex`] keyspace — the
+    /// safe default when the Store is co-tenanted with SQL/QMDB. Use
+    /// [`Self::unprefixed`] only for a Store simplex owns exclusively.
+    pub fn new(client: StoreClient) -> Self {
+        Self::prefixed(client.for_namespace(Namespace::Simplex))
     }
 
-    pub fn from_client(client: StoreClient) -> Self {
+    /// Build a client over a caller-chosen namespace.
+    pub fn prefixed(client: PrefixedStoreClient) -> Self {
+        Self::unprefixed(client.into_client())
+    }
+
+    /// Build a client over a raw, un-namespaced client — escape hatch for a
+    /// Store simplex owns exclusively.
+    pub fn unprefixed(client: StoreClient) -> Self {
         Self { client }
     }
 

--- a/simplex/rs/src/client.rs
+++ b/simplex/rs/src/client.rs
@@ -201,7 +201,7 @@ impl SimplexClient {
         B: Block,
     {
         let prepared = self.prepare_header(header);
-        self.commit_upload(self.client.client(), prepared).await
+        self.commit_upload(prepared).await
     }
 
     pub async fn upload_block<B>(
@@ -213,7 +213,7 @@ impl SimplexClient {
         B: Block,
     {
         let prepared = self.prepare_block(header, body);
-        self.commit_upload(self.client.client(), prepared).await
+        self.commit_upload(prepared).await
     }
 
     pub async fn upload_notarized<B, S, D>(
@@ -226,7 +226,7 @@ impl SimplexClient {
         D: Digest,
     {
         let prepared = self.prepare_notarized(notarized)?;
-        self.commit_upload(self.client.client(), prepared).await
+        self.commit_upload(prepared).await
     }
 
     pub async fn upload_finalized<B, S, D>(
@@ -239,7 +239,7 @@ impl SimplexClient {
         D: Digest,
     {
         let prepared = self.prepare_finalized(finalized)?;
-        self.commit_upload(self.client.client(), prepared).await
+        self.commit_upload(prepared).await
     }
 
     pub async fn get_header_raw<D: Digest>(
@@ -389,6 +389,10 @@ impl StoreBatchUpload for SimplexClient {
     type Prepared = PreparedUpload;
     type Receipt = UploadReceipt;
     type Error = SimplexError;
+
+    fn store_client(&self) -> &PrefixedStoreClient {
+        &self.client
+    }
 
     fn stage_upload(
         &self,

--- a/simplex/rs/tests/e2e.rs
+++ b/simplex/rs/tests/e2e.rs
@@ -315,7 +315,7 @@ async fn prepared_uploads_can_share_one_store_batch() {
     prepared.extend(simplex.prepare_finalized(&second).expect("second"));
 
     let receipt = simplex
-        .commit_upload(simplex.store_client().client(), prepared)
+        .commit_upload(prepared)
         .await
         .expect("commit combined");
     assert_eq!(receipt.summary.headers, 2);

--- a/simplex/rs/tests/e2e.rs
+++ b/simplex/rs/tests/e2e.rs
@@ -315,7 +315,7 @@ async fn prepared_uploads_can_share_one_store_batch() {
     prepared.extend(simplex.prepare_finalized(&second).expect("second"));
 
     let receipt = simplex
-        .commit_upload(simplex.store_client(), prepared)
+        .commit_upload(simplex.store_client().client(), prepared)
         .await
         .expect("commit combined");
     assert_eq!(receipt.summary.headers, 2);

--- a/simplex/rs/tests/e2e.rs
+++ b/simplex/rs/tests/e2e.rs
@@ -229,7 +229,7 @@ fn finalized(block: TestBlock, schemes: &[Scheme]) -> Finalized<TestBlock, Schem
 #[tokio::test]
 async fn uploads_and_reads_notarized_and_finalized_blocks() {
     let (_dir, _handle, store) = local_store_client().await;
-    let simplex = SimplexClient::from_client(store);
+    let simplex = SimplexClient::unprefixed(store);
     let schemes = schemes();
 
     let block1 = TestBlock::new(1, b"notarized");
@@ -305,7 +305,7 @@ async fn uploads_and_reads_notarized_and_finalized_blocks() {
 #[tokio::test]
 async fn prepared_uploads_can_share_one_store_batch() {
     let (_dir, _handle, store) = local_store_client().await;
-    let simplex = SimplexClient::from_client(store.clone());
+    let simplex = SimplexClient::unprefixed(store.clone());
     let schemes = schemes();
 
     let first = finalized(TestBlock::new(10, b"first"), &schemes);
@@ -337,7 +337,7 @@ async fn marshal_resolver_sinks_finalized_chain_from_simplex_api() {
     const BLOCKS_TO_PROCESS: u64 = 5;
 
     let (_dir, _handle, store) = local_store_client().await;
-    let simplex = SimplexClient::from_client(store);
+    let simplex = SimplexClient::unprefixed(store);
     let schemes = schemes();
 
     let genesis = TestBlock::new(0, b"genesis");

--- a/simplex/rs/tests/e2e.rs
+++ b/simplex/rs/tests/e2e.rs
@@ -24,7 +24,7 @@ use commonware_utils::{
     vec::NonEmptyVec,
     Acknowledgement as _, NZUsize, NZU16, NZU64,
 };
-use exoware_sdk::{RetryConfig, StoreBatchUpload, StoreClient};
+use exoware_sdk::{PrefixedStoreClient, RetryConfig, StoreBatchUpload, StoreClient};
 use exoware_simplex::{Finalized, MarshalResolver, Notarized, SimplexClient};
 use rand::{rngs::StdRng, SeedableRng};
 
@@ -229,7 +229,7 @@ fn finalized(block: TestBlock, schemes: &[Scheme]) -> Finalized<TestBlock, Schem
 #[tokio::test]
 async fn uploads_and_reads_notarized_and_finalized_blocks() {
     let (_dir, _handle, store) = local_store_client().await;
-    let simplex = SimplexClient::unprefixed(store);
+    let simplex = SimplexClient::from_prefixed(PrefixedStoreClient::empty(store));
     let schemes = schemes();
 
     let block1 = TestBlock::new(1, b"notarized");
@@ -305,7 +305,7 @@ async fn uploads_and_reads_notarized_and_finalized_blocks() {
 #[tokio::test]
 async fn prepared_uploads_can_share_one_store_batch() {
     let (_dir, _handle, store) = local_store_client().await;
-    let simplex = SimplexClient::unprefixed(store.clone());
+    let simplex = SimplexClient::from_prefixed(PrefixedStoreClient::empty(store.clone()));
     let schemes = schemes();
 
     let first = finalized(TestBlock::new(10, b"first"), &schemes);
@@ -315,7 +315,7 @@ async fn prepared_uploads_can_share_one_store_batch() {
     prepared.extend(simplex.prepare_finalized(&second).expect("second"));
 
     let receipt = simplex
-        .commit_upload(&store, prepared)
+        .commit_upload(simplex.store_client(), prepared)
         .await
         .expect("commit combined");
     assert_eq!(receipt.summary.headers, 2);
@@ -337,7 +337,7 @@ async fn marshal_resolver_sinks_finalized_chain_from_simplex_api() {
     const BLOCKS_TO_PROCESS: u64 = 5;
 
     let (_dir, _handle, store) = local_store_client().await;
-    let simplex = SimplexClient::unprefixed(store);
+    let simplex = SimplexClient::from_prefixed(PrefixedStoreClient::empty(store));
     let schemes = schemes();
 
     let genesis = TestBlock::new(0, b"genesis");

--- a/simplex/rs/tests/e2e.rs
+++ b/simplex/rs/tests/e2e.rs
@@ -229,7 +229,7 @@ fn finalized(block: TestBlock, schemes: &[Scheme]) -> Finalized<TestBlock, Schem
 #[tokio::test]
 async fn uploads_and_reads_notarized_and_finalized_blocks() {
     let (_dir, _handle, store) = local_store_client().await;
-    let simplex = SimplexClient::from_prefixed(PrefixedStoreClient::empty(store));
+    let simplex = SimplexClient::new(PrefixedStoreClient::empty(store));
     let schemes = schemes();
 
     let block1 = TestBlock::new(1, b"notarized");
@@ -305,7 +305,7 @@ async fn uploads_and_reads_notarized_and_finalized_blocks() {
 #[tokio::test]
 async fn prepared_uploads_can_share_one_store_batch() {
     let (_dir, _handle, store) = local_store_client().await;
-    let simplex = SimplexClient::from_prefixed(PrefixedStoreClient::empty(store.clone()));
+    let simplex = SimplexClient::new(PrefixedStoreClient::empty(store.clone()));
     let schemes = schemes();
 
     let first = finalized(TestBlock::new(10, b"first"), &schemes);
@@ -337,7 +337,7 @@ async fn marshal_resolver_sinks_finalized_chain_from_simplex_api() {
     const BLOCKS_TO_PROCESS: u64 = 5;
 
     let (_dir, _handle, store) = local_store_client().await;
-    let simplex = SimplexClient::from_prefixed(PrefixedStoreClient::empty(store));
+    let simplex = SimplexClient::new(PrefixedStoreClient::empty(store));
     let schemes = schemes();
 
     let genesis = TestBlock::new(0, b"genesis");

--- a/sql/rs/benches/read_path_perf.rs
+++ b/sql/rs/benches/read_path_perf.rs
@@ -25,7 +25,7 @@ use exoware_proto::store::query::v1::{
 };
 use exoware_sdk as exoware_proto;
 use exoware_sdk::keys::Key;
-use exoware_sdk::StoreClient;
+use exoware_sdk::{StoreClient, StoreKeyPrefix};
 use exoware_sql::{CellValue, IndexSpec, KvSchema, TableColumnConfig};
 use futures::stream;
 use tokio::runtime::Runtime;
@@ -278,7 +278,7 @@ fn bench_exoware_sql_end_to_end_index_scan(c: &mut Criterion) {
 
     let base_url = format!("http://{addr}");
     let client = StoreClient::new(&base_url);
-    let schema = KvSchema::new(client.clone())
+    let schema = KvSchema::new(client.prefixed(StoreKeyPrefix::identity()))
         .table(
             "orders",
             vec![

--- a/sql/rs/examples/join_kv.rs
+++ b/sql/rs/examples/join_kv.rs
@@ -2,7 +2,7 @@ use datafusion::arrow::datatypes::DataType;
 use datafusion::arrow::util::pretty::print_batches;
 use datafusion::common::Result as DataFusionResult;
 use datafusion::prelude::SessionContext;
-use exoware_sdk::StoreClient;
+use exoware_sdk::{StoreClient, StoreKeyPrefix};
 use exoware_sql::{IndexSpec, KvSchema, TableColumnConfig};
 
 #[tokio::main]
@@ -12,7 +12,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let client = StoreClient::new(&base_url);
     let ctx = SessionContext::new();
 
-    KvSchema::new(client)
+    KvSchema::new(client.prefixed(StoreKeyPrefix::identity()))
         .table(
             "customers",
             vec![

--- a/sql/rs/examples/orders_kv.rs
+++ b/sql/rs/examples/orders_kv.rs
@@ -1,7 +1,7 @@
 use datafusion::arrow::util::pretty::print_batches;
 use datafusion::common::Result as DataFusionResult;
 use datafusion::prelude::SessionContext;
-use exoware_sdk::StoreClient;
+use exoware_sdk::{StoreClient, StoreKeyPrefix};
 use exoware_sql::{default_orders_index_specs, KvSchema};
 
 #[tokio::main]
@@ -12,7 +12,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let ctx = SessionContext::new();
     let index_specs = default_orders_index_specs();
 
-    KvSchema::new(client)
+    KvSchema::new(client.prefixed(StoreKeyPrefix::identity()))
         .orders_table("orders_kv", index_specs)
         .map_err(datafusion::common::DataFusionError::Execution)?
         .register_all(&ctx)?;

--- a/sql/rs/examples/types_kv.rs
+++ b/sql/rs/examples/types_kv.rs
@@ -1,7 +1,7 @@
 use datafusion::arrow::datatypes::DataType;
 use datafusion::arrow::util::pretty::print_batches;
 use datafusion::prelude::SessionContext;
-use exoware_sdk::StoreClient;
+use exoware_sdk::{StoreClient, StoreKeyPrefix};
 use exoware_sql::{CellValue, IndexSpec, KvSchema, TableColumnConfig};
 
 #[tokio::main]
@@ -11,7 +11,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let client = StoreClient::new(&base_url);
     let ctx = SessionContext::new();
 
-    let schema = KvSchema::new(client)
+    let schema = KvSchema::new(client.prefixed(StoreKeyPrefix::identity()))
         .table(
             "wallets",
             vec![
@@ -56,7 +56,7 @@ async fn demo_batch_writer_insert() {
     println!("\n== BatchWriter: programmatic insert with FixedSizeBinary ==");
 
     let client = StoreClient::new("http://localhost:10000");
-    let schema = KvSchema::new(client)
+    let schema = KvSchema::new(client.prefixed(StoreKeyPrefix::identity()))
         .table(
             "wallets",
             vec![

--- a/sql/rs/examples/versioned_kv.rs
+++ b/sql/rs/examples/versioned_kv.rs
@@ -1,7 +1,7 @@
 use datafusion::arrow::datatypes::DataType;
 use datafusion::arrow::util::pretty::print_batches;
 use datafusion::prelude::SessionContext;
-use exoware_sdk::StoreClient;
+use exoware_sdk::{StoreClient, StoreKeyPrefix};
 use exoware_sql::{CellValue, KvSchema, TableColumnConfig};
 
 const DOC_ID_HEX: &str = "d0c1aabbccddeeff0011223344556677";
@@ -32,7 +32,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 fn build_schema(client: StoreClient) -> Result<KvSchema, String> {
-    KvSchema::new(client).table_versioned(
+    KvSchema::new(client.prefixed(StoreKeyPrefix::identity())).table_versioned(
         "documents",
         vec![
             TableColumnConfig::new("doc_id", DataType::FixedSizeBinary(16), false),

--- a/sql/rs/src/aggregate.rs
+++ b/sql/rs/src/aggregate.rs
@@ -32,7 +32,7 @@ use exoware_sdk::kv_codec::{
     canonicalize_reduced_group_values, encode_reduced_group_key, KvExpr, KvFieldKind, KvFieldRef,
     KvPredicate, KvPredicateCheck, KvPredicateConstraint, KvReducedValue,
 };
-use exoware_sdk::{SerializableReadSession, StoreClient};
+use exoware_sdk::{PrefixedStoreClient, SerializableReadSession};
 use futures::SinkExt;
 
 use crate::diagnostics::*;
@@ -138,7 +138,7 @@ pub(crate) struct AggregateGroupPlan {
 
 #[derive(Debug, Clone)]
 pub(crate) struct AggregatePushdownSpec {
-    pub(crate) client: StoreClient,
+    pub(crate) client: PrefixedStoreClient,
     pub(crate) group_plans: Vec<AggregateGroupPlan>,
     pub(crate) seed_job: Option<AggregateReduceJob>,
     pub(crate) aggregate_jobs: Vec<CombinedAggregateJob>,

--- a/sql/rs/src/bin/sql.rs
+++ b/sql/rs/src/bin/sql.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use axum::{routing::get, Router};
 use clap::{Parser, Subcommand};
-use exoware_sdk::StoreClient;
+use exoware_sdk::{StoreClient, StoreKeyPrefix};
 use exoware_sql::{default_orders_index_specs, sql_connect_stack, KvSchema, SqlServer};
 use tower_http::cors::CorsLayer;
 use tracing::info;
@@ -42,7 +42,7 @@ async fn health() -> &'static str {
 fn build_server(
     store_url: &str,
 ) -> Result<Arc<SqlServer>, Box<dyn std::error::Error + Send + Sync>> {
-    let client = StoreClient::new(store_url);
+    let client = StoreClient::new(store_url).prefixed(StoreKeyPrefix::identity());
     let schema = KvSchema::new(client)
         .orders_table(TABLE_NAME, default_orders_index_specs())
         .map_err(|e| format!("configure schema: {e}"))?;

--- a/sql/rs/src/lib.rs
+++ b/sql/rs/src/lib.rs
@@ -52,7 +52,9 @@ mod tests {
         canonicalize_reduced_group_values, decode_stored_row, encode_reduced_group_key,
         eval_predicate, KvReducedValue, StoredRow,
     };
-    use exoware_sdk::{RangeReduceOp, RangeReduceRequest, StoreBatchUpload, StoreClient};
+    use exoware_sdk::{
+        PrefixedStoreClient, RangeReduceOp, RangeReduceRequest, StoreBatchUpload, StoreClient,
+    };
     use std::collections::{BTreeMap, HashSet};
     use std::ops::Bound::{Included, Unbounded};
     use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering as AtomicOrdering};
@@ -4924,7 +4926,7 @@ mod tests {
         let (base_url, shutdown_tx) = spawn_mock_server(state.clone()).await;
         let client = StoreClient::new(&base_url);
 
-        let seed_schema = KvSchema::unprefixed(client.clone())
+        let seed_schema = KvSchema::from_prefixed(PrefixedStoreClient::empty(client.clone()))
             .table(
                 "orders",
                 vec![
@@ -4965,7 +4967,7 @@ mod tests {
             assert_eq!(index_rows, 0);
         }
 
-        let backfill_schema = KvSchema::unprefixed(client.clone())
+        let backfill_schema = KvSchema::from_prefixed(PrefixedStoreClient::empty(client.clone()))
             .table(
                 "orders",
                 vec![
@@ -5024,7 +5026,7 @@ mod tests {
         let (base_url, shutdown_tx) = spawn_mock_server(state.clone()).await;
         let client = StoreClient::new(&base_url);
 
-        let seed_schema = KvSchema::unprefixed(client.clone())
+        let seed_schema = KvSchema::from_prefixed(PrefixedStoreClient::empty(client.clone()))
             .table(
                 "points",
                 vec![
@@ -5053,7 +5055,7 @@ mod tests {
         }
         writer.flush().await.expect("seed flush");
 
-        let backfill_schema = KvSchema::unprefixed(client.clone())
+        let backfill_schema = KvSchema::from_prefixed(PrefixedStoreClient::empty(client.clone()))
             .table(
                 "points",
                 vec![
@@ -5326,7 +5328,7 @@ mod tests {
         let (base_url, shutdown_tx) = spawn_mock_server(state.clone()).await;
         let client = StoreClient::new(&base_url);
 
-        let seed_schema = KvSchema::unprefixed(client.clone())
+        let seed_schema = KvSchema::from_prefixed(PrefixedStoreClient::empty(client.clone()))
             .table(
                 "orders",
                 vec![
@@ -5353,7 +5355,7 @@ mod tests {
         }
         writer.flush().await.expect("seed flush");
 
-        let backfill_schema = KvSchema::unprefixed(client.clone())
+        let backfill_schema = KvSchema::from_prefixed(PrefixedStoreClient::empty(client.clone()))
             .table(
                 "orders",
                 vec![
@@ -5440,7 +5442,7 @@ mod tests {
         let (base_url, shutdown_tx) = spawn_mock_server(state.clone()).await;
         let client = StoreClient::new(&base_url);
 
-        let schema = KvSchema::unprefixed(client.clone())
+        let schema = KvSchema::from_prefixed(PrefixedStoreClient::empty(client.clone()))
             .table(
                 "orders",
                 vec![
@@ -5507,7 +5509,7 @@ mod tests {
         let (base_url, shutdown_tx) = spawn_mock_server(state.clone()).await;
         let client = StoreClient::new(&base_url);
 
-        let schema = KvSchema::unprefixed(client.clone())
+        let schema = KvSchema::from_prefixed(PrefixedStoreClient::empty(client.clone()))
             .table(
                 "orders",
                 vec![
@@ -5668,7 +5670,7 @@ mod tests {
         let (base_url, shutdown_tx) = spawn_mock_server(state.clone()).await;
         let client = StoreClient::new(&base_url);
 
-        let seed_schema = KvSchema::unprefixed(client.clone())
+        let seed_schema = KvSchema::from_prefixed(PrefixedStoreClient::empty(client.clone()))
             .table(
                 "orders",
                 vec![
@@ -5695,7 +5697,7 @@ mod tests {
         }
         writer.flush().await.expect("seed flush");
 
-        let backfill_schema = KvSchema::unprefixed(client.clone())
+        let backfill_schema = KvSchema::from_prefixed(PrefixedStoreClient::empty(client.clone()))
             .table(
                 "orders",
                 vec![
@@ -5708,7 +5710,7 @@ mod tests {
             )
             .expect("backfill schema");
 
-        let task_schema = KvSchema::unprefixed(client.clone())
+        let task_schema = KvSchema::from_prefixed(PrefixedStoreClient::empty(client.clone()))
             .table(
                 "orders",
                 vec![
@@ -5788,7 +5790,7 @@ mod tests {
         let (base_url, shutdown_tx) = spawn_mock_server(state.clone()).await;
         let client = StoreClient::new(&base_url);
 
-        let seed_schema = KvSchema::unprefixed(client.clone())
+        let seed_schema = KvSchema::from_prefixed(PrefixedStoreClient::empty(client.clone()))
             .table(
                 "orders",
                 vec![
@@ -5815,7 +5817,7 @@ mod tests {
         }
         seed_writer.flush().await.expect("seed flush");
 
-        let backfill_schema = KvSchema::unprefixed(client.clone())
+        let backfill_schema = KvSchema::from_prefixed(PrefixedStoreClient::empty(client.clone()))
             .table(
                 "orders",
                 vec![
@@ -5830,7 +5832,7 @@ mod tests {
             )
             .expect("backfill schema");
 
-        let task_schema = KvSchema::unprefixed(client.clone())
+        let task_schema = KvSchema::from_prefixed(PrefixedStoreClient::empty(client.clone()))
             .table(
                 "orders",
                 vec![
@@ -6174,7 +6176,7 @@ mod tests {
 
         let client = StoreClient::new(&url);
         let scan = KvScanExec::new(
-            client,
+            PrefixedStoreClient::empty(client),
             model.clone(),
             Arc::new(Vec::new()),
             QueryPredicate::default(),
@@ -6253,7 +6255,7 @@ mod tests {
         });
 
         let client = StoreClient::new(&url);
-        let schema = KvSchema::unprefixed(client)
+        let schema = KvSchema::from_prefixed(PrefixedStoreClient::empty(client))
             .table(
                 "items",
                 vec![TableColumnConfig::new("id", DataType::Int64, false)],
@@ -6290,7 +6292,7 @@ mod tests {
     fn kv_scan_physical_limit_pushdown_sets_leaf_fetch() {
         let model = Arc::new(simple_int64_model(0));
         let scan = Arc::new(KvScanExec::new(
-            StoreClient::new("http://127.0.0.1:0"),
+            PrefixedStoreClient::empty(StoreClient::new("http://127.0.0.1:0")),
             model.clone(),
             Arc::new(Vec::new()),
             QueryPredicate::default(),
@@ -6386,7 +6388,7 @@ mod tests {
         });
 
         let client = StoreClient::new(&url);
-        let schema = KvSchema::unprefixed(client)
+        let schema = KvSchema::from_prefixed(PrefixedStoreClient::empty(client))
             .table(
                 "tx_activity",
                 vec![
@@ -6903,7 +6905,7 @@ mod tests {
         });
 
         let client = StoreClient::new(&url);
-        let schema = KvSchema::unprefixed(client)
+        let schema = KvSchema::from_prefixed(PrefixedStoreClient::empty(client))
             .table(
                 "orders",
                 vec![

--- a/sql/rs/src/lib.rs
+++ b/sql/rs/src/lib.rs
@@ -767,7 +767,7 @@ mod tests {
         let (base_url, shutdown_tx) = spawn_mock_server(state).await;
         let client = StoreClient::new(&base_url);
 
-        let schema = KvSchema::new(client)
+        let schema = KvSchema::new(PrefixedStoreClient::empty(client))
             .table(
                 "orders",
                 vec![
@@ -810,7 +810,7 @@ mod tests {
         let (base_url, shutdown_tx) = spawn_mock_server(state).await;
         let client = StoreClient::new(&base_url);
 
-        let schema = KvSchema::new(client)
+        let schema = KvSchema::new(PrefixedStoreClient::empty(client))
             .table(
                 "orders",
                 vec![
@@ -860,7 +860,7 @@ mod tests {
         let (base_url, shutdown_tx) = spawn_mock_server(state).await;
         let client = StoreClient::new(&base_url);
 
-        let schema = KvSchema::new(client)
+        let schema = KvSchema::new(PrefixedStoreClient::empty(client))
             .table(
                 "points",
                 vec![
@@ -907,7 +907,7 @@ mod tests {
         let (base_url, shutdown_tx) = spawn_mock_server(state).await;
         let client = StoreClient::new(&base_url);
 
-        let schema = KvSchema::new(client)
+        let schema = KvSchema::new(PrefixedStoreClient::empty(client))
             .table(
                 "orders",
                 vec![
@@ -2586,7 +2586,7 @@ mod tests {
     #[test]
     fn kv_schema_auto_assigns_sequential_prefixes() {
         let client = StoreClient::new("http://localhost:10000");
-        let schema = KvSchema::new(client)
+        let schema = KvSchema::new(PrefixedStoreClient::empty(client))
             .table(
                 "alpha",
                 vec![TableColumnConfig::new("id", DataType::Int64, false)],
@@ -2618,7 +2618,7 @@ mod tests {
     #[test]
     fn kv_schema_allows_max_codec_table_count_and_rejects_overflow() {
         let client = StoreClient::new("http://localhost:10000");
-        let mut schema = KvSchema::new(client);
+        let mut schema = KvSchema::new(PrefixedStoreClient::empty(client));
         for idx in 0..MAX_TABLES {
             schema = schema
                 .table(
@@ -2719,7 +2719,7 @@ mod tests {
         let ctx = SessionContext::new();
         let client = StoreClient::new("http://localhost:10000");
 
-        let result = KvSchema::new(client)
+        let result = KvSchema::new(PrefixedStoreClient::empty(client))
             .table(
                 "customers",
                 vec![
@@ -2768,7 +2768,7 @@ mod tests {
         let ctx = SessionContext::new();
         let client = StoreClient::new("http://localhost:10000");
 
-        KvSchema::new(client)
+        KvSchema::new(PrefixedStoreClient::empty(client))
             .table(
                 "products",
                 vec![
@@ -2822,7 +2822,7 @@ mod tests {
     #[test]
     fn kv_schema_orders_table_convenience() {
         let client = StoreClient::new("http://localhost:10000");
-        let schema = KvSchema::new(client)
+        let schema = KvSchema::new(PrefixedStoreClient::empty(client))
             .orders_table(
                 "my_orders",
                 vec![IndexSpec::new(
@@ -3209,7 +3209,7 @@ mod tests {
     #[test]
     fn batch_writer_encodes_rows_across_tables() {
         let client = StoreClient::new("http://localhost:10000");
-        let schema = KvSchema::new(client)
+        let schema = KvSchema::new(PrefixedStoreClient::empty(client))
             .table(
                 "customers",
                 vec![
@@ -3267,7 +3267,7 @@ mod tests {
     #[test]
     fn batch_writer_rejects_unknown_table() {
         let client = StoreClient::new("http://localhost:10000");
-        let schema = KvSchema::new(client)
+        let schema = KvSchema::new(PrefixedStoreClient::empty(client))
             .table(
                 "t1",
                 vec![TableColumnConfig::new("id", DataType::Int64, false)],
@@ -3285,7 +3285,7 @@ mod tests {
     #[test]
     fn batch_writer_rejects_wrong_column_count() {
         let client = StoreClient::new("http://localhost:10000");
-        let schema = KvSchema::new(client)
+        let schema = KvSchema::new(PrefixedStoreClient::empty(client))
             .table(
                 "t1",
                 vec![
@@ -3306,7 +3306,7 @@ mod tests {
     #[test]
     fn batch_writer_rejects_non_pk_type_mismatch() {
         let client = StoreClient::new("http://localhost:10000");
-        let schema = KvSchema::new(client)
+        let schema = KvSchema::new(PrefixedStoreClient::empty(client))
             .table(
                 "t1",
                 vec![
@@ -3333,7 +3333,7 @@ mod tests {
     #[test]
     fn batch_writer_entries_use_distinct_table_prefixes() {
         let client = StoreClient::new("http://localhost:10000");
-        let schema = KvSchema::new(client)
+        let schema = KvSchema::new(PrefixedStoreClient::empty(client))
             .table(
                 "a",
                 vec![TableColumnConfig::new("id", DataType::Int64, false)],
@@ -3367,7 +3367,7 @@ mod tests {
     #[tokio::test]
     async fn batch_writer_trait_failure_requeues_prepared_before_new_pending() {
         let client = StoreClient::new("http://localhost:10000");
-        let schema = KvSchema::new(client)
+        let schema = KvSchema::new(PrefixedStoreClient::empty(client))
             .table(
                 "t",
                 vec![TableColumnConfig::new("id", DataType::Int64, false)],
@@ -3397,7 +3397,7 @@ mod tests {
     #[test]
     fn batch_writer_supports_nullable_columns() {
         let client = StoreClient::new("http://localhost:10000");
-        let schema = KvSchema::new(client)
+        let schema = KvSchema::new(PrefixedStoreClient::empty(client))
             .table(
                 "t",
                 vec![
@@ -3419,7 +3419,7 @@ mod tests {
     #[test]
     fn non_nullable_column_rejects_null_in_batch_writer() {
         let client = StoreClient::new("http://localhost:10000");
-        let schema = KvSchema::new(client)
+        let schema = KvSchema::new(PrefixedStoreClient::empty(client))
             .table(
                 "t",
                 vec![
@@ -4002,7 +4002,7 @@ mod tests {
     #[test]
     fn table_versioned_convenience() {
         let client = StoreClient::new("http://localhost:10000");
-        let schema = KvSchema::new(client)
+        let schema = KvSchema::new(PrefixedStoreClient::empty(client))
             .table_versioned(
                 "documents",
                 vec![
@@ -4926,7 +4926,7 @@ mod tests {
         let (base_url, shutdown_tx) = spawn_mock_server(state.clone()).await;
         let client = StoreClient::new(&base_url);
 
-        let seed_schema = KvSchema::from_prefixed(PrefixedStoreClient::empty(client.clone()))
+        let seed_schema = KvSchema::new(PrefixedStoreClient::empty(client.clone()))
             .table(
                 "orders",
                 vec![
@@ -4967,7 +4967,7 @@ mod tests {
             assert_eq!(index_rows, 0);
         }
 
-        let backfill_schema = KvSchema::from_prefixed(PrefixedStoreClient::empty(client.clone()))
+        let backfill_schema = KvSchema::new(PrefixedStoreClient::empty(client.clone()))
             .table(
                 "orders",
                 vec![
@@ -5026,7 +5026,7 @@ mod tests {
         let (base_url, shutdown_tx) = spawn_mock_server(state.clone()).await;
         let client = StoreClient::new(&base_url);
 
-        let seed_schema = KvSchema::from_prefixed(PrefixedStoreClient::empty(client.clone()))
+        let seed_schema = KvSchema::new(PrefixedStoreClient::empty(client.clone()))
             .table(
                 "points",
                 vec![
@@ -5055,7 +5055,7 @@ mod tests {
         }
         writer.flush().await.expect("seed flush");
 
-        let backfill_schema = KvSchema::from_prefixed(PrefixedStoreClient::empty(client.clone()))
+        let backfill_schema = KvSchema::new(PrefixedStoreClient::empty(client.clone()))
             .table(
                 "points",
                 vec![
@@ -5130,7 +5130,7 @@ mod tests {
     #[tokio::test]
     async fn backfill_added_indexes_requires_append_only_index_evolution() {
         let client = StoreClient::new("http://127.0.0.1:1");
-        let schema = KvSchema::new(client)
+        let schema = KvSchema::new(PrefixedStoreClient::empty(client))
             .table(
                 "orders",
                 vec![
@@ -5163,7 +5163,7 @@ mod tests {
         let existing = IndexSpec::new("status_idx", vec!["status".to_string()])
             .expect("valid")
             .with_cover_columns(vec!["amount_cents".to_string()]);
-        let schema = KvSchema::new(client)
+        let schema = KvSchema::new(PrefixedStoreClient::empty(client))
             .table(
                 "orders",
                 vec![
@@ -5186,7 +5186,7 @@ mod tests {
     #[tokio::test]
     async fn backfill_added_indexes_rejects_zero_row_batch_size() {
         let client = StoreClient::new("http://127.0.0.1:1");
-        let schema = KvSchema::new(client)
+        let schema = KvSchema::new(PrefixedStoreClient::empty(client))
             .table(
                 "orders",
                 vec![
@@ -5222,7 +5222,7 @@ mod tests {
         let (base_url, shutdown_tx) = spawn_mock_server(state.clone()).await;
         let client = StoreClient::new(&base_url);
 
-        let seed_schema = KvSchema::new(client.clone())
+        let seed_schema = KvSchema::new(PrefixedStoreClient::empty(client.clone()))
             .table(
                 "orders",
                 vec![
@@ -5249,7 +5249,7 @@ mod tests {
         }
         writer.flush().await.expect("seed flush");
 
-        let backfill_schema = KvSchema::new(client.clone())
+        let backfill_schema = KvSchema::new(PrefixedStoreClient::empty(client.clone()))
             .table(
                 "orders",
                 vec![
@@ -5328,7 +5328,7 @@ mod tests {
         let (base_url, shutdown_tx) = spawn_mock_server(state.clone()).await;
         let client = StoreClient::new(&base_url);
 
-        let seed_schema = KvSchema::from_prefixed(PrefixedStoreClient::empty(client.clone()))
+        let seed_schema = KvSchema::new(PrefixedStoreClient::empty(client.clone()))
             .table(
                 "orders",
                 vec![
@@ -5355,7 +5355,7 @@ mod tests {
         }
         writer.flush().await.expect("seed flush");
 
-        let backfill_schema = KvSchema::from_prefixed(PrefixedStoreClient::empty(client.clone()))
+        let backfill_schema = KvSchema::new(PrefixedStoreClient::empty(client.clone()))
             .table(
                 "orders",
                 vec![
@@ -5442,7 +5442,7 @@ mod tests {
         let (base_url, shutdown_tx) = spawn_mock_server(state.clone()).await;
         let client = StoreClient::new(&base_url);
 
-        let schema = KvSchema::from_prefixed(PrefixedStoreClient::empty(client.clone()))
+        let schema = KvSchema::new(PrefixedStoreClient::empty(client.clone()))
             .table(
                 "orders",
                 vec![
@@ -5509,7 +5509,7 @@ mod tests {
         let (base_url, shutdown_tx) = spawn_mock_server(state.clone()).await;
         let client = StoreClient::new(&base_url);
 
-        let schema = KvSchema::from_prefixed(PrefixedStoreClient::empty(client.clone()))
+        let schema = KvSchema::new(PrefixedStoreClient::empty(client.clone()))
             .table(
                 "orders",
                 vec![
@@ -5574,7 +5574,7 @@ mod tests {
         let (base_url, shutdown_tx) = spawn_mock_server(state.clone()).await;
         let client = StoreClient::new(&base_url);
 
-        let schema = KvSchema::new(client.clone())
+        let schema = KvSchema::new(PrefixedStoreClient::empty(client.clone()))
             .table(
                 "orders",
                 vec![
@@ -5670,7 +5670,7 @@ mod tests {
         let (base_url, shutdown_tx) = spawn_mock_server(state.clone()).await;
         let client = StoreClient::new(&base_url);
 
-        let seed_schema = KvSchema::from_prefixed(PrefixedStoreClient::empty(client.clone()))
+        let seed_schema = KvSchema::new(PrefixedStoreClient::empty(client.clone()))
             .table(
                 "orders",
                 vec![
@@ -5697,7 +5697,7 @@ mod tests {
         }
         writer.flush().await.expect("seed flush");
 
-        let backfill_schema = KvSchema::from_prefixed(PrefixedStoreClient::empty(client.clone()))
+        let backfill_schema = KvSchema::new(PrefixedStoreClient::empty(client.clone()))
             .table(
                 "orders",
                 vec![
@@ -5710,7 +5710,7 @@ mod tests {
             )
             .expect("backfill schema");
 
-        let task_schema = KvSchema::from_prefixed(PrefixedStoreClient::empty(client.clone()))
+        let task_schema = KvSchema::new(PrefixedStoreClient::empty(client.clone()))
             .table(
                 "orders",
                 vec![
@@ -5790,7 +5790,7 @@ mod tests {
         let (base_url, shutdown_tx) = spawn_mock_server(state.clone()).await;
         let client = StoreClient::new(&base_url);
 
-        let seed_schema = KvSchema::from_prefixed(PrefixedStoreClient::empty(client.clone()))
+        let seed_schema = KvSchema::new(PrefixedStoreClient::empty(client.clone()))
             .table(
                 "orders",
                 vec![
@@ -5817,7 +5817,7 @@ mod tests {
         }
         seed_writer.flush().await.expect("seed flush");
 
-        let backfill_schema = KvSchema::from_prefixed(PrefixedStoreClient::empty(client.clone()))
+        let backfill_schema = KvSchema::new(PrefixedStoreClient::empty(client.clone()))
             .table(
                 "orders",
                 vec![
@@ -5832,7 +5832,7 @@ mod tests {
             )
             .expect("backfill schema");
 
-        let task_schema = KvSchema::from_prefixed(PrefixedStoreClient::empty(client.clone()))
+        let task_schema = KvSchema::new(PrefixedStoreClient::empty(client.clone()))
             .table(
                 "orders",
                 vec![
@@ -6255,7 +6255,7 @@ mod tests {
         });
 
         let client = StoreClient::new(&url);
-        let schema = KvSchema::from_prefixed(PrefixedStoreClient::empty(client))
+        let schema = KvSchema::new(PrefixedStoreClient::empty(client))
             .table(
                 "items",
                 vec![TableColumnConfig::new("id", DataType::Int64, false)],
@@ -6388,7 +6388,7 @@ mod tests {
         });
 
         let client = StoreClient::new(&url);
-        let schema = KvSchema::from_prefixed(PrefixedStoreClient::empty(client))
+        let schema = KvSchema::new(PrefixedStoreClient::empty(client))
             .table(
                 "tx_activity",
                 vec![
@@ -6454,7 +6454,7 @@ mod tests {
         let (base_url, shutdown_tx) = spawn_mock_server(state).await;
         let client = StoreClient::new(&base_url);
 
-        let schema = KvSchema::new(client)
+        let schema = KvSchema::new(PrefixedStoreClient::empty(client))
             .table(
                 "tx_activity",
                 vec![
@@ -6510,7 +6510,7 @@ mod tests {
         let (base_url, shutdown_tx) = spawn_mock_server(state).await;
         let client = StoreClient::new(&base_url);
 
-        let schema = KvSchema::new(client)
+        let schema = KvSchema::new(PrefixedStoreClient::empty(client))
             .table(
                 "tx_activity",
                 vec![
@@ -6569,7 +6569,7 @@ mod tests {
         let (base_url, shutdown_tx) = spawn_mock_server(state).await;
         let client = StoreClient::new(&base_url);
 
-        let schema = KvSchema::new(client.clone())
+        let schema = KvSchema::new(PrefixedStoreClient::empty(client.clone()))
             .table(
                 "tx_activity",
                 vec![
@@ -6663,7 +6663,7 @@ mod tests {
         let (base_url, shutdown_tx) = spawn_mock_server(state.clone()).await;
         let client = StoreClient::new(&base_url);
 
-        let schema = KvSchema::new(client.clone())
+        let schema = KvSchema::new(PrefixedStoreClient::empty(client.clone()))
             .table(
                 "events",
                 vec![TableColumnConfig::new("id", DataType::Int64, false)],
@@ -6721,7 +6721,7 @@ mod tests {
         let (base_url, shutdown_tx) = spawn_mock_server(state.clone()).await;
         let client = StoreClient::new(&base_url);
 
-        let schema = KvSchema::new(client.clone())
+        let schema = KvSchema::new(PrefixedStoreClient::empty(client.clone()))
             .table(
                 "events",
                 vec![TableColumnConfig::new("id", DataType::Int64, false)],
@@ -6779,7 +6779,7 @@ mod tests {
         let (base_url, shutdown_tx) = spawn_mock_server(state.clone()).await;
         let client = StoreClient::new(&base_url);
 
-        let schema = KvSchema::new(client.clone())
+        let schema = KvSchema::new(PrefixedStoreClient::empty(client.clone()))
             .table(
                 "items",
                 vec![TableColumnConfig::new("id", DataType::Utf8, false)],
@@ -6905,7 +6905,7 @@ mod tests {
         });
 
         let client = StoreClient::new(&url);
-        let schema = KvSchema::from_prefixed(PrefixedStoreClient::empty(client))
+        let schema = KvSchema::new(PrefixedStoreClient::empty(client))
             .table(
                 "orders",
                 vec![
@@ -6957,7 +6957,7 @@ mod tests {
         let (base_url, shutdown_tx) = spawn_mock_server(state).await;
         let client = StoreClient::new(&base_url);
 
-        let schema = KvSchema::new(client)
+        let schema = KvSchema::new(PrefixedStoreClient::empty(client))
             .table(
                 "points",
                 vec![
@@ -7045,7 +7045,7 @@ mod tests {
         let (base_url, shutdown_tx) = spawn_mock_server(state.clone()).await;
         let client = StoreClient::new(&base_url);
 
-        let schema = KvSchema::new(client)
+        let schema = KvSchema::new(PrefixedStoreClient::empty(client))
             .table(
                 "orders",
                 vec![
@@ -7138,7 +7138,7 @@ mod tests {
         let (base_url, shutdown_tx) = spawn_mock_server(state.clone()).await;
         let client = StoreClient::new(&base_url);
 
-        let schema = KvSchema::new(client)
+        let schema = KvSchema::new(PrefixedStoreClient::empty(client))
             .table(
                 "inc_pk",
                 vec![
@@ -7235,7 +7235,7 @@ mod tests {
         let (base_url, shutdown_tx) = spawn_mock_server(state.clone()).await;
         let client = StoreClient::new(&base_url);
 
-        let schema = KvSchema::new(client)
+        let schema = KvSchema::new(PrefixedStoreClient::empty(client))
             .table(
                 "inc_pk",
                 vec![
@@ -7337,7 +7337,7 @@ mod tests {
         let (base_url, shutdown_tx) = spawn_mock_server(state.clone()).await;
         let client = StoreClient::new(&base_url);
 
-        let schema = KvSchema::new(client)
+        let schema = KvSchema::new(PrefixedStoreClient::empty(client))
             .table(
                 "points",
                 vec![
@@ -7430,7 +7430,7 @@ mod tests {
         let (base_url, shutdown_tx) = spawn_mock_server(state.clone()).await;
         let client = StoreClient::new(&base_url);
 
-        let schema = KvSchema::new(client)
+        let schema = KvSchema::new(PrefixedStoreClient::empty(client))
             .table(
                 "orders",
                 vec![
@@ -7517,7 +7517,7 @@ mod tests {
         let (base_url, shutdown_tx) = spawn_mock_server(state.clone()).await;
         let client = StoreClient::new(&base_url);
 
-        let schema = KvSchema::new(client)
+        let schema = KvSchema::new(PrefixedStoreClient::empty(client))
             .table(
                 "orders",
                 vec![
@@ -7601,7 +7601,7 @@ mod tests {
         let (base_url, shutdown_tx) = spawn_mock_server(state.clone()).await;
         let client = StoreClient::new(&base_url);
 
-        let schema = KvSchema::new(client)
+        let schema = KvSchema::new(PrefixedStoreClient::empty(client))
             .table(
                 "orders",
                 vec![
@@ -7688,7 +7688,7 @@ mod tests {
         let (base_url, shutdown_tx) = spawn_mock_server(state.clone()).await;
         let client = StoreClient::new(&base_url);
 
-        let schema = KvSchema::new(client)
+        let schema = KvSchema::new(PrefixedStoreClient::empty(client))
             .table(
                 "orders",
                 vec![
@@ -7781,7 +7781,7 @@ mod tests {
         let (base_url, shutdown_tx) = spawn_mock_server(state.clone()).await;
         let client = StoreClient::new(&base_url);
 
-        let schema = KvSchema::new(client)
+        let schema = KvSchema::new(PrefixedStoreClient::empty(client))
             .table(
                 "orders",
                 vec![
@@ -7862,7 +7862,7 @@ mod tests {
         let (base_url, shutdown_tx) = spawn_mock_server(state.clone()).await;
         let client = StoreClient::new(&base_url);
 
-        let schema = KvSchema::new(client)
+        let schema = KvSchema::new(PrefixedStoreClient::empty(client))
             .table(
                 "orders",
                 vec![
@@ -7940,7 +7940,7 @@ mod tests {
         let (base_url, shutdown_tx) = spawn_mock_server(state.clone()).await;
         let client = StoreClient::new(&base_url);
 
-        let schema = KvSchema::new(client)
+        let schema = KvSchema::new(PrefixedStoreClient::empty(client))
             .table(
                 "orders",
                 vec![
@@ -8021,7 +8021,7 @@ mod tests {
         let (base_url, shutdown_tx) = spawn_mock_server(state.clone()).await;
         let client = StoreClient::new(&base_url);
 
-        let schema = KvSchema::new(client)
+        let schema = KvSchema::new(PrefixedStoreClient::empty(client))
             .table(
                 "orders",
                 vec![
@@ -8115,7 +8115,7 @@ mod tests {
         let (base_url, shutdown_tx) = spawn_mock_server(state.clone()).await;
         let client = StoreClient::new(&base_url);
 
-        let schema = KvSchema::new(client)
+        let schema = KvSchema::new(PrefixedStoreClient::empty(client))
             .table(
                 "events",
                 vec![
@@ -8231,7 +8231,7 @@ mod tests {
         let (base_url, shutdown_tx) = spawn_mock_server(state.clone()).await;
         let client = StoreClient::new(&base_url);
 
-        let schema = KvSchema::new(client)
+        let schema = KvSchema::new(PrefixedStoreClient::empty(client))
             .table(
                 "orders",
                 vec![
@@ -8323,7 +8323,7 @@ mod tests {
         let (base_url, shutdown_tx) = spawn_mock_server(state.clone()).await;
         let client = StoreClient::new(&base_url);
 
-        let schema = KvSchema::new(client)
+        let schema = KvSchema::new(PrefixedStoreClient::empty(client))
             .table(
                 "metrics",
                 vec![
@@ -8393,7 +8393,7 @@ mod tests {
         let (base_url, shutdown_tx) = spawn_mock_server(state.clone()).await;
         let client = StoreClient::new(&base_url);
 
-        let schema = KvSchema::new(client)
+        let schema = KvSchema::new(PrefixedStoreClient::empty(client))
             .table(
                 "orders",
                 vec![
@@ -8556,7 +8556,7 @@ mod tests {
             let servers = spawn_e2e_servers().await;
             let client = servers.client();
 
-            let schema = KvSchema::new(client)
+            let schema = KvSchema::new(PrefixedStoreClient::empty(client))
                 .table(
                     "orders",
                     vec![

--- a/sql/rs/src/lib.rs
+++ b/sql/rs/src/lib.rs
@@ -4924,7 +4924,7 @@ mod tests {
         let (base_url, shutdown_tx) = spawn_mock_server(state.clone()).await;
         let client = StoreClient::new(&base_url);
 
-        let seed_schema = KvSchema::new(client.clone())
+        let seed_schema = KvSchema::unprefixed(client.clone())
             .table(
                 "orders",
                 vec![
@@ -4965,7 +4965,7 @@ mod tests {
             assert_eq!(index_rows, 0);
         }
 
-        let backfill_schema = KvSchema::new(client.clone())
+        let backfill_schema = KvSchema::unprefixed(client.clone())
             .table(
                 "orders",
                 vec![
@@ -5024,7 +5024,7 @@ mod tests {
         let (base_url, shutdown_tx) = spawn_mock_server(state.clone()).await;
         let client = StoreClient::new(&base_url);
 
-        let seed_schema = KvSchema::new(client.clone())
+        let seed_schema = KvSchema::unprefixed(client.clone())
             .table(
                 "points",
                 vec![
@@ -5053,7 +5053,7 @@ mod tests {
         }
         writer.flush().await.expect("seed flush");
 
-        let backfill_schema = KvSchema::new(client.clone())
+        let backfill_schema = KvSchema::unprefixed(client.clone())
             .table(
                 "points",
                 vec![
@@ -5326,7 +5326,7 @@ mod tests {
         let (base_url, shutdown_tx) = spawn_mock_server(state.clone()).await;
         let client = StoreClient::new(&base_url);
 
-        let seed_schema = KvSchema::new(client.clone())
+        let seed_schema = KvSchema::unprefixed(client.clone())
             .table(
                 "orders",
                 vec![
@@ -5353,7 +5353,7 @@ mod tests {
         }
         writer.flush().await.expect("seed flush");
 
-        let backfill_schema = KvSchema::new(client.clone())
+        let backfill_schema = KvSchema::unprefixed(client.clone())
             .table(
                 "orders",
                 vec![
@@ -5440,7 +5440,7 @@ mod tests {
         let (base_url, shutdown_tx) = spawn_mock_server(state.clone()).await;
         let client = StoreClient::new(&base_url);
 
-        let schema = KvSchema::new(client.clone())
+        let schema = KvSchema::unprefixed(client.clone())
             .table(
                 "orders",
                 vec![
@@ -5507,7 +5507,7 @@ mod tests {
         let (base_url, shutdown_tx) = spawn_mock_server(state.clone()).await;
         let client = StoreClient::new(&base_url);
 
-        let schema = KvSchema::new(client.clone())
+        let schema = KvSchema::unprefixed(client.clone())
             .table(
                 "orders",
                 vec![
@@ -5668,7 +5668,7 @@ mod tests {
         let (base_url, shutdown_tx) = spawn_mock_server(state.clone()).await;
         let client = StoreClient::new(&base_url);
 
-        let seed_schema = KvSchema::new(client.clone())
+        let seed_schema = KvSchema::unprefixed(client.clone())
             .table(
                 "orders",
                 vec![
@@ -5695,7 +5695,7 @@ mod tests {
         }
         writer.flush().await.expect("seed flush");
 
-        let backfill_schema = KvSchema::new(client.clone())
+        let backfill_schema = KvSchema::unprefixed(client.clone())
             .table(
                 "orders",
                 vec![
@@ -5708,7 +5708,7 @@ mod tests {
             )
             .expect("backfill schema");
 
-        let task_schema = KvSchema::new(client.clone())
+        let task_schema = KvSchema::unprefixed(client.clone())
             .table(
                 "orders",
                 vec![
@@ -5788,7 +5788,7 @@ mod tests {
         let (base_url, shutdown_tx) = spawn_mock_server(state.clone()).await;
         let client = StoreClient::new(&base_url);
 
-        let seed_schema = KvSchema::new(client.clone())
+        let seed_schema = KvSchema::unprefixed(client.clone())
             .table(
                 "orders",
                 vec![
@@ -5815,7 +5815,7 @@ mod tests {
         }
         seed_writer.flush().await.expect("seed flush");
 
-        let backfill_schema = KvSchema::new(client.clone())
+        let backfill_schema = KvSchema::unprefixed(client.clone())
             .table(
                 "orders",
                 vec![
@@ -5830,7 +5830,7 @@ mod tests {
             )
             .expect("backfill schema");
 
-        let task_schema = KvSchema::new(client.clone())
+        let task_schema = KvSchema::unprefixed(client.clone())
             .table(
                 "orders",
                 vec![
@@ -6253,7 +6253,7 @@ mod tests {
         });
 
         let client = StoreClient::new(&url);
-        let schema = KvSchema::new(client)
+        let schema = KvSchema::unprefixed(client)
             .table(
                 "items",
                 vec![TableColumnConfig::new("id", DataType::Int64, false)],
@@ -6386,7 +6386,7 @@ mod tests {
         });
 
         let client = StoreClient::new(&url);
-        let schema = KvSchema::new(client)
+        let schema = KvSchema::unprefixed(client)
             .table(
                 "tx_activity",
                 vec![
@@ -6903,7 +6903,7 @@ mod tests {
         });
 
         let client = StoreClient::new(&url);
-        let schema = KvSchema::new(client)
+        let schema = KvSchema::unprefixed(client)
             .table(
                 "orders",
                 vec![

--- a/sql/rs/src/scan.rs
+++ b/sql/rs/src/scan.rs
@@ -20,7 +20,7 @@ use datafusion::physical_plan::{
 };
 use exoware_sdk::keys::Key;
 use exoware_sdk::kv_codec::decode_stored_row;
-use exoware_sdk::StoreClient;
+use exoware_sdk::PrefixedStoreClient;
 use exoware_sdk::{RangeMode, RangeStream, SerializableReadSession};
 use futures::SinkExt;
 
@@ -48,7 +48,7 @@ impl ScanDirection {
 
 #[derive(Debug, Clone)]
 pub(crate) struct KvScanExec {
-    pub(crate) client: StoreClient,
+    pub(crate) client: PrefixedStoreClient,
     pub(crate) model: Arc<TableModel>,
     pub(crate) index_specs: Arc<Vec<ResolvedIndexSpec>>,
     pub(crate) predicate: QueryPredicate,
@@ -79,7 +79,7 @@ impl KvScanExec {
     }
 
     pub(crate) fn new(
-        client: StoreClient,
+        client: PrefixedStoreClient,
         model: Arc<TableModel>,
         index_specs: Arc<Vec<ResolvedIndexSpec>>,
         predicate: QueryPredicate,

--- a/sql/rs/src/schema.rs
+++ b/sql/rs/src/schema.rs
@@ -26,7 +26,7 @@ use crate::writer::*;
 pub(crate) fn register_kv_table(
     ctx: &SessionContext,
     table_name: &str,
-    client: StoreClient,
+    client: PrefixedStoreClient,
     config: KvTableConfig,
 ) -> DataFusionResult<()> {
     let table = Arc::new(
@@ -38,7 +38,7 @@ pub(crate) fn register_kv_table(
 }
 
 pub struct KvSchema {
-    client: StoreClient,
+    client: PrefixedStoreClient,
     tables: Vec<(String, KvTableConfig)>,
     next_prefix: u8,
 }
@@ -46,22 +46,15 @@ pub struct KvSchema {
 impl KvSchema {
     /// Build a schema over the canonical [`Namespace::Sql`] keyspace — the safe
     /// default when the Store is co-tenanted with simplex/qmdb, so SQL's
-    /// prefix-bounded scans can't observe foreign keys. Use [`Self::unprefixed`]
-    /// only for a Store SQL owns exclusively.
+    /// prefix-bounded scans can't observe another namespace's keys.
     pub fn new(client: StoreClient) -> Self {
-        Self::prefixed(client.for_namespace(Namespace::Sql))
+        Self::from_prefixed(client.for_namespace(Namespace::Sql))
     }
 
     /// Build a schema over a caller-chosen namespace (e.g. multiple `KvSchema`
     /// instances in one Store). The caller must pick a slot disjoint from every
     /// co-tenant.
-    pub fn prefixed(client: PrefixedStoreClient) -> Self {
-        Self::unprefixed(client.into_client())
-    }
-
-    /// Build a schema over a raw, un-namespaced client — escape hatch for a
-    /// single-tenant Store. `grep` for `unprefixed` to audit such call sites.
-    pub fn unprefixed(client: StoreClient) -> Self {
+    pub fn from_prefixed(client: PrefixedStoreClient) -> Self {
         Self {
             client,
             tables: Vec::new(),
@@ -137,7 +130,7 @@ impl KvSchema {
         self.tables.len()
     }
 
-    pub(crate) fn client(&self) -> &StoreClient {
+    pub(crate) fn client(&self) -> &PrefixedStoreClient {
         &self.client
     }
 

--- a/sql/rs/src/schema.rs
+++ b/sql/rs/src/schema.rs
@@ -14,7 +14,7 @@ use datafusion::logical_expr::{Expr, TableProviderFilterPushDown, TableType};
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion::prelude::SessionContext;
 use exoware_sdk::kv_codec::decode_stored_row;
-use exoware_sdk::StoreClient;
+use exoware_sdk::{Namespace, PrefixedStoreClient, StoreClient};
 
 use crate::aggregate::KvAggregatePushdownRule;
 use crate::codec::*;
@@ -44,7 +44,24 @@ pub struct KvSchema {
 }
 
 impl KvSchema {
+    /// Build a schema over the canonical [`Namespace::Sql`] keyspace — the safe
+    /// default when the Store is co-tenanted with simplex/qmdb, so SQL's
+    /// prefix-bounded scans can't observe foreign keys. Use [`Self::unprefixed`]
+    /// only for a Store SQL owns exclusively.
     pub fn new(client: StoreClient) -> Self {
+        Self::prefixed(client.for_namespace(Namespace::Sql))
+    }
+
+    /// Build a schema over a caller-chosen namespace (e.g. multiple `KvSchema`
+    /// instances in one Store). The caller must pick a slot disjoint from every
+    /// co-tenant.
+    pub fn prefixed(client: PrefixedStoreClient) -> Self {
+        Self::unprefixed(client.into_client())
+    }
+
+    /// Build a schema over a raw, un-namespaced client — escape hatch for a
+    /// single-tenant Store. `grep` for `unprefixed` to audit such call sites.
+    pub fn unprefixed(client: StoreClient) -> Self {
         Self {
             client,
             tables: Vec::new(),

--- a/sql/rs/src/schema.rs
+++ b/sql/rs/src/schema.rs
@@ -14,7 +14,7 @@ use datafusion::logical_expr::{Expr, TableProviderFilterPushDown, TableType};
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion::prelude::SessionContext;
 use exoware_sdk::kv_codec::decode_stored_row;
-use exoware_sdk::{Namespace, PrefixedStoreClient, StoreClient};
+use exoware_sdk::PrefixedStoreClient;
 
 use crate::aggregate::KvAggregatePushdownRule;
 use crate::codec::*;
@@ -44,17 +44,10 @@ pub struct KvSchema {
 }
 
 impl KvSchema {
-    /// Build a schema over the canonical [`Namespace::Sql`] keyspace — the safe
-    /// default when the Store is co-tenanted with simplex/qmdb, so SQL's
-    /// prefix-bounded scans can't observe another namespace's keys.
-    pub fn new(client: StoreClient) -> Self {
-        Self::from_prefixed(client.for_namespace(Namespace::Sql))
-    }
-
-    /// Build a schema over a caller-chosen namespace (e.g. multiple `KvSchema`
-    /// instances in one Store). The caller must pick a slot disjoint from every
-    /// co-tenant.
-    pub fn from_prefixed(client: PrefixedStoreClient) -> Self {
+    /// Build a schema over `client`'s namespace prefix. When the Store is
+    /// co-tenanted, the caller must pick a prefix disjoint from every co-tenant
+    /// so SQL's prefix-bounded scans can't observe another's keys.
+    pub fn new(client: PrefixedStoreClient) -> Self {
         Self {
             client,
             tables: Vec::new(),

--- a/sql/rs/src/server.rs
+++ b/sql/rs/src/server.rs
@@ -44,7 +44,7 @@ use exoware_sdk::keys::Key;
 use exoware_sdk::kv_codec::{decode_stored_row, Utf8};
 use exoware_sdk::selector::Selector;
 use exoware_sdk::stream_filter::StreamFilter;
-use exoware_sdk::{StoreClient, StreamSubscription};
+use exoware_sdk::{PrefixedStoreClient, StreamSubscription};
 use futures::future::BoxFuture;
 use futures::stream::Stream;
 use futures::FutureExt;
@@ -131,7 +131,7 @@ pub struct SqlServer {
     // Registration order, preserved for the `Tables` RPC so clients see
     // tables in the same order the operator declared them.
     table_names: Vec<String>,
-    store: StoreClient,
+    store: PrefixedStoreClient,
 }
 
 impl SqlServer {

--- a/sql/rs/src/types.rs
+++ b/sql/rs/src/types.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use datafusion::arrow::datatypes::{i256, DataType, Field, Schema, SchemaRef, TimeUnit};
 use exoware_sdk::keys::{Key, KeyCodec};
-use exoware_sdk::StoreClient;
+use exoware_sdk::PrefixedStoreClient;
 
 use crate::codec::{primary_key_codec, secondary_index_codec};
 
@@ -578,13 +578,13 @@ pub(crate) struct IndexPlan {
 
 #[derive(Debug, Clone)]
 pub(crate) struct KvTable {
-    pub(crate) client: StoreClient,
+    pub(crate) client: PrefixedStoreClient,
     pub(crate) model: Arc<TableModel>,
     pub(crate) index_specs: Arc<Vec<ResolvedIndexSpec>>,
 }
 
 impl KvTable {
-    pub(crate) fn new(client: StoreClient, config: KvTableConfig) -> Result<Self, String> {
+    pub(crate) fn new(client: PrefixedStoreClient, config: KvTableConfig) -> Result<Self, String> {
         let model = Arc::new(TableModel::from_config(&config)?);
         let index_specs = Arc::new(model.resolve_index_specs(&config.index_specs)?);
         Ok(Self {

--- a/sql/rs/src/writer.rs
+++ b/sql/rs/src/writer.rs
@@ -168,7 +168,9 @@ impl BatchWriter {
         let Some(prepared) = self.prepare_flush()? else {
             return Ok(None);
         };
-        Ok(Some(self.commit_upload(&self.client, prepared).await?))
+        Ok(Some(
+            self.commit_upload(self.client.client(), prepared).await?,
+        ))
     }
 
     pub fn prepare_flush(&mut self) -> DataFusionResult<Option<PreparedBatch>> {
@@ -195,7 +197,7 @@ impl BatchWriter {
     ) -> DataFusionResult<()> {
         for (key, value) in prepared.keys.iter().zip(prepared.values.iter()) {
             batch
-                .push(&self.client, key, value)
+                .push(self.client.key_prefix(), key, value)
                 .map_err(|e| DataFusionError::External(Box::new(e)))?;
         }
         Ok(())
@@ -963,11 +965,11 @@ pub(crate) async fn flush_ingest_batch(
     let mut batch = StoreWriteBatch::new();
     for (key, value) in keys.iter().zip(values.iter()) {
         batch
-            .push(client, key, value)
+            .push(client.key_prefix(), key, value)
             .map_err(|e| DataFusionError::External(Box::new(e)))?;
     }
     let token = batch
-        .commit(client)
+        .commit(client.client())
         .await
         .map_err(|e| DataFusionError::External(Box::new(e)))?;
     keys.clear();

--- a/sql/rs/src/writer.rs
+++ b/sql/rs/src/writer.rs
@@ -22,7 +22,7 @@ use exoware_sdk::keys::Key;
 #[cfg(test)]
 use exoware_sdk::kv_codec::decode_stored_row;
 use exoware_sdk::kv_codec::{StoredRow, StoredValue};
-use exoware_sdk::{StoreBatchUpload, StoreClient, StoreWriteBatch};
+use exoware_sdk::{PrefixedStoreClient, StoreBatchUpload, StoreWriteBatch};
 use futures::{future::BoxFuture, TryStreamExt};
 
 use crate::builder::archived_non_pk_value_is_valid;
@@ -61,7 +61,7 @@ impl TableWriter {
 
 #[derive(Debug)]
 pub struct BatchWriter {
-    client: StoreClient,
+    client: PrefixedStoreClient,
     tables: HashMap<String, TableWriter>,
     next_request_id: u64,
     failed_prepared: Mutex<Vec<PreparedBatch>>,
@@ -100,7 +100,10 @@ pub struct BatchReceipt {
 }
 
 impl BatchWriter {
-    pub(crate) fn new(client: StoreClient, table_configs: &[(String, KvTableConfig)]) -> Self {
+    pub(crate) fn new(
+        client: PrefixedStoreClient,
+        table_configs: &[(String, KvTableConfig)],
+    ) -> Self {
         let mut tables = HashMap::new();
         for (name, config) in table_configs {
             let model = Arc::new(
@@ -276,7 +279,7 @@ impl StoreBatchUpload for BatchWriter {
 
 #[derive(Debug)]
 pub(crate) struct KvIngestSink {
-    pub(crate) client: StoreClient,
+    pub(crate) client: PrefixedStoreClient,
     pub(crate) schema: SchemaRef,
     pub(crate) model: Arc<TableModel>,
     pub(crate) index_specs: Arc<Vec<ResolvedIndexSpec>>,
@@ -284,7 +287,7 @@ pub(crate) struct KvIngestSink {
 
 impl KvIngestSink {
     pub(crate) fn new(
-        client: StoreClient,
+        client: PrefixedStoreClient,
         schema: SchemaRef,
         model: Arc<TableModel>,
         index_specs: Arc<Vec<ResolvedIndexSpec>>,
@@ -950,7 +953,7 @@ pub(crate) fn list_value_at(
 }
 
 pub(crate) async fn flush_ingest_batch(
-    client: &StoreClient,
+    client: &PrefixedStoreClient,
     keys: &mut Vec<Key>,
     values: &mut Vec<Bytes>,
 ) -> DataFusionResult<u64> {
@@ -975,12 +978,16 @@ pub(crate) async fn flush_ingest_batch(
 #[cfg(test)]
 mod tests {
     use bytes::Bytes;
+    use exoware_sdk::StoreClient;
 
     use super::*;
 
     #[test]
     fn store_batch_upload_stage_preserves_rows_for_failed_retry() {
-        let writer = BatchWriter::new(StoreClient::new("http://127.0.0.1:1"), &[]);
+        let writer = BatchWriter::new(
+            PrefixedStoreClient::empty(StoreClient::new("http://127.0.0.1:1")),
+            &[],
+        );
         let mut prepared = PreparedBatch {
             request_id: 7,
             entry_count: 2,

--- a/sql/rs/src/writer.rs
+++ b/sql/rs/src/writer.rs
@@ -168,9 +168,7 @@ impl BatchWriter {
         let Some(prepared) = self.prepare_flush()? else {
             return Ok(None);
         };
-        Ok(Some(
-            self.commit_upload(self.client.client(), prepared).await?,
-        ))
+        Ok(Some(self.commit_upload(prepared).await?))
     }
 
     pub fn prepare_flush(&mut self) -> DataFusionResult<Option<PreparedBatch>> {
@@ -239,6 +237,10 @@ impl StoreBatchUpload for BatchWriter {
     type Prepared = PreparedBatch;
     type Receipt = BatchReceipt;
     type Error = DataFusionError;
+
+    fn store_client(&self) -> &PrefixedStoreClient {
+        &self.client
+    }
 
     fn stage_upload(
         &self,

--- a/sql/rs/tests/e2e_slam.rs
+++ b/sql/rs/tests/e2e_slam.rs
@@ -6,6 +6,7 @@ use datafusion::arrow::array::Int64Array;
 use datafusion::arrow::datatypes::DataType;
 use datafusion::common::ScalarValue;
 use datafusion::prelude::SessionContext;
+use exoware_sdk::PrefixedStoreClient;
 use exoware_sql::{CellValue, IndexSpec, KvSchema, TableColumnConfig};
 
 #[tokio::test]
@@ -13,7 +14,7 @@ async fn sql_full_pipeline_insert_and_query() {
     let (_dir, _server, write_client) = common::local_store_client().await;
     let read_client = write_client.clone();
 
-    let write_schema = KvSchema::new(write_client)
+    let write_schema = KvSchema::new(PrefixedStoreClient::empty(write_client))
         .table(
             "slam_orders",
             vec![
@@ -54,7 +55,7 @@ async fn sql_full_pipeline_insert_and_query() {
     }
     let min_sequence = writer.flush().await.expect("flush batch");
     assert!(min_sequence > 0);
-    let read_schema = KvSchema::new(read_client)
+    let read_schema = KvSchema::new(PrefixedStoreClient::empty(read_client))
         .table(
             "slam_orders",
             vec![

--- a/sql/rs/tests/examples_smoke.rs
+++ b/sql/rs/tests/examples_smoke.rs
@@ -4,6 +4,7 @@ use datafusion::arrow::array::{Int64Array, StringArray, UInt64Array};
 use datafusion::arrow::datatypes::DataType;
 use datafusion::common::ScalarValue;
 use datafusion::prelude::SessionContext;
+use exoware_sdk::PrefixedStoreClient;
 use exoware_sql::{default_orders_index_specs, CellValue, IndexSpec, KvSchema, TableColumnConfig};
 
 fn collect_i64_rows(
@@ -101,7 +102,7 @@ async fn orders_example_queries_work_end_to_end() {
     let (_dir, _server, client) = common::local_store_client().await;
     let ctx = SessionContext::new();
 
-    KvSchema::new(client)
+    KvSchema::new(PrefixedStoreClient::empty(client))
         .orders_table("orders_kv", default_orders_index_specs())
         .expect("orders schema")
         .register_all(&ctx)
@@ -182,7 +183,7 @@ async fn join_example_queries_work_end_to_end() {
     let (_dir, _server, client) = common::local_store_client().await;
     let ctx = SessionContext::new();
 
-    KvSchema::new(client)
+    KvSchema::new(PrefixedStoreClient::empty(client))
         .table(
             "customers",
             vec![
@@ -292,7 +293,7 @@ async fn versioned_example_queries_work_end_to_end() {
     let ctx = SessionContext::new();
     let writer_client = client.clone();
 
-    let schema = KvSchema::new(client)
+    let schema = KvSchema::new(PrefixedStoreClient::empty(client))
         .table_versioned(
             "documents",
             vec![
@@ -312,7 +313,7 @@ async fn versioned_example_queries_work_end_to_end() {
     let doc_id_hex = "d0c1aabbccddeeff0011223344556677";
     let doc_id = hex::decode(doc_id_hex).expect("doc_id hex");
 
-    let mut batch = KvSchema::new(writer_client)
+    let mut batch = KvSchema::new(PrefixedStoreClient::empty(writer_client))
         .table_versioned(
             "documents",
             vec![
@@ -412,7 +413,7 @@ async fn fixed_binary_example_filters_work_end_to_end() {
     let ctx = SessionContext::new();
     let writer_client = client.clone();
 
-    let schema = KvSchema::new(client)
+    let schema = KvSchema::new(PrefixedStoreClient::empty(client))
         .table(
             "wallets",
             vec![
@@ -443,7 +444,7 @@ async fn fixed_binary_example_filters_work_end_to_end() {
 
     schema.register_all(&ctx).expect("register");
 
-    let mut batch = KvSchema::new(writer_client)
+    let mut batch = KvSchema::new(PrefixedStoreClient::empty(writer_client))
         .table(
             "wallets",
             vec![


### PR DESCRIPTION
This should prevent collision bugs like https://github.com/commonwarexyz/constantinople/issues/21 by having conventional store prefixes (`Namespace`s) be the default when constructing stores in the exoware sdk.

Custom prefixes or unprefixed stores are still possible if desired.

See https://github.com/commonwarexyz/constantinople/pull/22 for what the usage would look like.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mechanical but wide API change on the store write/read path for all QMDB backends; wrong prefix wiring could cause silent cross-tenant data access, though tests heavily cover prefix isolation.
> 
> **Overview**
> QMDB **read clients, writers, and Connect backends** now take a **`PrefixedStoreClient`** (namespace prefix baked into the handle) instead of a bare **`StoreClient`**. URL/`from_client` constructors are removed; callers use **`StoreClient::…prefixed(…)`** or **`PrefixedStoreClient::empty`**, and writers use **`fresh`** instead of **`empty`**.
> 
> **`commit_upload` / publication commits** no longer accept a separate store client—the writer’s prefixed client drives staging and commit. **`StoreWriteBatch::push`** and QMDB staging helpers take an explicit **`StoreKeyPrefix`** rather than inferring it from the client.
> 
> Tests, examples, integration multi-instance flows, and docs are updated to **`prefixed(...)`** isolation and the slimmer commit APIs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9781fdc781303eef90260f5a9551821010e7f59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->