### PR TITLE
[simulator] Decouple log commits from key/value application

### DIFF
--- a/examples/simulator/src/rocks.rs
+++ b/examples/simulator/src/rocks.rs
@@ -1455,6 +1455,14 @@ impl Log for RocksStore {
             }
         }
     }
+
+    fn log_sequence(&self) -> u64 {
+        // The logged frontier, not the applied one `current_sequence` reports: stream RPCs
+        // classify missing batches against what the log durably contains, and every sequence
+        // at or below `logged` was acknowledged (its row exists unless the batch was empty or
+        // pruned — both "evicted", never "not found").
+        self.logged.load(Ordering::Acquire)
+    }
 }
 
 /// Encodes a sequence number as a log-CF key that preserves numeric order in RocksDB.

--- a/examples/simulator/src/rocks.rs
+++ b/examples/simulator/src/rocks.rs
@@ -10,7 +10,7 @@
 //! (a synced RocksDB write covering the `log` and `meta` column families). How the current-state
 //! key/value rows land depends on the wave's payload size:
 //!
-//! - Waves whose key/value payload is at most [`INLINE_APPLY_MAX_BATCH_BYTES`] ride the synced
+//! - Waves whose key/value payload is at most `INLINE_APPLY_MAX_BATCH_BYTES` ride the synced
 //!   commit batch directly ("inline apply"). Duplicating a few kilobytes into the WAL costs less
 //!   than a second RocksDB write-group cycle, so small-value workloads keep the single-write
 //!   profile of the pre-decoupled store.
@@ -41,7 +41,7 @@
 //! - Inline-applied rows travel through the synced WAL, so they are recoverable whether or not
 //!   any marker covers them. Inline waves advance the in-memory frontier immediately but leave
 //!   the durable marker behind; the apply thread persists a catch-up marker every
-//!   [`APPLY_MARKER_STRIDE_SEQUENCES`] sequences to bound how much a crash replays.
+//!   `APPLY_MARKER_STRIDE_SEQUENCES` sequences to bound how much a crash replays.
 //!
 //! Sequence pruning persists the applied marker and flushes the key/value column families
 //! before deleting log rows, and never deletes rows at or above the applied frontier, so the

--- a/examples/simulator/src/rocks.rs
+++ b/examples/simulator/src/rocks.rs
@@ -7,10 +7,17 @@
 //! # Write pipeline
 //!
 //! Ingest acknowledges a write once its replay-log row and the sequence frontier are durable
-//! (a synced RocksDB write covering the `log` and `meta` column families). The current-state
-//! key/value rows are applied afterwards by a background thread with the RocksDB WAL disabled:
-//! the replay log already is the write-ahead log for the default column family, so key/value
-//! rows never need to be fsync'd on the ingest critical path.
+//! (a synced RocksDB write covering the `log` and `meta` column families). How the current-state
+//! key/value rows land depends on the wave's payload size:
+//!
+//! - Waves whose key/value payload is at most [`INLINE_APPLY_MAX_BATCH_BYTES`] ride the synced
+//!   commit batch directly ("inline apply"). Duplicating a few kilobytes into the WAL costs less
+//!   than a second RocksDB write-group cycle, so small-value workloads keep the single-write
+//!   profile of the pre-decoupled store.
+//! - Larger waves are applied afterwards by a background thread with the RocksDB WAL disabled:
+//!   the replay log already is the write-ahead log for the default column family, so large
+//!   key/value payloads never make a second trip through the WAL and never extend the fsync on
+//!   the ingest critical path.
 //!
 //! Two frontiers result. The *logged* frontier is returned to writers and drives the stream
 //! service (which reads the `log` column family directly). The *applied* frontier is what
@@ -19,13 +26,26 @@
 //!
 //! # Crash recovery
 //!
-//! Every key/value apply batch also advances an applied-frontier marker in the `kv_meta` column
-//! family. Both column families skip the WAL and the database opens with atomic flush enabled,
-//! so the marker recovered after a crash never runs ahead of the recovered key/value rows. On
-//! open, replay-log rows between the recovered marker and the logged frontier are re-applied
-//! (idempotent last-writer-wins puts) before the store serves traffic. Sequence pruning flushes
-//! the key/value column families first and never deletes rows at or above the applied frontier,
-//! so the replay source for this recovery cannot be pruned away.
+//! An applied-frontier marker in the `kv_meta` column family records how far the durable
+//! key/value state is known to reach; on open, replay-log rows between the recovered marker and
+//! the logged frontier are re-applied (idempotent, sequence-ordered last-writer-wins puts)
+//! before the store serves traffic. The marker may under-claim — replay then re-applies rows
+//! whose effects already survived — but must never over-claim. Two mechanisms keep that
+//! invariant:
+//!
+//! - The marker is only written by no-WAL batches (background applies, replay, prune, and the
+//!   apply thread's shutdown handoff), and every such batch carries the key/value rows it
+//!   claims. The default and `kv_meta` column families both skip the WAL and the database opens
+//!   with atomic flush enabled, so their durable states are always cut at the same write-batch
+//!   boundary: a recovered marker cannot claim no-WAL rows the default column family lost.
+//! - Inline-applied rows travel through the synced WAL, so they are recoverable whether or not
+//!   any marker covers them. Inline waves advance the in-memory frontier immediately but leave
+//!   the durable marker behind; the apply thread persists a catch-up marker every
+//!   [`APPLY_MARKER_STRIDE_SEQUENCES`] sequences to bound how much a crash replays.
+//!
+//! Sequence pruning persists the applied marker and flushes the key/value column families
+//! before deleting log rows, and never deletes rows at or above the applied frontier, so the
+//! replay source for this recovery cannot be pruned away.
 
 use std::cmp::Ordering as CmpOrdering;
 use std::collections::BTreeMap;
@@ -64,6 +84,15 @@ const KV_APPLIED_KEY: &[u8] = b"applied";
 const LOG_BATCH_KEY_LEN: usize = 8;
 const PRUNE_SCAN_BATCH_SIZE: usize = 4096;
 const DEFAULT_COMMIT_COALESCE_MAX_BATCH_BYTES: usize = 16 * 1024 * 1024;
+/// Waves whose key/value payload fits in this many bytes are applied inline in the synced
+/// commit batch: duplicating a small payload into the WAL is cheaper than the extra RocksDB
+/// write-group cycle (and cross-thread handoff) a separate no-WAL apply write costs. Larger
+/// payloads skip the WAL via the background apply thread, where avoiding the second copy wins.
+const INLINE_APPLY_MAX_BATCH_BYTES: usize = 16 * 1024;
+/// How far (in sequence numbers) the durable applied marker may trail the in-memory applied
+/// frontier before the apply thread persists a catch-up marker. Inline-applied waves are
+/// WAL-durable without a marker, so this only bounds how much log a crash reopen replays.
+const APPLY_MARKER_STRIDE_SEQUENCES: u64 = 4096;
 /// Committed waves the apply thread may buffer before commit blocks handing off more work.
 const APPLY_QUEUE_WAVES: usize = 4;
 const APPLY_RETRY_INITIAL_BACKOFF: Duration = Duration::from_millis(10);
@@ -326,6 +355,9 @@ struct PreparedWrite {
     batch_bytes: usize,
     /// Assignment epoch; `commit` rejects a group whose epoch an earlier failure has superseded.
     epoch: u64,
+    /// Whether the key/value rows ride `batch` itself (small payload) instead of the background
+    /// no-WAL apply write.
+    inline_kv: bool,
 }
 
 /// Key/value rows of one durably committed wave, handed to the background apply thread.
@@ -549,6 +581,7 @@ fn prepare_queued_write(
                 batch: Err(error),
                 batch_bytes: 0,
                 epoch,
+                inline_kv: false,
             };
             return Ok((group, disconnected));
         }
@@ -633,16 +666,18 @@ fn commit_group(
 
     let requests = group.writes.len();
     let batch_bytes = group.batch_bytes;
+    let inline_kv = group.inline_kv;
     match write_prepared_group(db, group) {
         Ok((writes, last_sequence)) => {
             logged.store(last_sequence, Ordering::Release);
             debug!(
                 requests,
                 batch_bytes,
+                inline_kv,
                 sequence = last_sequence,
                 "committed log batch"
             );
-            let work = complete_assigned_writes(writes);
+            let work = complete_assigned_writes(writes, inline_kv);
             (last_sequence, Some(work))
         }
         Err((writes, error)) => {
@@ -659,6 +694,10 @@ fn commit_group(
 /// coalescing queued waves and publishing the applied frontier queries gate on. A failed write is
 /// retried with backoff: the rows are already durable in the replay log, so the only alternatives
 /// are catching up in-process or catching up via replay on the next open.
+///
+/// Marker-only work (from inline waves, whose rows are already WAL-durable) skips the RocksDB
+/// write until the durable marker trails the frontier by [`APPLY_MARKER_STRIDE_SEQUENCES`], so
+/// steady small-value load costs no extra write calls while crash replay stays bounded.
 fn run_apply(
     db: Arc<DB>,
     applied: Arc<AtomicU64>,
@@ -667,16 +706,33 @@ fn run_apply(
     receiver: mpsc::Receiver<ApplyWork>,
     max_batch_bytes: usize,
 ) {
+    let mut marker = applied.load(Ordering::Acquire);
     while let Ok(first) = receiver.recv() {
         let (work, disconnected) = coalesce_apply_work(&receiver, first, max_batch_bytes);
-        if !write_apply_work_with_retry(&db, &work, &stopping) {
-            return;
+        let lag = work.last_sequence.saturating_sub(marker);
+        if !work.kvs.is_empty() || lag >= APPLY_MARKER_STRIDE_SEQUENCES {
+            if !write_apply_work_with_retry(&db, &work, &stopping) {
+                return;
+            }
+            marker = work.last_sequence;
         }
         applied.store(work.last_sequence, Ordering::Release);
         let _ = applied_watch.send(work.last_sequence);
         if disconnected {
-            return;
+            break;
         }
+    }
+    // Clean shutdown: catch the durable marker up to the frontier so RocksDB's flush-on-close
+    // (no-WAL data is flushed on close by default) leaves the next open nothing to replay.
+    // Skipping this is safe — the marker would just under-claim — but replaying inline waves
+    // that are already WAL-durable on every clean reopen is wasted work.
+    let frontier = applied.load(Ordering::Acquire);
+    if frontier > marker {
+        let work = ApplyWork {
+            last_sequence: frontier,
+            kvs: Vec::new(),
+        };
+        let _ = write_apply_work_with_retry(&db, &work, &stopping);
     }
 }
 
@@ -850,12 +906,26 @@ fn finalize_prepared_write(
     if let Some(write) = writes.last() {
         append_sequence_meta(db, &mut batch, write.sequence);
     }
+    let kv_bytes: usize = writes
+        .iter()
+        .flat_map(|write| write.request.kvs.iter())
+        .map(|(key, value)| key.len() + value.len())
+        .sum();
+    let inline_kv = kv_bytes <= INLINE_APPLY_MAX_BATCH_BYTES;
+    if inline_kv {
+        for write in &writes {
+            for (key, value) in &write.request.kvs {
+                batch.put(key.as_ref(), value.as_ref());
+            }
+        }
+    }
     let batch_bytes = batch.size_in_bytes();
     PreparedWrite {
         writes,
         batch: Ok(batch),
         batch_bytes,
         epoch,
+        inline_kv,
     }
 }
 
@@ -920,8 +990,10 @@ fn fail_assigned_writes(writes: Vec<AssignedWrite>, error: String) {
 }
 
 /// Resolves every assigned write with its own committed sequence number and collects the wave's
-/// key/value rows (in assignment order) for the apply thread.
-fn complete_assigned_writes(writes: Vec<AssignedWrite>) -> ApplyWork {
+/// key/value rows (in assignment order) for the apply thread. An inline wave already wrote its
+/// rows in the commit batch, so its work carries only the frontier for the apply thread's
+/// in-order bookkeeping.
+fn complete_assigned_writes(writes: Vec<AssignedWrite>, inline_kv: bool) -> ApplyWork {
     let mut work = ApplyWork {
         last_sequence: 0,
         kvs: Vec::new(),
@@ -930,7 +1002,9 @@ fn complete_assigned_writes(writes: Vec<AssignedWrite>) -> ApplyWork {
         let AssignedWrite { sequence, request } = write;
         let WriteRequest { mut kvs, response } = request;
         work.last_sequence = sequence;
-        work.kvs.append(&mut kvs);
+        if !inline_kv {
+            work.kvs.append(&mut kvs);
+        }
         let _ = response.send(Ok(sequence));
     }
     work
@@ -1115,13 +1189,19 @@ impl RocksStore {
         Ok(())
     }
 
-    /// Deletes replay-log batches with sequence numbers below `cutoff_exclusive`. Flushes the
-    /// no-WAL column families first so the durable applied frontier covers every deleted row;
-    /// otherwise a crash could need pruned rows to rebuild the current key/value state.
+    /// Deletes replay-log batches with sequence numbers below `cutoff_exclusive`. Persists the
+    /// applied marker and flushes the no-WAL column families first so the durable applied
+    /// frontier covers every deleted row; otherwise a crash could need pruned rows to rebuild
+    /// the current key/value state. (Inline waves advance the in-memory frontier without
+    /// touching the durable marker, so the marker must be caught up here before it can vouch
+    /// for the rows the delete removes. A concurrent background apply can only race in an
+    /// older marker value, which under-claims and is therefore safe.)
     fn prune_log(&self, cutoff_exclusive: u64) -> Result<(), String> {
         if cutoff_exclusive == 0 {
             return Ok(());
         }
+        let applied = self.applied.load(Ordering::Acquire);
+        write_kv_batch(&self.db, build_apply_batch(&self.db, &[], applied))?;
         flush_kv_cfs(&self.db)?;
         let cf = self.log_cf();
         self.db
@@ -1428,6 +1508,7 @@ mod tests {
                 batch: Err(error.to_string()),
                 batch_bytes: 0,
                 epoch,
+                inline_kv: false,
             },
             receivers,
         )
@@ -1520,6 +1601,7 @@ mod tests {
                     batch: Err(error),
                     batch_bytes: 0,
                     epoch,
+                    inline_kv: false,
                 };
             }
             prepared.push(write);
@@ -1987,6 +2069,12 @@ mod tests {
         assert_eq!(value.as_deref(), Some(b"v".as_slice()));
     }
 
+    /// A value larger than the inline-apply cap, forcing a wave through the deferred no-WAL
+    /// apply path (the only path whose un-flushed key/value state a crash can lose).
+    fn oversized_value(fill: u8) -> Bytes {
+        Bytes::from(vec![fill; INLINE_APPLY_MAX_BATCH_BYTES + 1])
+    }
+
     /// Rewinds the durable applied marker and removes the key/value rows it no longer covers,
     /// modeling a crash that lost un-flushed no-WAL state while the synced log survived.
     fn lose_applied_kv_state(store: &RocksStore, marker: u64, lost_keys: &[&[u8]]) {
@@ -2006,14 +2094,16 @@ mod tests {
     #[tokio::test]
     async fn open_replays_log_rows_the_kv_state_lost() {
         let dir = tempdir().expect("tempdir");
+        let rows: Vec<(&[u8], Bytes)> = vec![
+            (b"a", oversized_value(b'1')),
+            (b"b", oversized_value(b'2')),
+            (b"c", oversized_value(b'3')),
+        ];
         {
             let store = RocksStore::open(dir.path(), None).expect("open db");
-            for (key, value) in [(b"a", b"1"), (b"b", b"2"), (b"c", b"3")] {
+            for (key, value) in &rows {
                 store
-                    .put_batch(vec![(
-                        Bytes::copy_from_slice(key),
-                        Bytes::copy_from_slice(value),
-                    )])
+                    .put_batch(vec![(Bytes::copy_from_slice(key), value.clone())])
                     .await
                     .expect("put");
             }
@@ -2023,10 +2113,10 @@ mod tests {
 
         let store = RocksStore::open(dir.path(), None).expect("reopen db");
         assert_eq!(store.current_sequence(), 3);
-        for (key, value) in [(b"a", b"1"), (b"b", b"2"), (b"c", b"3")] {
+        for (key, value) in &rows {
             assert_eq!(
                 store.db.get(key).expect("get").as_deref(),
-                Some(value.as_slice()),
+                Some(value.as_ref()),
                 "row {} must be restored by replay",
                 String::from_utf8_lossy(key),
             );
@@ -2036,13 +2126,14 @@ mod tests {
     #[tokio::test]
     async fn open_replays_across_log_gaps() {
         let dir = tempdir().expect("tempdir");
+        let value = oversized_value(b'v');
         {
             let store = RocksStore::open(dir.path(), None).expect("open db");
             // An empty batch consumes sequence 1 without writing a log row.
             let first = store.put_batch(Vec::new()).await.expect("empty put");
             assert_eq!(first, 1);
             let second = store
-                .put_batch(vec![(Bytes::from_static(b"k"), Bytes::from_static(b"v"))])
+                .put_batch(vec![(Bytes::from_static(b"k"), value.clone())])
                 .await
                 .expect("put");
             assert_eq!(second, 2);
@@ -2054,9 +2145,109 @@ mod tests {
         assert_eq!(store.current_sequence(), 2);
         assert_eq!(
             store.db.get(b"k").expect("get").as_deref(),
-            Some(b"v".as_slice())
+            Some(value.as_ref())
         );
         assert!(store.get_batch(1).await.expect("get").is_none());
+    }
+
+    #[tokio::test]
+    async fn small_wave_applies_inline_with_the_synced_commit() {
+        let dir = tempdir().expect("tempdir");
+        let store = RocksStore::open(dir.path(), None).expect("open db");
+        let epoch = AtomicU64::new(0);
+
+        let (write, result) = assigned_write_with_response(1, b"a", b"1");
+        let group = prepared_write(&store.db, 0, vec![write]);
+        assert!(group.inline_kv, "a tiny payload must ride the commit batch");
+
+        // Commit WITHOUT running any apply work: the row must already be readable because the
+        // synced commit batch carried it, and the handed-off work must be marker-only.
+        let (committed, work) = commit_group(&store.db, &store.logged, &epoch, 0, group);
+        assert_eq!(committed, 1);
+        assert_eq!(result.await.expect("response"), Ok(1));
+        let work = work.expect("commit must hand off frontier bookkeeping");
+        assert_eq!(work.last_sequence, 1);
+        assert!(work.kvs.is_empty(), "inline rows must not be re-applied");
+        assert_eq!(store.db.get(b"a").expect("get").as_deref(), Some(&b"1"[..]));
+    }
+
+    #[tokio::test]
+    async fn large_wave_defers_kv_rows_to_the_background_apply() {
+        let dir = tempdir().expect("tempdir");
+        let store = RocksStore::open(dir.path(), None).expect("open db");
+        let epoch = AtomicU64::new(0);
+
+        let value: &'static [u8] =
+            Box::leak(vec![7u8; INLINE_APPLY_MAX_BATCH_BYTES + 1].into_boxed_slice());
+        let (write, result) = assigned_write_with_response(1, b"big", value);
+        let group = prepared_write(&store.db, 0, vec![write]);
+        assert!(!group.inline_kv, "an oversized payload must defer");
+
+        let (committed, work) = commit_group(&store.db, &store.logged, &epoch, 0, group);
+        assert_eq!(committed, 1);
+        assert_eq!(result.await.expect("response"), Ok(1));
+        let work = work.expect("commit must hand off the kv rows");
+        assert_eq!(work.kvs.len(), 1);
+        assert!(
+            store.db.get(b"big").expect("get").is_none(),
+            "deferred rows are not visible until the apply write lands",
+        );
+
+        apply_work_for_test(&store, work);
+        assert_eq!(store.db.get(b"big").expect("get").as_deref(), Some(value));
+    }
+
+    #[tokio::test]
+    async fn open_replays_inline_waves_the_durable_marker_does_not_cover() {
+        let dir = tempdir().expect("tempdir");
+        {
+            let store = RocksStore::open(dir.path(), None).expect("open db");
+            for (key, value) in [(b"a", b"1"), (b"b", b"2")] {
+                store
+                    .put_batch(vec![(
+                        Bytes::copy_from_slice(key),
+                        Bytes::copy_from_slice(value),
+                    )])
+                    .await
+                    .expect("put");
+            }
+            store.wait_for_applied(2).await.expect("applied");
+        }
+
+        // With the store closed (a clean close catches the marker up), rewind the marker and
+        // drop the rows out-of-band: replay from an under-claiming marker must restore inline
+        // waves from their replay-log rows just like deferred ones.
+        {
+            let mut options = Options::default();
+            options.create_if_missing(false);
+            let db = DB::open_cf(
+                &options,
+                dir.path(),
+                [
+                    rocksdb::DEFAULT_COLUMN_FAMILY_NAME,
+                    META_CF,
+                    LOG_CF,
+                    KV_META_CF,
+                ],
+            )
+            .expect("open raw db");
+            let kv_meta_cf = db.cf_handle(KV_META_CF).expect("kv_meta CF");
+            db.put_cf(kv_meta_cf, KV_APPLIED_KEY, 0u64.to_le_bytes())
+                .expect("rewind applied marker");
+            db.delete(b"a").expect("drop kv row");
+            db.delete(b"b").expect("drop kv row");
+        }
+
+        let store = RocksStore::open(dir.path(), None).expect("reopen db");
+        assert_eq!(store.current_sequence(), 2);
+        for (key, value) in [(b"a", b"1"), (b"b", b"2")] {
+            assert_eq!(
+                store.db.get(key).expect("get").as_deref(),
+                Some(value.as_slice()),
+                "row {} must be restored by replay",
+                String::from_utf8_lossy(key),
+            );
+        }
     }
 
     #[tokio::test]

--- a/examples/simulator/src/rocks.rs
+++ b/examples/simulator/src/rocks.rs
@@ -3,14 +3,38 @@
 //! A separate `log` column family keeps per-sequence-number batch payloads so the stream service
 //! can serve replay and point lookups. Batch-log pruning is driven exclusively by the compact
 //! service's `Sequence` scope.
+//!
+//! # Write pipeline
+//!
+//! Ingest acknowledges a write once its replay-log row and the sequence frontier are durable
+//! (a synced RocksDB write covering the `log` and `meta` column families). The current-state
+//! key/value rows are applied afterwards by a background thread with the RocksDB WAL disabled:
+//! the replay log already is the write-ahead log for the default column family, so key/value
+//! rows never need to be fsync'd on the ingest critical path.
+//!
+//! Two frontiers result. The *logged* frontier is returned to writers and drives the stream
+//! service (which reads the `log` column family directly). The *applied* frontier is what
+//! [`Sequence::current_sequence`] reports, so query RPCs gated on `min_sequence_number` reject
+//! reads the key/value state does not cover yet instead of serving them partially.
+//!
+//! # Crash recovery
+//!
+//! Every key/value apply batch also advances an applied-frontier marker in the `kv_meta` column
+//! family. Both column families skip the WAL and the database opens with atomic flush enabled,
+//! so the marker recovered after a crash never runs ahead of the recovered key/value rows. On
+//! open, replay-log rows between the recovered marker and the logged frontier are re-applied
+//! (idempotent last-writer-wins puts) before the store serves traffic. Sequence pruning flushes
+//! the key/value column families first and never deletes rows at or above the applied frontier,
+//! so the replay source for this recovery cannot be pruned away.
 
 use std::cmp::Ordering as CmpOrdering;
 use std::collections::BTreeMap;
 use std::num::NonZeroUsize;
 use std::path::Path;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{mpsc, Arc, Mutex};
 use std::thread;
+use std::time::Duration;
 
 use buffa::Message;
 use bytes::Bytes;
@@ -26,18 +50,24 @@ use exoware_server::{
 };
 use regex::bytes::Regex;
 use rocksdb::{
-    ColumnFamily, ColumnFamilyDescriptor, DBIterator, Direction, IteratorMode, Options,
-    WriteOptions, DB,
+    ColumnFamily, ColumnFamilyDescriptor, DBIterator, Direction, FlushOptions, IteratorMode,
+    Options, WriteOptions, DB,
 };
-use tokio::sync::oneshot;
-use tracing::debug;
+use tokio::sync::{oneshot, watch};
+use tracing::{debug, error};
 
 const META_CF: &str = "meta";
 const SEQ_META_KEY: &[u8] = b"sequence";
 const LOG_CF: &str = "log";
+const KV_META_CF: &str = "kv_meta";
+const KV_APPLIED_KEY: &[u8] = b"applied";
 const LOG_BATCH_KEY_LEN: usize = 8;
 const PRUNE_SCAN_BATCH_SIZE: usize = 4096;
 const DEFAULT_COMMIT_COALESCE_MAX_BATCH_BYTES: usize = 16 * 1024 * 1024;
+/// Committed waves the apply thread may buffer before commit blocks handing off more work.
+const APPLY_QUEUE_WAVES: usize = 4;
+const APPLY_RETRY_INITIAL_BACKOFF: Duration = Duration::from_millis(10);
+const APPLY_RETRY_MAX_BACKOFF: Duration = Duration::from_secs(1);
 type RocksIterItem = Result<(Box<[u8]>, Box<[u8]>), rocksdb::Error>;
 
 /// Owns the DB handle for a RocksDB iterator that is moved through blocking tasks.
@@ -288,8 +318,8 @@ struct AssignedWrite {
     request: WriteRequest,
 }
 
-/// One RocksDB `WriteBatch` covering a contiguous run of assigned sequence numbers, committed
-/// atomically by a single synced write.
+/// One RocksDB `WriteBatch` covering the replay-log rows for a contiguous run of assigned
+/// sequence numbers, committed atomically by a single synced write.
 struct PreparedWrite {
     writes: Vec<AssignedWrite>,
     batch: Result<rocksdb::WriteBatch, String>,
@@ -298,38 +328,78 @@ struct PreparedWrite {
     epoch: u64,
 }
 
+/// Key/value rows of one durably committed wave, handed to the background apply thread.
+struct ApplyWork {
+    last_sequence: u64,
+    kvs: Vec<(Bytes, Bytes)>,
+}
+
 struct Writer {
     sender: Mutex<Option<mpsc::Sender<WriteRequest>>>,
     handles: Mutex<Vec<thread::JoinHandle<()>>>,
+    stopping: Arc<AtomicBool>,
 }
 
 impl Writer {
-    /// Starts the two-stage write pipeline. `prepare` drains queued requests up to the configured
-    /// byte cap, assigns a contiguous sequence number to each, and builds a size-capped
-    /// `WriteBatch`; `commit` syncs each group and resolves its requests. Keeping `commit` on its
-    /// own thread lets `prepare` build the next wave while the current one is being fsync'd.
+    /// Starts the three-stage write pipeline. `prepare` drains queued requests up to the
+    /// configured byte cap, assigns a contiguous sequence number to each, and builds a
+    /// size-capped log `WriteBatch`; `commit` syncs each group, resolves its requests, and hands
+    /// the key/value rows to `apply`, which writes them to the current-state column family
+    /// without the WAL. Keeping the stages on their own threads lets `prepare` build the next
+    /// wave while the current one is being fsync'd and keeps key/value application off the
+    /// ingest critical path entirely.
     fn start(
         db: Arc<DB>,
-        sequence: Arc<AtomicU64>,
+        logged: Arc<AtomicU64>,
+        applied: Arc<AtomicU64>,
+        applied_watch: watch::Sender<u64>,
         write_pipeline: RocksWritePipelineConfig,
     ) -> Self {
         let (request_sender, request_receiver) = mpsc::channel();
         // Rendezvous so `prepare` runs at most one wave ahead of `commit`: it hands off a built
         // group, then builds the next while `commit` syncs this one.
         let (group_sender, group_receiver) = mpsc::sync_channel(0);
+        // Bounded so a stalled apply thread eventually backpressures commit instead of buffering
+        // committed waves without limit.
+        let (apply_sender, apply_receiver) = mpsc::sync_channel(APPLY_QUEUE_WAVES);
         let max_commit_batch_bytes = write_pipeline.max_commit_batch_bytes.get();
 
         // Bumped by `commit` whenever a group fails. That rejects the in-flight groups assigned
         // under the failed frontier and signals `prepare` to re-sync its counter to the durable
         // sequence, re-allocating the abandoned numbers.
         let epoch = Arc::new(AtomicU64::new(0));
+        let stopping = Arc::new(AtomicBool::new(false));
+
+        let apply_db = db.clone();
+        let apply_stopping = stopping.clone();
+        let apply = thread::Builder::new()
+            .name("simulator-rocks-apply".to_string())
+            .spawn(move || {
+                run_apply(
+                    apply_db,
+                    applied,
+                    applied_watch,
+                    apply_stopping,
+                    apply_receiver,
+                    max_commit_batch_bytes,
+                )
+            })
+            .expect("failed to spawn RocksDB apply worker");
 
         let commit_db = db.clone();
-        let commit_sequence = sequence.clone();
+        let commit_logged = logged.clone();
         let commit_epoch = epoch.clone();
         let commit = thread::Builder::new()
             .name("simulator-rocks-commit".to_string())
-            .spawn(move || run_commit(commit_db, commit_sequence, commit_epoch, group_receiver))
+            .spawn(move || {
+                run_commit(
+                    commit_db,
+                    commit_logged,
+                    commit_epoch,
+                    group_receiver,
+                    apply_sender,
+                )
+            })
             .expect("failed to spawn RocksDB commit worker");
 
         let prepare = thread::Builder::new()
@@ -337,7 +407,7 @@ impl Writer {
             .spawn(move || {
                 run_prepare(
                     db,
-                    sequence,
+                    logged,
                     epoch,
                     request_receiver,
                     group_sender,
@@ -348,7 +418,8 @@ impl Writer {
 
         Self {
             sender: Mutex::new(Some(request_sender)),
-            handles: Mutex::new(vec![prepare, commit]),
+            handles: Mutex::new(vec![prepare, commit, apply]),
+            stopping,
         }
     }
 
@@ -373,8 +444,11 @@ impl Writer {
 
 impl Drop for Writer {
     fn drop(&mut self) {
-        // Closing the request channel lets `prepare` drain and exit, which drops the group channel
-        // and stops `commit`; joining keeps background RocksDB writers from outliving the store.
+        // `stopping` only makes `apply` give up an error-retry loop; healthy shutdown still
+        // drains every queued wave. Closing the request channel lets `prepare` drain and exit,
+        // which drops the group channel and stops `commit`, which in turn drops the apply channel
+        // and stops `apply`; joining keeps background RocksDB writers from outliving the store.
+        self.stopping.store(true, Ordering::Release);
         if let Ok(mut sender) = self.sender.lock() {
             sender.take();
         }
@@ -508,32 +582,42 @@ fn forward_group(sender: &mpsc::SyncSender<PreparedWrite>, group: PreparedWrite)
     true
 }
 
-/// Commits prepared groups one at a time with a synced write, publishing the durable frontier after
-/// each success. A group whose epoch was superseded by an earlier failure is rejected without being
-/// written; a failing group bumps the epoch so its frontier (and every later group assigned under
-/// it) is abandoned and re-allocated by `prepare`.
+/// Commits prepared groups one at a time with a synced write, publishing the durable frontier and
+/// forwarding key/value rows to `apply` after each success. A group whose epoch was superseded by
+/// an earlier failure is rejected without being written; a failing group bumps the epoch so its
+/// frontier (and every later group assigned under it) is abandoned and re-allocated by `prepare`.
 fn run_commit(
     db: Arc<DB>,
-    sequence: Arc<AtomicU64>,
+    logged: Arc<AtomicU64>,
     epoch: Arc<AtomicU64>,
     receiver: mpsc::Receiver<PreparedWrite>,
+    apply_sender: mpsc::SyncSender<ApplyWork>,
 ) {
-    let mut committed = sequence.load(Ordering::Acquire);
+    let mut committed = logged.load(Ordering::Acquire);
     while let Ok(group) = receiver.recv() {
-        committed = commit_group(&db, &sequence, &epoch, committed, group);
+        let (next_committed, work) = commit_group(&db, &logged, &epoch, committed, group);
+        committed = next_committed;
+        if let Some(work) = work {
+            if apply_sender.send(work).is_err() {
+                // The acknowledged rows are durable in the replay log; the next open replays
+                // them into the current-state column family.
+                error!("rocks apply worker stopped; key/value rows deferred to reopen replay");
+            }
+        }
     }
 }
 
-/// Commits one group, returning the durable frontier afterwards (unchanged on rejection or failure).
+/// Commits one group, returning the durable log frontier afterwards (unchanged on rejection or
+/// failure) plus the key/value rows to apply for a successful commit.
 fn commit_group(
     db: &DB,
-    sequence: &AtomicU64,
+    logged: &AtomicU64,
     epoch: &AtomicU64,
     committed: u64,
     group: PreparedWrite,
-) -> u64 {
+) -> (u64, Option<ApplyWork>) {
     if group.writes.is_empty() {
-        return committed;
+        return (committed, None);
     }
     if group.epoch != epoch.load(Ordering::Acquire) {
         // This group was assigned under a frontier an earlier commit failure has since abandoned
@@ -544,32 +628,196 @@ fn commit_group(
             group.writes,
             "rocks write batch superseded by an earlier failure, retry".to_string(),
         );
-        return committed;
+        return (committed, None);
     }
 
     let requests = group.writes.len();
     let batch_bytes = group.batch_bytes;
     match write_prepared_group(db, group) {
         Ok((writes, last_sequence)) => {
-            // Release so `current_sequence` readers only observe rows that are already durable.
-            sequence.store(last_sequence, Ordering::Release);
+            logged.store(last_sequence, Ordering::Release);
             debug!(
                 requests,
                 batch_bytes,
                 sequence = last_sequence,
-                "committed write batch"
+                "committed log batch"
             );
-            complete_assigned_writes(writes);
-            last_sequence
+            let work = complete_assigned_writes(writes);
+            (last_sequence, Some(work))
         }
         Err((writes, error)) => {
             // Bump before failing: any in-flight group sharing the failed epoch is then rejected,
             // and `prepare` re-syncs to `committed`, leaving the abandoned numbers for reuse.
             epoch.fetch_add(1, Ordering::AcqRel);
             fail_assigned_writes(writes, error);
-            committed
+            (committed, None)
         }
     }
+}
+
+/// Applies committed key/value rows to the current-state column family without the WAL,
+/// coalescing queued waves and publishing the applied frontier queries gate on. A failed write is
+/// retried with backoff: the rows are already durable in the replay log, so the only alternatives
+/// are catching up in-process or catching up via replay on the next open.
+fn run_apply(
+    db: Arc<DB>,
+    applied: Arc<AtomicU64>,
+    applied_watch: watch::Sender<u64>,
+    stopping: Arc<AtomicBool>,
+    receiver: mpsc::Receiver<ApplyWork>,
+    max_batch_bytes: usize,
+) {
+    while let Ok(first) = receiver.recv() {
+        let (work, disconnected) = coalesce_apply_work(&receiver, first, max_batch_bytes);
+        if !write_apply_work_with_retry(&db, &work, &stopping) {
+            return;
+        }
+        applied.store(work.last_sequence, Ordering::Release);
+        let _ = applied_watch.send(work.last_sequence);
+        if disconnected {
+            return;
+        }
+    }
+}
+
+/// Folds waves already queued behind `first` into one apply unit, up to the soft byte cap.
+fn coalesce_apply_work(
+    receiver: &mpsc::Receiver<ApplyWork>,
+    first: ApplyWork,
+    max_batch_bytes: usize,
+) -> (ApplyWork, bool) {
+    let mut work = first;
+    let mut disconnected = false;
+    let mut bytes: usize = work.kvs.iter().map(|(k, v)| k.len() + v.len()).sum();
+    while bytes < max_batch_bytes {
+        match receiver.try_recv() {
+            Ok(mut next) => {
+                bytes += next
+                    .kvs
+                    .iter()
+                    .map(|(k, v)| k.len() + v.len())
+                    .sum::<usize>();
+                work.kvs.append(&mut next.kvs);
+                work.last_sequence = next.last_sequence;
+            }
+            Err(mpsc::TryRecvError::Empty) => break,
+            Err(mpsc::TryRecvError::Disconnected) => {
+                disconnected = true;
+                break;
+            }
+        }
+    }
+    (work, disconnected)
+}
+
+/// Writes one apply unit, retrying with backoff until it lands or shutdown begins. Returns false
+/// only when giving up during shutdown; the rows then reach the current-state column family via
+/// replay on the next open.
+fn write_apply_work_with_retry(db: &DB, work: &ApplyWork, stopping: &AtomicBool) -> bool {
+    let mut backoff = APPLY_RETRY_INITIAL_BACKOFF;
+    loop {
+        match write_kv_batch(db, build_apply_batch(db, &work.kvs, work.last_sequence)) {
+            Ok(()) => return true,
+            Err(err) => {
+                error!(
+                    error = %err,
+                    last_sequence = work.last_sequence,
+                    "applying committed key/value rows failed; retrying"
+                );
+                if stopping.load(Ordering::Acquire) {
+                    return false;
+                }
+                thread::sleep(backoff);
+                backoff = (backoff * 2).min(APPLY_RETRY_MAX_BACKOFF);
+            }
+        }
+    }
+}
+
+/// Builds the no-WAL batch for one apply unit: the key/value rows plus the applied-frontier
+/// marker that recovery replays from. Writing the marker in the same batch (with atomic flush
+/// enabled) keeps it from ever running ahead of the rows it covers.
+fn build_apply_batch(db: &DB, kvs: &[(Bytes, Bytes)], last_sequence: u64) -> rocksdb::WriteBatch {
+    let kv_meta_cf = db
+        .cf_handle(KV_META_CF)
+        .expect("kv_meta CF must exist (created on open)");
+    let mut batch = rocksdb::WriteBatch::default();
+    for (k, v) in kvs {
+        batch.put(k.as_ref(), v.as_ref());
+    }
+    batch.put_cf(kv_meta_cf, KV_APPLIED_KEY, last_sequence.to_le_bytes());
+    batch
+}
+
+/// Writes current-state rows without the WAL: the replay log is their write-ahead log.
+fn write_kv_batch(db: &DB, batch: rocksdb::WriteBatch) -> Result<(), String> {
+    let mut write_options = WriteOptions::default();
+    write_options.disable_wal(true);
+    db.write_opt(batch, &write_options)
+        .map_err(|e| e.to_string())
+}
+
+/// Flushes the column families that skip the WAL, making the applied frontier durable.
+fn flush_kv_cfs(db: &DB) -> Result<(), String> {
+    let default_cf = db
+        .cf_handle(rocksdb::DEFAULT_COLUMN_FAMILY_NAME)
+        .expect("default CF must exist");
+    let kv_meta_cf = db
+        .cf_handle(KV_META_CF)
+        .expect("kv_meta CF must exist (created on open)");
+    let mut flush_options = FlushOptions::default();
+    flush_options.set_wait(true);
+    db.flush_cfs_opt(&[default_cf, kv_meta_cf], &flush_options)
+        .map_err(|e| e.to_string())
+}
+
+/// Replays replay-log rows in `(from_exclusive, to_inclusive]` into the current-state column
+/// family in size-capped no-WAL batches, then flushes so the recovery is not repeated on the
+/// next open. Re-applying rows the crash had already applied is harmless: puts are last-writer
+/// wins and replay preserves sequence order.
+fn replay_log_into_kv(
+    db: &DB,
+    from_exclusive: u64,
+    to_inclusive: u64,
+    max_batch_bytes: usize,
+) -> Result<(), String> {
+    let log_cf = db
+        .cf_handle(LOG_CF)
+        .expect("log CF must exist (created on open)");
+    let start = sequence_log_key(from_exclusive.saturating_add(1));
+    let iter = db.iterator_cf(log_cf, IteratorMode::From(&start, Direction::Forward));
+
+    let mut kvs: Vec<(Bytes, Bytes)> = Vec::new();
+    let mut bytes = 0usize;
+    let mut replayed = 0u64;
+    for item in iter {
+        let (key, value) = item.map_err(|e| e.to_string())?;
+        let sequence = sequence_from_log_key(&key)?;
+        if sequence > to_inclusive {
+            break;
+        }
+        let response = StreamGetResponse::decode_from_slice(&value)
+            .map_err(|e| format!("failed to decode replay-log row {sequence}: {e}"))?;
+        for entry in response.entries {
+            bytes += entry.key.len() + entry.value.len();
+            kvs.push((Bytes::from(entry.key), entry.value));
+        }
+        replayed += 1;
+        if bytes >= max_batch_bytes {
+            write_kv_batch(db, build_apply_batch(db, &kvs, sequence))?;
+            kvs.clear();
+            bytes = 0;
+        }
+    }
+    write_kv_batch(db, build_apply_batch(db, &kvs, to_inclusive))?;
+    flush_kv_cfs(db)?;
+    debug!(
+        from = from_exclusive,
+        to = to_inclusive,
+        replayed,
+        "replayed log rows into key/value state"
+    );
+    Ok(())
 }
 
 /// Commits one prepared group with a single synced write. Returns the group's writes alongside its
@@ -624,7 +872,8 @@ fn append_assigned_write_batch(
     )
 }
 
-/// Appends one sequence's current-state rows plus its replay-log row to `batch`.
+/// Appends one sequence's replay-log row to `batch`. Current-state rows are not part of the
+/// synced commit; the apply thread writes them after the log write is durable.
 fn append_sequence_entries(
     db: &DB,
     batch: &mut rocksdb::WriteBatch,
@@ -635,11 +884,6 @@ fn append_sequence_entries(
         .cf_handle(LOG_CF)
         .expect("log CF must exist (created on open)");
 
-    for request in requests {
-        for (k, v) in &request.kvs {
-            batch.put(k.as_ref(), v.as_ref());
-        }
-    }
     if let Some(log_value) = encode_log_value(sequence, requests) {
         batch.put_cf(log_cf, sequence_log_key(sequence), log_value);
     }
@@ -653,7 +897,7 @@ fn append_sequence_meta(db: &DB, batch: &mut rocksdb::WriteBatch, sequence: u64)
     batch.put_cf(meta_cf, SEQ_META_KEY, sequence.to_le_bytes());
 }
 
-/// Writes a sequence batch with sync enabled because it defines the stream log high-water mark.
+/// Writes a log batch with sync enabled because it defines the acknowledged write frontier.
 fn write_sequence_batch(db: &DB, batch: rocksdb::WriteBatch) -> Result<(), String> {
     let mut write_options = WriteOptions::default();
     write_options.set_sync(true);
@@ -675,11 +919,21 @@ fn fail_assigned_writes(writes: Vec<AssignedWrite>, error: String) {
     }
 }
 
-/// Resolves every assigned write with its own committed sequence number.
-fn complete_assigned_writes(writes: Vec<AssignedWrite>) {
+/// Resolves every assigned write with its own committed sequence number and collects the wave's
+/// key/value rows (in assignment order) for the apply thread.
+fn complete_assigned_writes(writes: Vec<AssignedWrite>) -> ApplyWork {
+    let mut work = ApplyWork {
+        last_sequence: 0,
+        kvs: Vec::new(),
+    };
     for write in writes {
-        let _ = write.request.response.send(Ok(write.sequence));
+        let AssignedWrite { sequence, request } = write;
+        let WriteRequest { mut kvs, response } = request;
+        work.last_sequence = sequence;
+        work.kvs.append(&mut kvs);
+        let _ = response.send(Ok(sequence));
     }
+    work
 }
 
 /// Application-level write pipeline options used by [`RocksStore::open`].
@@ -709,6 +963,8 @@ pub struct RocksConfig {
     pub meta_cf_options: Options,
     /// Options for the sequence log column family.
     pub log_cf_options: Options,
+    /// Options for the key/value apply-frontier metadata column family.
+    pub kv_meta_cf_options: Options,
     /// Options for the application-level ingest write pipeline.
     pub write_pipeline: RocksWritePipelineConfig,
 }
@@ -718,48 +974,115 @@ pub struct RocksConfig {
 #[derive(Clone)]
 pub struct RocksStore {
     db: Arc<DB>,
-    sequence: Arc<AtomicU64>,
+    /// Durable replay-log frontier: the highest sequence number acknowledged to writers.
+    logged: Arc<AtomicU64>,
+    /// Applied key/value frontier: the highest sequence number point/range reads fully cover.
+    applied: Arc<AtomicU64>,
+    applied_watch: watch::Receiver<u64>,
     writer: Arc<Writer>,
 }
 
 impl RocksStore {
     /// Open the store with stock RocksDB defaults, unless `config` overrides
-    /// the database and column-family options.
-    pub fn open(path: &Path, config: Option<RocksConfig>) -> Result<Self, rocksdb::Error> {
+    /// the database and column-family options. Replays any replay-log rows the current-state
+    /// column family had not durably absorbed before the last shutdown, so the applied frontier
+    /// matches the logged frontier before the store serves traffic.
+    pub fn open(path: &Path, config: Option<RocksConfig>) -> Result<Self, String> {
         let RocksConfig {
             mut db_options,
             default_cf_options,
             meta_cf_options,
             log_cf_options,
+            kv_meta_cf_options,
             write_pipeline,
         } = config.unwrap_or_default();
 
         db_options.create_if_missing(true);
         db_options.create_missing_column_families(true);
+        // Correctness requirement, not tunable: the default and kv_meta column families skip the
+        // WAL, and atomic flush is what keeps their durable states cut at the same write batch,
+        // so the recovered applied-frontier marker never claims rows the default CF lost.
+        db_options.set_atomic_flush(true);
 
         let cf_default =
             ColumnFamilyDescriptor::new(rocksdb::DEFAULT_COLUMN_FAMILY_NAME, default_cf_options);
         let cf_meta = ColumnFamilyDescriptor::new(META_CF, meta_cf_options);
         let cf_log = ColumnFamilyDescriptor::new(LOG_CF, log_cf_options);
-        let db = Arc::new(DB::open_cf_descriptors(
-            &db_options,
-            path,
-            vec![cf_default, cf_meta, cf_log],
-        )?);
+        let cf_kv_meta = ColumnFamilyDescriptor::new(KV_META_CF, kv_meta_cf_options);
+        let db = Arc::new(
+            DB::open_cf_descriptors(
+                &db_options,
+                path,
+                vec![cf_default, cf_meta, cf_log, cf_kv_meta],
+            )
+            .map_err(|e| e.to_string())?,
+        );
         let meta_cf = db
             .cf_handle(META_CF)
             .expect("meta CF must exist (created on open)");
-        let seq = match db.get_cf(meta_cf, SEQ_META_KEY)? {
+        let logged_seq = match db
+            .get_cf(meta_cf, SEQ_META_KEY)
+            .map_err(|e| e.to_string())?
+        {
             Some(bytes) if bytes.len() == 8 => u64::from_le_bytes(bytes.try_into().unwrap()),
             _ => 0,
         };
-        let sequence = Arc::new(AtomicU64::new(seq));
-        let writer = Arc::new(Writer::start(db.clone(), sequence.clone(), write_pipeline));
+        let kv_meta_cf = db
+            .cf_handle(KV_META_CF)
+            .expect("kv_meta CF must exist (created on open)");
+        let applied_seq = match db
+            .get_cf(kv_meta_cf, KV_APPLIED_KEY)
+            .map_err(|e| e.to_string())?
+        {
+            Some(bytes) if bytes.len() == 8 => u64::from_le_bytes(bytes.try_into().unwrap()),
+            _ => 0,
+        };
+        if applied_seq > logged_seq {
+            return Err(format!(
+                "rocks applied frontier {applied_seq} is ahead of logged frontier {logged_seq}"
+            ));
+        }
+        if applied_seq < logged_seq {
+            replay_log_into_kv(
+                &db,
+                applied_seq,
+                logged_seq,
+                write_pipeline.max_commit_batch_bytes.get(),
+            )?;
+        }
+
+        let logged = Arc::new(AtomicU64::new(logged_seq));
+        let applied = Arc::new(AtomicU64::new(logged_seq));
+        let (applied_tx, applied_rx) = watch::channel(logged_seq);
+        let writer = Arc::new(Writer::start(
+            db.clone(),
+            logged.clone(),
+            applied.clone(),
+            applied_tx,
+            write_pipeline,
+        ));
         Ok(Self {
             db,
-            sequence,
+            logged,
+            applied,
+            applied_watch: applied_rx,
             writer,
         })
+    }
+
+    /// Waits until the background apply covers `sequence`, i.e. until point and range reads
+    /// reflect every write acknowledged at or below it.
+    pub async fn wait_for_applied(&self, sequence: u64) -> Result<(), String> {
+        let mut watch = self.applied_watch.clone();
+        loop {
+            if *watch.borrow_and_update() >= sequence {
+                return Ok(());
+            }
+            watch
+                .changed()
+                .await
+                .map_err(|_| "rocks apply worker stopped".to_string())?;
+        }
     }
 
     /// Returns the log column-family handle created during open.
@@ -774,7 +1097,9 @@ impl RocksStore {
         self.db.get(key)
     }
 
-    /// Deletes current rows without touching sequence metadata or the replay log.
+    /// Deletes current rows without touching sequence metadata or the replay log. Skips the WAL
+    /// like every other current-state write: a delete lost to a crash resurfaces the key, which
+    /// the next prune pass removes again (pruning is best-effort).
     fn delete_keys(&self, keys: &[Bytes]) -> Result<(), rocksdb::Error> {
         if keys.is_empty() {
             return Ok(());
@@ -784,15 +1109,20 @@ impl RocksStore {
         for k in keys {
             batch.delete(k.as_ref());
         }
-        self.db.write(batch)?;
+        let mut write_options = WriteOptions::default();
+        write_options.disable_wal(true);
+        self.db.write_opt(batch, &write_options)?;
         Ok(())
     }
 
-    /// Deletes replay-log batches with sequence numbers below `cutoff_exclusive`.
+    /// Deletes replay-log batches with sequence numbers below `cutoff_exclusive`. Flushes the
+    /// no-WAL column families first so the durable applied frontier covers every deleted row;
+    /// otherwise a crash could need pruned rows to rebuild the current key/value state.
     fn prune_log(&self, cutoff_exclusive: u64) -> Result<(), String> {
         if cutoff_exclusive == 0 {
             return Ok(());
         }
+        flush_kv_cfs(&self.db)?;
         let cf = self.log_cf();
         self.db
             .delete_range_cf(cf, sequence_log_key(0), sequence_log_key(cutoff_exclusive))
@@ -800,14 +1130,20 @@ impl RocksStore {
     }
 
     /// Applies each prune policy in document order to either current rows or replay-log rows.
-    fn apply_prune_policies(&self, document: PrunePolicyDocument) -> Result<(), String> {
+    /// `frontier` is the logged sequence the applied key/value state is known to cover; sequence
+    /// policies never prune past it.
+    fn apply_prune_policies(
+        &self,
+        document: PrunePolicyDocument,
+        frontier: u64,
+    ) -> Result<(), String> {
         for policy in &document.policies {
             match &policy.scope {
                 PolicyScope::Keys(scope) => {
                     self.apply_key_prune_policy(scope, &policy.retain)?;
                 }
                 PolicyScope::Sequence => {
-                    self.apply_sequence_prune_policy(&policy.retain)?;
+                    self.apply_sequence_prune_policy(&policy.retain, frontier)?;
                 }
             }
         }
@@ -867,25 +1203,32 @@ impl RocksStore {
         self.delete_keys(&all_deletes).map_err(|e| e.to_string())
     }
 
-    /// Computes the replay-log cutoff for a sequence policy and prunes only log rows.
-    fn apply_sequence_prune_policy(&self, retain: &RetainPolicy) -> Result<(), String> {
-        let current = self.sequence.load(Ordering::Acquire);
+    /// Computes the replay-log cutoff for a sequence policy and prunes only log rows. The cutoff
+    /// is capped at `frontier + 1` so rows the applied key/value state may still need for crash
+    /// recovery are always retained.
+    fn apply_sequence_prune_policy(
+        &self,
+        retain: &RetainPolicy,
+        frontier: u64,
+    ) -> Result<(), String> {
         let cutoff_exclusive = match retain {
             RetainPolicy::KeepLatest { count } => {
                 let count = *count as u64;
-                current.saturating_add(1).saturating_sub(count)
+                frontier.saturating_add(1).saturating_sub(count)
             }
             RetainPolicy::GreaterThan { threshold } => threshold.saturating_add(1),
             RetainPolicy::GreaterThanOrEqual { threshold } => *threshold,
-            RetainPolicy::DropAll => current.saturating_add(1),
+            RetainPolicy::DropAll => frontier.saturating_add(1),
         };
-        self.prune_log(cutoff_exclusive)
+        self.prune_log(cutoff_exclusive.min(frontier.saturating_add(1)))
     }
 }
 
 impl Sequence for RocksStore {
     fn current_sequence(&self) -> u64 {
-        self.sequence.load(Ordering::Acquire)
+        // The applied frontier, not the logged one: query RPCs use this to gate
+        // `min_sequence_number` reads, and only applied rows are visible to point/range reads.
+        self.applied.load(Ordering::Acquire)
     }
 }
 
@@ -940,8 +1283,13 @@ impl Query for RocksStore {
 
 impl Prune for RocksStore {
     async fn apply_prune_policies(&self, document: PrunePolicyDocument) -> Result<(), String> {
+        // Prune observes every write acknowledged before this call started: key policies then
+        // scan a current-state view that covers those writes, and sequence policies can prune up
+        // to this frontier without endangering crash recovery.
+        let frontier = self.logged.load(Ordering::Acquire);
+        self.wait_for_applied(frontier).await?;
         let store = self.clone();
-        store.apply_prune_policies(document)
+        store.apply_prune_policies(document, frontier)
     }
 }
 
@@ -1085,20 +1433,57 @@ mod tests {
         )
     }
 
+    /// Applies committed key/value rows synchronously, standing in for the apply thread in tests
+    /// that drive `commit_group` directly.
+    fn apply_work_for_test(store: &RocksStore, work: ApplyWork) {
+        write_kv_batch(
+            &store.db,
+            build_apply_batch(&store.db, &work.kvs, work.last_sequence),
+        )
+        .expect("apply kv batch");
+        store.applied.store(work.last_sequence, Ordering::Release);
+    }
+
+    /// Commits one group through the real commit path, then applies its key/value rows
+    /// synchronously so both frontiers reflect the outcome.
+    fn commit_group_for_test(
+        store: &RocksStore,
+        epoch: &AtomicU64,
+        committed: u64,
+        group: PreparedWrite,
+    ) -> u64 {
+        let (committed, work) = commit_group(&store.db, &store.logged, epoch, committed, group);
+        if let Some(work) = work {
+            apply_work_for_test(store, work);
+        }
+        committed
+    }
+
     fn commit_sequence_requests(
-        db: &DB,
-        sequence: &AtomicU64,
+        store: &RocksStore,
         requests: &[WriteRequest],
     ) -> Result<u64, String> {
-        let next = sequence
+        let next = store
+            .logged
             .load(Ordering::Acquire)
             .checked_add(1)
             .ok_or_else(|| "rocks sequence number overflowed".to_string())?;
         let mut batch = rocksdb::WriteBatch::default();
-        append_sequence_entries(db, &mut batch, next, requests)?;
-        append_sequence_meta(db, &mut batch, next);
-        write_sequence_batch(db, batch)?;
-        sequence.store(next, Ordering::Release);
+        append_sequence_entries(&store.db, &mut batch, next, requests)?;
+        append_sequence_meta(&store.db, &mut batch, next);
+        write_sequence_batch(&store.db, batch)?;
+        store.logged.store(next, Ordering::Release);
+        let kvs = requests
+            .iter()
+            .flat_map(|request| request.kvs.iter().cloned())
+            .collect();
+        apply_work_for_test(
+            store,
+            ApplyWork {
+                last_sequence: next,
+                kvs,
+            },
+        );
         Ok(next)
     }
 
@@ -1247,7 +1632,7 @@ mod tests {
 
         // A group that cannot commit (modeled with an already-failed batch) at sequences 1 and 2.
         let (group, receivers) = failing_group(0, &[(1, b"a", b"1"), (2, b"b", b"2")], "disk full");
-        let committed = commit_group(&store.db, &store.sequence, &epoch, 0, group);
+        let committed = commit_group_for_test(&store, &epoch, 0, group);
 
         // Nothing was published, and the epoch advanced so the abandoned numbers can be re-used.
         assert_eq!(committed, 0);
@@ -1264,7 +1649,7 @@ mod tests {
         let (write_x, result_x) = assigned_write_with_response(1, b"x", b"24");
         let (write_y, result_y) = assigned_write_with_response(2, b"y", b"25");
         let group = prepared_write(&store.db, 1, vec![write_x, write_y]);
-        let committed = commit_group(&store.db, &store.sequence, &epoch, committed, group);
+        let committed = commit_group_for_test(&store, &epoch, committed, group);
 
         assert_eq!(committed, 2);
         assert_eq!(store.current_sequence(), 2);
@@ -1289,7 +1674,7 @@ mod tests {
 
         let (write, result) = assigned_write_with_response(1, b"a", b"1");
         let group = prepared_write(&store.db, 0, vec![write]);
-        let committed = commit_group(&store.db, &store.sequence, &epoch, 0, group);
+        let committed = commit_group_for_test(&store, &epoch, 0, group);
 
         assert_eq!(committed, 0);
         assert_eq!(store.current_sequence(), 0);
@@ -1311,7 +1696,7 @@ mod tests {
         for attempt in [b"first" as &[u8], b"second"] {
             let current = epoch.load(Ordering::Acquire);
             let (group, receivers) = failing_group(current, &[(1, b"k", b"v")], "boom");
-            let committed = commit_group(&store.db, &store.sequence, &epoch, 0, group);
+            let committed = commit_group_for_test(&store, &epoch, 0, group);
             assert_eq!(
                 committed, 0,
                 "attempt {attempt:?} must not advance the frontier"
@@ -1326,7 +1711,7 @@ mod tests {
         let current = epoch.load(Ordering::Acquire);
         let (write, result) = assigned_write_with_response(1, b"k", b"v");
         let group = prepared_write(&store.db, current, vec![write]);
-        let committed = commit_group(&store.db, &store.sequence, &epoch, 0, group);
+        let committed = commit_group_for_test(&store, &epoch, 0, group);
         assert_eq!(committed, 1);
         assert_eq!(result.await.expect("response"), Ok(1));
         assert_eq!(store.current_sequence(), 1);
@@ -1354,7 +1739,7 @@ mod tests {
         );
 
         let (failed, receivers) = failing_group(0, &[(1, b"k", b"failed")], "boom");
-        let committed = commit_group(&store.db, &store.sequence, &epoch, 0, failed);
+        let committed = commit_group_for_test(&store, &epoch, 0, failed);
         assert_eq!(committed, 0);
         assert_eq!(store.current_sequence(), 0);
         assert_eq!(epoch.load(Ordering::Acquire), 1);
@@ -1364,7 +1749,7 @@ mod tests {
 
         let (write, result) = assigned_write_with_response(1, b"k", b"new");
         let group = prepared_write(&store.db, 1, vec![write]);
-        let committed = commit_group(&store.db, &store.sequence, &epoch, committed, group);
+        let committed = commit_group_for_test(&store, &epoch, committed, group);
 
         assert_eq!(committed, 1);
         assert_eq!(result.await.expect("response"), Ok(1));
@@ -1394,6 +1779,7 @@ mod tests {
             .await
             .expect("put");
         assert_eq!(sequence, 1);
+        store.wait_for_applied(sequence).await.expect("applied");
         assert_eq!(store.current_sequence(), 1);
     }
 
@@ -1417,8 +1803,7 @@ mod tests {
             },
         ];
 
-        let sequence =
-            commit_sequence_requests(&store.db, &store.sequence, &requests).expect("write");
+        let sequence = commit_sequence_requests(&store, &requests).expect("write");
         assert_eq!(sequence, 1);
         assert_eq!(store.current_sequence(), 1);
         let log_cf = store.log_cf();
@@ -1469,7 +1854,7 @@ mod tests {
 
         assert_eq!(prepared.writes.len(), 3);
         assert!(prepared.batch_bytes > 0);
-        let committed = commit_group(&store.db, &store.sequence, &epoch, 0, prepared);
+        let committed = commit_group_for_test(&store, &epoch, 0, prepared);
         assert_eq!(committed, 3);
 
         assert_eq!(store.current_sequence(), 3);
@@ -1507,7 +1892,9 @@ mod tests {
         for put in puts {
             sequences.push(put.await.expect("put task"));
         }
-        let current = store.current_sequence();
+        let current = *sequences.iter().max().expect("at least one sequence");
+        store.wait_for_applied(current).await.expect("applied");
+        assert_eq!(store.current_sequence(), current);
         assert!((1..=32).contains(&current));
         assert!(sequences
             .iter()
@@ -1540,6 +1927,7 @@ mod tests {
             .put_batch(vec![(key.clone(), value.clone())])
             .await
             .expect("put");
+        store.wait_for_applied(sequence).await.expect("applied");
 
         store
             .delete_keys(std::slice::from_ref(&key))
@@ -1564,6 +1952,10 @@ mod tests {
         );
         let seq_a = seq_a.expect("first write");
         let seq_b = seq_b.expect("second write");
+        store
+            .wait_for_applied(seq_a.max(seq_b))
+            .await
+            .expect("applied");
 
         let current = store.current_sequence();
         assert!((1..=2).contains(&current));
@@ -1577,5 +1969,148 @@ mod tests {
             store.db.get(b"b").expect("get b").as_deref(),
             Some(&b"2"[..])
         );
+    }
+
+    #[tokio::test]
+    async fn acked_write_is_readable_once_applied() {
+        let dir = tempdir().expect("tempdir");
+        let store = RocksStore::open(dir.path(), None).expect("open db");
+
+        let sequence = store
+            .put_batch(vec![(Bytes::from_static(b"k"), Bytes::from_static(b"v"))])
+            .await
+            .expect("put");
+        store.wait_for_applied(sequence).await.expect("applied");
+
+        assert_eq!(store.current_sequence(), sequence);
+        let (value, _extra) = store.get(Bytes::from_static(b"k")).await.expect("get");
+        assert_eq!(value.as_deref(), Some(b"v".as_slice()));
+    }
+
+    /// Rewinds the durable applied marker and removes the key/value rows it no longer covers,
+    /// modeling a crash that lost un-flushed no-WAL state while the synced log survived.
+    fn lose_applied_kv_state(store: &RocksStore, marker: u64, lost_keys: &[&[u8]]) {
+        let kv_meta_cf = store
+            .db
+            .cf_handle(KV_META_CF)
+            .expect("kv_meta CF must exist (created on open)");
+        store
+            .db
+            .put_cf(kv_meta_cf, KV_APPLIED_KEY, marker.to_le_bytes())
+            .expect("rewind applied marker");
+        for key in lost_keys {
+            store.db.delete(key).expect("drop kv row");
+        }
+    }
+
+    #[tokio::test]
+    async fn open_replays_log_rows_the_kv_state_lost() {
+        let dir = tempdir().expect("tempdir");
+        {
+            let store = RocksStore::open(dir.path(), None).expect("open db");
+            for (key, value) in [(b"a", b"1"), (b"b", b"2"), (b"c", b"3")] {
+                store
+                    .put_batch(vec![(
+                        Bytes::copy_from_slice(key),
+                        Bytes::copy_from_slice(value),
+                    )])
+                    .await
+                    .expect("put");
+            }
+            store.wait_for_applied(3).await.expect("applied");
+            lose_applied_kv_state(&store, 1, &[b"b", b"c"]);
+        }
+
+        let store = RocksStore::open(dir.path(), None).expect("reopen db");
+        assert_eq!(store.current_sequence(), 3);
+        for (key, value) in [(b"a", b"1"), (b"b", b"2"), (b"c", b"3")] {
+            assert_eq!(
+                store.db.get(key).expect("get").as_deref(),
+                Some(value.as_slice()),
+                "row {} must be restored by replay",
+                String::from_utf8_lossy(key),
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn open_replays_across_log_gaps() {
+        let dir = tempdir().expect("tempdir");
+        {
+            let store = RocksStore::open(dir.path(), None).expect("open db");
+            // An empty batch consumes sequence 1 without writing a log row.
+            let first = store.put_batch(Vec::new()).await.expect("empty put");
+            assert_eq!(first, 1);
+            let second = store
+                .put_batch(vec![(Bytes::from_static(b"k"), Bytes::from_static(b"v"))])
+                .await
+                .expect("put");
+            assert_eq!(second, 2);
+            store.wait_for_applied(second).await.expect("applied");
+            lose_applied_kv_state(&store, 0, &[b"k"]);
+        }
+
+        let store = RocksStore::open(dir.path(), None).expect("reopen db");
+        assert_eq!(store.current_sequence(), 2);
+        assert_eq!(
+            store.db.get(b"k").expect("get").as_deref(),
+            Some(b"v".as_slice())
+        );
+        assert!(store.get_batch(1).await.expect("get").is_none());
+    }
+
+    #[tokio::test]
+    async fn empty_put_advances_frontiers_without_log_row() {
+        let dir = tempdir().expect("tempdir");
+        let store = RocksStore::open(dir.path(), None).expect("open db");
+
+        let sequence = store.put_batch(Vec::new()).await.expect("empty put");
+        assert_eq!(sequence, 1);
+        store.wait_for_applied(sequence).await.expect("applied");
+        assert_eq!(store.current_sequence(), 1);
+        assert!(store.get_batch(1).await.expect("get").is_none());
+    }
+
+    #[tokio::test]
+    async fn reopen_after_sequence_prune_needs_no_pruned_rows() {
+        use exoware_sdk::prune_policy::{PrunePolicy, PRUNE_POLICY_DOCUMENT_VERSION};
+
+        let dir = tempdir().expect("tempdir");
+        {
+            let store = RocksStore::open(dir.path(), None).expect("open db");
+            for (key, value) in [(b"a", b"1"), (b"b", b"2"), (b"c", b"3")] {
+                store
+                    .put_batch(vec![(
+                        Bytes::copy_from_slice(key),
+                        Bytes::copy_from_slice(value),
+                    )])
+                    .await
+                    .expect("put");
+            }
+            Prune::apply_prune_policies(
+                &store,
+                PrunePolicyDocument {
+                    version: PRUNE_POLICY_DOCUMENT_VERSION,
+                    policies: vec![PrunePolicy {
+                        scope: PolicyScope::Sequence,
+                        retain: RetainPolicy::DropAll,
+                    }],
+                },
+            )
+            .await
+            .expect("prune");
+            assert!(store.get_batch(3).await.expect("get").is_none());
+        }
+
+        // Recovery must not depend on the pruned rows: the flush that precedes pruning makes the
+        // applied frontier durable, so the reopen has nothing to replay.
+        let store = RocksStore::open(dir.path(), None).expect("reopen db");
+        assert_eq!(store.current_sequence(), 3);
+        for (key, value) in [(b"a", b"1"), (b"b", b"2"), (b"c", b"3")] {
+            assert_eq!(
+                store.db.get(key).expect("get").as_deref(),
+                Some(value.as_slice())
+            );
+        }
     }
 }

--- a/examples/simulator/src/rocks.rs
+++ b/examples/simulator/src/rocks.rs
@@ -402,15 +402,24 @@ impl Writer {
         let epoch = Arc::new(AtomicU64::new(0));
         let stopping = Arc::new(AtomicBool::new(false));
 
+        let applied_watch = Arc::new(applied_watch);
+        // Highest sequence the durable applied marker covers. Open leaves the marker at the
+        // logged frontier (replay catches it up), which is also `logged`'s value right now.
+        let durable_marker = Arc::new(AtomicU64::new(logged.load(Ordering::Acquire)));
+
         let apply_db = db.clone();
+        let apply_applied = applied.clone();
+        let apply_watch = applied_watch.clone();
+        let apply_marker = durable_marker.clone();
         let apply_stopping = stopping.clone();
         let apply = thread::Builder::new()
             .name("simulator-rocks-apply".to_string())
             .spawn(move || {
                 run_apply(
                     apply_db,
-                    applied,
-                    applied_watch,
+                    apply_applied,
+                    apply_watch,
+                    apply_marker,
                     apply_stopping,
                     apply_receiver,
                     max_commit_batch_bytes,
@@ -427,6 +436,9 @@ impl Writer {
                 run_commit(
                     commit_db,
                     commit_logged,
+                    applied,
+                    applied_watch,
+                    durable_marker,
                     commit_epoch,
                     group_receiver,
                     apply_sender,
@@ -619,25 +631,64 @@ fn forward_group(sender: &mpsc::SyncSender<PreparedWrite>, group: PreparedWrite)
 /// forwarding key/value rows to `apply` after each success. A group whose epoch was superseded by
 /// an earlier failure is rejected without being written; a failing group bumps the epoch so its
 /// frontier (and every later group assigned under it) is abandoned and re-allocated by `prepare`.
+///
+/// An inline wave (rows already in the synced batch) whose predecessors are all applied advances
+/// the applied frontier right here instead of round-tripping marker-only work through the apply
+/// thread: at high wave rates the channel send and thread wakeup are measurable, and skipping
+/// them keeps the small-value hot path identical to a coupled writer. The handoff is still taken
+/// when `apply` is behind (frontier order must follow sequence order) or when the durable marker
+/// needs a stride catch-up.
+#[allow(clippy::too_many_arguments)]
 fn run_commit(
     db: Arc<DB>,
     logged: Arc<AtomicU64>,
+    applied: Arc<AtomicU64>,
+    applied_watch: Arc<watch::Sender<u64>>,
+    durable_marker: Arc<AtomicU64>,
     epoch: Arc<AtomicU64>,
     receiver: mpsc::Receiver<PreparedWrite>,
     apply_sender: mpsc::SyncSender<ApplyWork>,
 ) {
     let mut committed = logged.load(Ordering::Acquire);
     while let Ok(group) = receiver.recv() {
+        let previous = committed;
         let (next_committed, work) = commit_group(&db, &logged, &epoch, committed, group);
         committed = next_committed;
-        if let Some(work) = work {
-            if apply_sender.send(work).is_err() {
-                // The acknowledged rows are durable in the replay log; the next open replays
-                // them into the current-state column family.
-                error!("rocks apply worker stopped; key/value rows deferred to reopen replay");
-            }
+        let Some(work) = work else {
+            continue;
+        };
+        // `applied` can never exceed `previous` here (this wave's work has not been handed
+        // off yet), so equality means every earlier wave is fully applied and the queue is
+        // drained: frontier order is preserved if we advance it directly.
+        let caught_up = applied.load(Ordering::Acquire) == previous;
+        let marker_lag = work
+            .last_sequence
+            .saturating_sub(durable_marker.load(Ordering::Acquire));
+        if work.kvs.is_empty() && caught_up && marker_lag < APPLY_MARKER_STRIDE_SEQUENCES {
+            advance_applied(&applied, &applied_watch, work.last_sequence);
+            continue;
+        }
+        if apply_sender.send(work).is_err() {
+            // The acknowledged rows are durable in the replay log; the next open replays
+            // them into the current-state column family.
+            error!("rocks apply worker stopped; key/value rows deferred to reopen replay");
         }
     }
+}
+
+/// Advances the applied frontier monotonically and wakes `wait_for_applied` watchers. Both the
+/// commit thread (inline fast path) and the apply thread publish through this, so a slower
+/// bookkeeping wave can never rewind a frontier a faster path already advanced.
+fn advance_applied(applied: &AtomicU64, applied_watch: &watch::Sender<u64>, sequence: u64) {
+    applied.fetch_max(sequence, Ordering::AcqRel);
+    applied_watch.send_if_modified(|current| {
+        if sequence > *current {
+            *current = sequence;
+            true
+        } else {
+            false
+        }
+    });
 }
 
 /// Commits one group, returning the durable log frontier afterwards (unchanged on rejection or
@@ -697,16 +748,18 @@ fn commit_group(
 ///
 /// Marker-only work (from inline waves, whose rows are already WAL-durable) skips the RocksDB
 /// write until the durable marker trails the frontier by [`APPLY_MARKER_STRIDE_SEQUENCES`], so
-/// steady small-value load costs no extra write calls while crash replay stays bounded.
+/// an inline wave that reaches this thread costs no extra write call while crash replay stays
+/// bounded.
 fn run_apply(
     db: Arc<DB>,
     applied: Arc<AtomicU64>,
-    applied_watch: watch::Sender<u64>,
+    applied_watch: Arc<watch::Sender<u64>>,
+    durable_marker: Arc<AtomicU64>,
     stopping: Arc<AtomicBool>,
     receiver: mpsc::Receiver<ApplyWork>,
     max_batch_bytes: usize,
 ) {
-    let mut marker = applied.load(Ordering::Acquire);
+    let mut marker = durable_marker.load(Ordering::Acquire);
     while let Ok(first) = receiver.recv() {
         let (work, disconnected) = coalesce_apply_work(&receiver, first, max_batch_bytes);
         let lag = work.last_sequence.saturating_sub(marker);
@@ -715,9 +768,9 @@ fn run_apply(
                 return;
             }
             marker = work.last_sequence;
+            durable_marker.store(marker, Ordering::Release);
         }
-        applied.store(work.last_sequence, Ordering::Release);
-        let _ = applied_watch.send(work.last_sequence);
+        advance_applied(&applied, &applied_watch, work.last_sequence);
         if disconnected {
             break;
         }
@@ -725,7 +778,8 @@ fn run_apply(
     // Clean shutdown: catch the durable marker up to the frontier so RocksDB's flush-on-close
     // (no-WAL data is flushed on close by default) leaves the next open nothing to replay.
     // Skipping this is safe — the marker would just under-claim — but replaying inline waves
-    // that are already WAL-durable on every clean reopen is wasted work.
+    // that are already WAL-durable on every clean reopen is wasted work. The commit thread has
+    // exited by the time the channel disconnects, so `applied` is final here.
     let frontier = applied.load(Ordering::Acquire);
     if frontier > marker {
         let work = ApplyWork {

--- a/examples/simulator/tests/e2e_connect.rs
+++ b/examples/simulator/tests/e2e_connect.rs
@@ -19,11 +19,14 @@ use exoware_sdk::{
 };
 use tempfile::tempdir;
 
-async fn spawn_client() -> (tokio::task::JoinHandle<()>, PrefixedStoreClient, String) {
+async fn spawn_client() -> (
+    tempfile::TempDir,
+    tokio::task::JoinHandle<()>,
+    PrefixedStoreClient,
+    String,
+) {
     let dir = tempdir().expect("tempdir");
-    let dir_path = dir.path().to_owned();
-    let _dir = dir;
-    let (handle, url) = exoware_simulator::spawn_for_test(&dir_path)
+    let (handle, url) = exoware_simulator::spawn_for_test(dir.path())
         .await
         .expect("spawn_for_test");
     let client = StoreClient::builder()
@@ -31,22 +34,42 @@ async fn spawn_client() -> (tokio::task::JoinHandle<()>, PrefixedStoreClient, St
         .retry_config(RetryConfig::disabled())
         .build()
         .expect("build client");
-    (handle, PrefixedStoreClient::empty(client), url)
+    (dir, handle, PrefixedStoreClient::empty(client), url)
 }
 
 fn key(b: &[u8]) -> Key {
     Bytes::copy_from_slice(b)
 }
 
+/// The simulator acknowledges ingest once the write is durable in its replay log and applies
+/// key/value rows in the background. Wait until reads cover `sequence` before asserting on
+/// unfenced read-side state.
+async fn sync_reads_to(client: &PrefixedStoreClient, sequence: u64) {
+    let probe = key(b"read-sync-probe");
+    for _ in 0..400 {
+        if client
+            .query()
+            .get_with_min_sequence_number(&probe, sequence)
+            .await
+            .is_ok()
+        {
+            return;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+    }
+    panic!("reads did not catch up to sequence {sequence}");
+}
+
 // -- put + get --
 
 #[tokio::test]
 async fn put_and_get_round_trip() {
-    let (_h, client, _url) = spawn_client().await;
+    let (_dir, _h, client, _url) = spawn_client().await;
     let k = key(b"hello");
     let v = b"world";
     let seq = client.ingest().put(&[(&k, v)]).await.expect("put");
     assert!(seq > 0);
+    sync_reads_to(&client, seq).await;
 
     let got = client.query().get(&k).await.expect("get");
     assert_eq!(got.as_deref(), Some(v.as_slice()));
@@ -54,17 +77,18 @@ async fn put_and_get_round_trip() {
 
 #[tokio::test]
 async fn get_missing_key_returns_none() {
-    let (_h, client, _url) = spawn_client().await;
+    let (_dir, _h, client, _url) = spawn_client().await;
     let got = client.query().get(&key(b"nope")).await.expect("get");
     assert!(got.is_none());
 }
 
 #[tokio::test]
 async fn put_overwrites_value() {
-    let (_h, client, _url) = spawn_client().await;
+    let (_dir, _h, client, _url) = spawn_client().await;
     let k = key(b"k");
     client.ingest().put(&[(&k, b"v1")]).await.expect("put1");
     let seq2 = client.ingest().put(&[(&k, b"v2")]).await.expect("put2");
+    sync_reads_to(&client, seq2).await;
     let got = client
         .query()
         .get_with_min_sequence_number(&k, seq2)
@@ -77,15 +101,16 @@ async fn put_overwrites_value() {
 
 #[tokio::test]
 async fn get_many_returns_found_and_missing() {
-    let (_h, client, _url) = spawn_client().await;
+    let (_dir, _h, client, _url) = spawn_client().await;
     let ka = key(b"a");
     let kb = key(b"b");
     let kc = key(b"c");
-    client
+    let seq = client
         .ingest()
         .put(&[(&ka, b"1"), (&kc, b"3")])
         .await
         .expect("put");
+    sync_reads_to(&client, seq).await;
 
     let stream = client
         .query()
@@ -102,15 +127,16 @@ async fn get_many_returns_found_and_missing() {
 
 #[tokio::test]
 async fn range_forward() {
-    let (_h, client, _url) = spawn_client().await;
+    let (_dir, _h, client, _url) = spawn_client().await;
     let ka = key(b"ra");
     let kb = key(b"rb");
     let kc = key(b"rc");
-    client
+    let seq = client
         .ingest()
         .put(&[(&ka, b"1"), (&kb, b"2"), (&kc, b"3")])
         .await
         .expect("put");
+    sync_reads_to(&client, seq).await;
 
     let rows = client
         .query()
@@ -123,15 +149,16 @@ async fn range_forward() {
 
 #[tokio::test]
 async fn range_reverse() {
-    let (_h, client, _url) = spawn_client().await;
+    let (_dir, _h, client, _url) = spawn_client().await;
     let ka = key(b"sa");
     let kb = key(b"sb");
     let kc = key(b"sc");
-    client
+    let seq = client
         .ingest()
         .put(&[(&ka, b"1"), (&kb, b"2"), (&kc, b"3")])
         .await
         .expect("put");
+    sync_reads_to(&client, seq).await;
 
     let rows = client
         .query()
@@ -144,15 +171,16 @@ async fn range_reverse() {
 
 #[tokio::test]
 async fn range_with_limit() {
-    let (_h, client, _url) = spawn_client().await;
+    let (_dir, _h, client, _url) = spawn_client().await;
     let ka = key(b"la");
     let kb = key(b"lb");
     let kc = key(b"lc");
-    client
+    let seq = client
         .ingest()
         .put(&[(&ka, b"1"), (&kb, b"2"), (&kc, b"3")])
         .await
         .expect("put");
+    sync_reads_to(&client, seq).await;
 
     let rows = client
         .query()
@@ -166,7 +194,7 @@ async fn range_with_limit() {
 
 #[tokio::test]
 async fn range_empty_result() {
-    let (_h, client, _url) = spawn_client().await;
+    let (_dir, _h, client, _url) = spawn_client().await;
     let rows = client
         .query()
         .range(&key(b"zzz_no"), &key(b"zzz_nz"), 100)
@@ -179,15 +207,16 @@ async fn range_empty_result() {
 
 #[tokio::test]
 async fn reduce_count_all() {
-    let (_h, client, _url) = spawn_client().await;
+    let (_dir, _h, client, _url) = spawn_client().await;
     let ka = key(b"ca");
     let kb = key(b"cb");
     let kc = key(b"cc");
-    client
+    let seq = client
         .ingest()
         .put(&[(&ka, b"1"), (&kb, b"2"), (&kc, b"3")])
         .await
         .expect("put");
+    sync_reads_to(&client, seq).await;
 
     let request = RangeReduceRequest {
         reducers: vec![RangeReducerSpec {
@@ -210,7 +239,7 @@ async fn reduce_count_all() {
 
 #[tokio::test]
 async fn reduce_sum_int64() {
-    let (_h, client, _url) = spawn_client().await;
+    let (_dir, _h, client, _url) = spawn_client().await;
     let ka = key(b"ua");
     let kb = key(b"ub");
     let kc = key(b"uc");
@@ -221,7 +250,7 @@ async fn reduce_sum_int64() {
         .encode()
         .to_vec()
     };
-    client
+    let seq = client
         .ingest()
         .put(&[
             (&ka, encode_row(10).as_slice()),
@@ -230,6 +259,7 @@ async fn reduce_sum_int64() {
         ])
         .await
         .expect("put");
+    sync_reads_to(&client, seq).await;
 
     let request = RangeReduceRequest {
         reducers: vec![RangeReducerSpec {
@@ -256,17 +286,18 @@ async fn reduce_sum_int64() {
 
 #[tokio::test]
 async fn prune_drop_all_removes_keys() {
-    let (_h, client, url) = spawn_client().await;
+    let (_dir, _h, client, url) = spawn_client().await;
 
     let codec = KeyCodec::new(4, 1);
     let ka = codec.encode(b"aaa").expect("encode key a");
     let kb = codec.encode(b"bbb").expect("encode key b");
     let kc = codec.encode(b"ccc").expect("encode key c");
-    client
+    let seq = client
         .ingest()
         .put(&[(&ka, b"va"), (&kb, b"vb"), (&kc, b"vc")])
         .await
         .expect("put");
+    sync_reads_to(&client, seq).await;
 
     // Verify keys exist
     assert!(client.query().get(&ka).await.expect("get a").is_some());
@@ -316,12 +347,13 @@ async fn prune_drop_all_removes_keys() {
 
 #[tokio::test]
 async fn create_session_with_sequence_reads_at_or_above_floor() {
-    let (_h, client, _url) = spawn_client().await;
+    let (_dir, _h, client, _url) = spawn_client().await;
     let k1 = key(b"s1");
     let k2 = key(b"s2");
     let seq1 = client.ingest().put(&[(&k1, b"v1")]).await.expect("put1");
     let seq2 = client.ingest().put(&[(&k2, b"v2")]).await.expect("put2");
     assert!(seq2 > seq1);
+    sync_reads_to(&client, seq2).await;
 
     let session = client.create_session_with_sequence(seq2);
     let got = session.get(&k2).await.expect("session get");
@@ -332,7 +364,7 @@ async fn create_session_with_sequence_reads_at_or_above_floor() {
 
 #[tokio::test]
 async fn health_endpoint() {
-    let (_h, client, _url) = spawn_client().await;
+    let (_dir, _h, client, _url) = spawn_client().await;
     assert!(client.client().health().await.expect("health"));
 }
 
@@ -340,15 +372,16 @@ async fn health_endpoint() {
 
 #[tokio::test]
 async fn put_batch_multiple_keys() {
-    let (_h, client, _url) = spawn_client().await;
+    let (_dir, _h, client, _url) = spawn_client().await;
     let ka = key(b"ba");
     let kb = key(b"bb");
     let kc = key(b"bc");
-    client
+    let seq = client
         .ingest()
         .put(&[(&ka, b"1"), (&kb, b"2"), (&kc, b"3")])
         .await
         .expect("put batch");
+    sync_reads_to(&client, seq).await;
 
     assert_eq!(
         client.query().get(&ka).await.expect("get a").as_deref(),
@@ -368,16 +401,17 @@ async fn put_batch_multiple_keys() {
 
 #[tokio::test]
 async fn range_stream_collects_all() {
-    let (_h, client, _url) = spawn_client().await;
+    let (_dir, _h, client, _url) = spawn_client().await;
     let ka = key(b"xa");
     let kb = key(b"xb");
     let kc = key(b"xc");
     let kd = key(b"xd");
-    client
+    let seq = client
         .ingest()
         .put(&[(&ka, b"1"), (&kb, b"2"), (&kc, b"3"), (&kd, b"4")])
         .await
         .expect("put");
+    sync_reads_to(&client, seq).await;
 
     let stream = client
         .query()
@@ -394,9 +428,10 @@ async fn range_stream_collects_all() {
 
 #[tokio::test]
 async fn get_with_min_sequence_number() {
-    let (_h, client, _url) = spawn_client().await;
+    let (_dir, _h, client, _url) = spawn_client().await;
     let k = key(b"msn");
     let seq = client.ingest().put(&[(&k, b"val")]).await.expect("put");
+    sync_reads_to(&client, seq).await;
     let got = client
         .query()
         .get_with_min_sequence_number(&k, seq)
@@ -409,7 +444,7 @@ async fn get_with_min_sequence_number() {
 
 #[tokio::test]
 async fn prune_keep_latest_retains_newest() {
-    let (_h, client, url) = spawn_client().await;
+    let (_dir, _h, client, url) = spawn_client().await;
 
     let codec = KeyCodec::new(4, 2);
     // Keys: prefix(4bits,family=2) + logical(3 bytes) + \x00\x00 + version(8 bytes big-endian u64)
@@ -502,7 +537,7 @@ async fn prune_keep_latest_retains_newest() {
 
 #[tokio::test]
 async fn reduce_count_min_max_field() {
-    let (_h, client, _url) = spawn_client().await;
+    let (_dir, _h, client, _url) = spawn_client().await;
     let encode_row = |v: i64| -> Vec<u8> {
         StoredRow {
             values: vec![Some(StoredValue::Int64(v))],
@@ -510,7 +545,7 @@ async fn reduce_count_min_max_field() {
         .encode()
         .to_vec()
     };
-    client
+    let seq = client
         .ingest()
         .put(&[
             (&key(b"fa"), encode_row(10).as_slice()),
@@ -519,6 +554,7 @@ async fn reduce_count_min_max_field() {
         ])
         .await
         .expect("put");
+    sync_reads_to(&client, seq).await;
 
     let field = KvExpr::Field(KvFieldRef::Value {
         index: 0,
@@ -558,7 +594,7 @@ async fn reduce_count_min_max_field() {
 
 #[tokio::test]
 async fn reduce_grouped_count() {
-    let (_h, client, _url) = spawn_client().await;
+    let (_dir, _h, client, _url) = spawn_client().await;
     let codec = KeyCodec::new(4, 1);
     let encode_row = |v: i64| -> Vec<u8> {
         StoredRow {
@@ -571,7 +607,7 @@ async fn reduce_grouped_count() {
     let ka2 = codec.encode(b"a\x02").expect("encode");
     let kb1 = codec.encode(b"b\x01").expect("encode");
 
-    client
+    let seq = client
         .ingest()
         .put(&[
             (&ka1, encode_row(1).as_slice()),
@@ -580,6 +616,7 @@ async fn reduce_grouped_count() {
         ])
         .await
         .expect("put");
+    sync_reads_to(&client, seq).await;
 
     let request = RangeReduceRequest {
         reducers: vec![RangeReducerSpec {
@@ -604,16 +641,17 @@ async fn reduce_grouped_count() {
 
 #[tokio::test]
 async fn store_client_prune_drop_all() {
-    let (_h, client, _url) = spawn_client().await;
+    let (_dir, _h, client, _url) = spawn_client().await;
 
     let codec = KeyCodec::new(4, 5);
     let ka = codec.encode(b"pa").expect("encode");
     let kb = codec.encode(b"pb").expect("encode");
-    client
+    let seq = client
         .ingest()
         .put(&[(&ka, b"v1"), (&kb, b"v2")])
         .await
         .expect("put");
+    sync_reads_to(&client, seq).await;
     assert!(client.query().get(&ka).await.expect("get").is_some());
 
     client
@@ -641,7 +679,7 @@ async fn store_client_prune_drop_all() {
 
 #[tokio::test]
 async fn prune_greater_than_retains_above_threshold() {
-    let (_h, client, url) = spawn_client().await;
+    let (_dir, _h, client, url) = spawn_client().await;
 
     let codec = KeyCodec::new(4, 3);
     let make_key = |logical: &[u8; 2], version: u64| -> Key {

--- a/examples/simulator/tests/e2e_stream.rs
+++ b/examples/simulator/tests/e2e_stream.rs
@@ -9,11 +9,13 @@ use exoware_sdk::stream_filter::StreamFilter;
 use exoware_sdk::{PrefixedStoreClient, RetryConfig, StoreClient};
 use tempfile::tempdir;
 
-async fn spawn_client() -> (tokio::task::JoinHandle<()>, PrefixedStoreClient) {
+async fn spawn_client() -> (
+    tempfile::TempDir,
+    tokio::task::JoinHandle<()>,
+    PrefixedStoreClient,
+) {
     let dir = tempdir().expect("tempdir");
-    let dir_path = dir.path().to_owned();
-    let _dir = dir;
-    let (handle, url) = exoware_simulator::spawn_for_test(&dir_path)
+    let (handle, url) = exoware_simulator::spawn_for_test(dir.path())
         .await
         .expect("spawn_for_test");
     let client = StoreClient::builder()
@@ -21,7 +23,7 @@ async fn spawn_client() -> (tokio::task::JoinHandle<()>, PrefixedStoreClient) {
         .retry_config(RetryConfig::disabled())
         .build()
         .expect("build client");
-    (handle, PrefixedStoreClient::empty(client))
+    (dir, handle, PrefixedStoreClient::empty(client))
 }
 
 fn key(family: u16, payload: &[u8]) -> Key {
@@ -63,11 +65,30 @@ async fn next_with_timeout(
         .and_then(|r| r.expect("stream error"))
 }
 
+/// The simulator acknowledges ingest once the write is durable in its replay log and applies
+/// key/value rows in the background. Wait until reads cover `sequence` before asserting on
+/// unfenced read-side state.
+async fn sync_reads_to(client: &PrefixedStoreClient, sequence: u64) {
+    let probe = key(1, b"read-sync-probe");
+    for _ in 0..400 {
+        if client
+            .query()
+            .get_with_min_sequence_number(&probe, sequence)
+            .await
+            .is_ok()
+        {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+    panic!("reads did not catch up to sequence {sequence}");
+}
+
 // ---------- live subscribe ----------
 
 #[tokio::test]
 async fn live_subscribe_delivers_matching_entries() {
-    let (_h, client) = spawn_client().await;
+    let (_dir, _h, client) = spawn_client().await;
     let mut sub = client
         .stream()
         .subscribe(filter(1), None)
@@ -91,7 +112,7 @@ async fn live_subscribe_delivers_matching_entries() {
 
 #[tokio::test]
 async fn non_matching_put_yields_no_frame() {
-    let (_h, client) = spawn_client().await;
+    let (_dir, _h, client) = spawn_client().await;
     let mut sub = client
         .stream()
         .subscribe(filter(1), None)
@@ -113,7 +134,7 @@ async fn non_matching_put_yields_no_frame() {
 
 #[tokio::test]
 async fn multiple_selectors_delivered_once_per_put() {
-    let (_h, client) = spawn_client().await;
+    let (_dir, _h, client) = spawn_client().await;
     let f = StreamFilter {
         selectors: vec![
             Selector {
@@ -152,7 +173,7 @@ async fn multiple_selectors_delivered_once_per_put() {
 
 #[tokio::test]
 async fn two_puts_yield_two_distinct_frames() {
-    let (_h, client) = spawn_client().await;
+    let (_dir, _h, client) = spawn_client().await;
     let mut sub = client
         .stream()
         .subscribe(filter(1), None)
@@ -182,7 +203,7 @@ async fn two_puts_yield_two_distinct_frames() {
 
 #[tokio::test]
 async fn replay_since_delivers_retained_batches_then_live() {
-    let (_h, client) = spawn_client().await;
+    let (_dir, _h, client) = spawn_client().await;
     let mut seen_seqs = Vec::new();
     for i in 0..5u8 {
         let seq = client
@@ -226,7 +247,7 @@ async fn replay_since_delivers_retained_batches_then_live() {
 
 #[tokio::test]
 async fn replay_past_end_delivers_only_live() {
-    let (_h, client) = spawn_client().await;
+    let (_dir, _h, client) = spawn_client().await;
     let current = client
         .ingest()
         .put(&[(&key(1, b"seed"), b"v")])
@@ -257,7 +278,7 @@ async fn replay_past_end_delivers_only_live() {
 
 #[tokio::test]
 async fn replay_miss_after_prune_returns_batch_evicted() {
-    let (_h, client) = spawn_client().await;
+    let (_dir, _h, client) = spawn_client().await;
     for i in 0..20u8 {
         client
             .ingest()
@@ -293,7 +314,7 @@ async fn replay_miss_after_prune_returns_batch_evicted() {
 
 #[tokio::test]
 async fn get_batch_returns_whole_batch_unfiltered() {
-    let (_h, client) = spawn_client().await;
+    let (_dir, _h, client) = spawn_client().await;
     let ka = key(1, b"a");
     let kb = key(2, b"b");
     let seq = client
@@ -318,7 +339,7 @@ async fn get_batch_returns_whole_batch_unfiltered() {
 
 #[tokio::test]
 async fn get_batch_missing_seq_returns_none() {
-    let (_h, client) = spawn_client().await;
+    let (_dir, _h, client) = spawn_client().await;
     client
         .ingest()
         .put(&[(&key(1, b"a"), b"1")])
@@ -334,7 +355,7 @@ async fn get_batch_missing_seq_returns_none() {
 
 #[tokio::test]
 async fn get_batch_after_drop_all_returns_none() {
-    let (_h, client) = spawn_client().await;
+    let (_dir, _h, client) = spawn_client().await;
     let seq = client
         .ingest()
         .put(&[(&key(1, b"a"), b"1")])
@@ -352,7 +373,7 @@ async fn get_batch_after_drop_all_returns_none() {
 
 #[tokio::test]
 async fn get_batch_after_keep_latest_evicts_old_but_keeps_new() {
-    let (_h, client) = spawn_client().await;
+    let (_dir, _h, client) = spawn_client().await;
     let mut seqs = Vec::new();
     for i in 0..20u8 {
         let s = client
@@ -385,7 +406,7 @@ async fn get_batch_after_keep_latest_evicts_old_but_keeps_new() {
 
 #[tokio::test]
 async fn slow_subscriber_drops_without_blocking_ingest() {
-    let (_h, client) = spawn_client().await;
+    let (_dir, _h, client) = spawn_client().await;
     // Open subscription but never drain it. Internal cap = 256 frames.
     let _sub = client
         .stream()
@@ -398,15 +419,17 @@ async fn slow_subscriber_drops_without_blocking_ingest() {
     // Ingest latency must stay bounded: if the subscriber ever blocked
     // ingest, this loop would hang.
     let started = std::time::Instant::now();
+    let mut last_seq = 0;
     for i in 0..512u16 {
         let k = key(1, &i.to_be_bytes());
-        client.ingest().put(&[(&k, b"x")]).await.expect("put");
+        last_seq = client.ingest().put(&[(&k, b"x")]).await.expect("put");
     }
     let elapsed = started.elapsed();
     assert!(
         elapsed < Duration::from_secs(30),
         "ingest should not stall on slow subscriber (took {elapsed:?})"
     );
+    sync_reads_to(&client, last_seq).await;
     // Small verification that the store actually still serves reads.
     let last = Bytes::copy_from_slice(
         client
@@ -423,7 +446,7 @@ async fn slow_subscriber_drops_without_blocking_ingest() {
 #[tokio::test]
 async fn value_filter_restricts_to_matching_values() {
     use exoware_sdk::stream_filter::Filter;
-    let (_h, client) = spawn_client().await;
+    let (_dir, _h, client) = spawn_client().await;
     let f = StreamFilter {
         selectors: vec![Selector {
             reserved_bits: 4,

--- a/examples/simulator/tests/prune_contract.rs
+++ b/examples/simulator/tests/prune_contract.rs
@@ -37,8 +37,16 @@ fn versioned_key(logical: &[u8], version: u64) -> Bytes {
     Bytes::copy_from_slice(codec().encode(&payload).expect("encode key").as_ref())
 }
 
+/// Writes a batch and waits for the background apply so subsequent reads observe it.
 fn put_batch(store: &RocksStore, kvs: Vec<(Bytes, Bytes)>) -> u64 {
-    block_on(store.put_batch(kvs)).expect("put_batch")
+    block_on(async {
+        let sequence = Ingest::put_batch(store, kvs).await.expect("put_batch");
+        store
+            .wait_for_applied(sequence)
+            .await
+            .expect("wait for apply");
+        sequence
+    })
 }
 
 fn get_value(store: &RocksStore, key: &Bytes) -> Option<Bytes> {

--- a/examples/simulator/tests/range_scan_contract.rs
+++ b/examples/simulator/tests/range_scan_contract.rs
@@ -15,8 +15,16 @@ fn block_on<T>(future: impl Future<Output = T>) -> T {
         .block_on(future)
 }
 
+/// Writes a batch and waits for the background apply so subsequent reads observe it.
 fn put_batch(store: &RocksStore, kvs: Vec<(Bytes, Bytes)>) -> u64 {
-    block_on(store.put_batch(kvs)).expect("put_batch")
+    block_on(async {
+        let sequence = Ingest::put_batch(store, kvs).await.expect("put_batch");
+        store
+            .wait_for_applied(sequence)
+            .await
+            .expect("wait for apply");
+        sequence
+    })
 }
 
 fn seed_abc(store: &RocksStore) {

--- a/integration/tests/multi_instance.rs
+++ b/integration/tests/multi_instance.rs
@@ -144,6 +144,25 @@ async fn next_frame(
         .and_then(|result| result.expect("stream frame"))
 }
 
+/// The simulator acknowledges ingest once the write is durable in its replay log and applies
+/// key/value rows in the background. Wait until reads cover `sequence` before asserting on
+/// unfenced read-side state.
+async fn sync_reads_to(client: &PrefixedStoreClient, sequence: u64) {
+    let probe = Key::from(Bytes::from_static(b"read-sync-probe"));
+    for _ in 0..400 {
+        if client
+            .query()
+            .get_with_min_sequence_number(&probe, sequence)
+            .await
+            .is_ok()
+        {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+    panic!("reads did not catch up to sequence {sequence}");
+}
+
 fn keyless_reader(client: PrefixedStoreClient) -> QmdbReader {
     QmdbReader::new(client, ((0..=10000).into(), ()))
 }
@@ -288,6 +307,7 @@ async fn raw_prefixes_support_atomic_batch_fetch_range_and_stream() {
         .commit(&base)
         .await
         .expect("commit cross-prefix batch");
+    sync_reads_to(&unprefixed, sequence).await;
 
     assert_eq!(
         a.query().get(&shared).await.expect("get a").as_deref(),
@@ -361,8 +381,11 @@ async fn sql_schemas_are_isolated_by_store_prefix() {
         .expect("insert b3");
 
     let (seq_a, seq_b) = tokio::join!(writer_a.flush(), writer_b.flush());
-    assert!(seq_a.expect("flush a") > 0);
-    assert!(seq_b.expect("flush b") > 0);
+    let seq_a = seq_a.expect("flush a");
+    let seq_b = seq_b.expect("flush b");
+    assert!(seq_a > 0);
+    assert!(seq_b > 0);
+    sync_reads_to(&PrefixedStoreClient::empty(base.clone()), seq_a.max(seq_b)).await;
 
     assert_eq!(
         query_sql_items(base.prefixed(StoreKeyPrefix::new(4, 0).unwrap())).await,
@@ -654,6 +677,7 @@ async fn prepared_sql_and_qmdb_batches_commit_atomically_with_sequence_receipts(
         Some(checkpoint)
     );
 
+    sync_reads_to(&sql_client, sequence).await;
     assert_eq!(query_sql_items(sql_client).await, (vec![42], vec![4200]));
     let expected_qmdb: Vec<QmdbOp> = ops1.into_iter().chain(ops2.into_iter()).collect();
     let reader = keyless_reader(qmdb_client);
@@ -695,9 +719,10 @@ async fn qmdb_streaming_is_isolated_by_store_prefix() {
 
     let ops_b = qops("stream-b", 0);
     let writer_b = keyless_writer(client_b.clone());
-    commit_qmdb_upload(&writer_b, &ops_b)
+    let receipt_b = commit_qmdb_upload(&writer_b, &ops_b)
         .await
         .expect("upload b stream");
+    sync_reads_to(&client_b, receipt_b.store_sequence_number).await;
     let root_b = keyless_reader(client_b.clone())
         .root_at(QmdbLocation::new((ops_b.len() - 1) as u64))
         .await
@@ -729,9 +754,10 @@ async fn qmdb_streaming_is_isolated_by_store_prefix() {
 
     let ops_a = qops("stream-a", 0);
     let writer_a = keyless_writer(client_a.clone());
-    commit_qmdb_upload(&writer_a, &ops_a)
+    let receipt_a = commit_qmdb_upload(&writer_a, &ops_a)
         .await
         .expect("upload a stream");
+    sync_reads_to(&client_a, receipt_a.store_sequence_number).await;
     let root_a = keyless_reader(client_a.clone())
         .root_at(QmdbLocation::new((ops_a.len() - 1) as u64))
         .await

--- a/qmdb/rs/tests/common/mod.rs
+++ b/qmdb/rs/tests/common/mod.rs
@@ -6,6 +6,7 @@ use std::num::NonZeroU64;
 use std::time::Duration;
 
 use axum::{routing::get, Router};
+use bytes::Bytes;
 use commonware_codec::{Codec, Decode, Encode};
 use commonware_cryptography::{Digest, Hasher};
 use commonware_parallel::Sequential;
@@ -33,8 +34,9 @@ use exoware_qmdb::{
     CurrentBoundaryState, ImmutableWriter, KeylessWriter, OrderedWriter, QmdbError,
     UnorderedWriter, UploadReceipt,
 };
+use exoware_sdk::keys::Key as StoreKey;
 use exoware_sdk::proto::PreferZstdHttpClient;
-use exoware_sdk::{StoreBatchUpload, StoreClient};
+use exoware_sdk::{PrefixedStoreClient, StoreBatchUpload, StoreClient};
 
 #[allow(dead_code)]
 pub fn merkle_config(prefix: &str, page_cache: CacheRef) -> MerkleConfig<Sequential> {
@@ -154,6 +156,26 @@ pub async fn local_store_client() -> (tempfile::TempDir, tokio::task::JoinHandle
     (dir, jh, client)
 }
 
+/// The simulator acknowledges ingest once the write is durable in its replay
+/// log and applies key/value rows in the background. Wait until reads cover
+/// `sequence` before issuing unfenced read-side queries (proofs, watermarks).
+#[allow(dead_code)]
+pub async fn sync_reads_to(client: &PrefixedStoreClient, sequence: u64) {
+    let probe = StoreKey::from(Bytes::from_static(b"read-sync-probe"));
+    for _ in 0..400 {
+        if client
+            .query()
+            .get_with_min_sequence_number(&probe, sequence)
+            .await
+            .is_ok()
+        {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+    panic!("reads did not catch up to sequence {sequence}");
+}
+
 #[allow(dead_code)]
 pub async fn retry<F, Fut, T>(f: F, label: &str) -> T
 where
@@ -186,7 +208,13 @@ where
     keyless::Operation<F, E>: Encode,
 {
     let prepared = writer.prepare_upload(ops).await?;
-    writer.commit_upload(prepared).await
+    let receipt = writer.commit_upload(prepared).await?;
+    sync_reads_to(
+        StoreBatchUpload::store_client(writer),
+        receipt.store_sequence_number,
+    )
+    .await;
+    Ok(receipt)
 }
 
 #[allow(dead_code)]
@@ -204,7 +232,13 @@ where
     unordered::Operation<F, K, E>: Encode,
 {
     let prepared = writer.prepare_upload(ops).await?;
-    writer.commit_upload(prepared).await
+    let receipt = writer.commit_upload(prepared).await?;
+    sync_reads_to(
+        StoreBatchUpload::store_client(writer),
+        receipt.store_sequence_number,
+    )
+    .await;
+    Ok(receipt)
 }
 
 #[allow(dead_code)]
@@ -223,7 +257,13 @@ where
     unordered::Operation<F, K, E>: Encode,
 {
     let prepared = writer.prepare_current_upload(ops, current_boundary).await?;
-    writer.commit_upload(prepared).await
+    let receipt = writer.commit_upload(prepared).await?;
+    sync_reads_to(
+        StoreBatchUpload::store_client(writer),
+        receipt.store_sequence_number,
+    )
+    .await;
+    Ok(receipt)
 }
 
 #[allow(dead_code)]
@@ -242,7 +282,13 @@ where
     ordered::Operation<F, K, E>: Encode + Decode,
 {
     let prepared = writer.prepare_upload(ops, current_boundary).await?;
-    writer.commit_upload(prepared).await
+    let receipt = writer.commit_upload(prepared).await?;
+    sync_reads_to(
+        StoreBatchUpload::store_client(writer),
+        receipt.store_sequence_number,
+    )
+    .await;
+    Ok(receipt)
 }
 
 #[allow(dead_code)]
@@ -261,7 +307,13 @@ where
     immutable::Operation<F, K, E>: Encode + Decode + Clone,
 {
     let prepared = writer.prepare_upload(ops).await?;
-    writer.commit_upload(prepared).await
+    let receipt = writer.commit_upload(prepared).await?;
+    sync_reads_to(
+        StoreBatchUpload::store_client(writer),
+        receipt.store_sequence_number,
+    )
+    .await;
+    Ok(receipt)
 }
 
 #[allow(dead_code)]

--- a/server/src/connect.rs
+++ b/server/src/connect.rs
@@ -1082,8 +1082,11 @@ where
                 batch.into_response_bytes(),
             )),
             None => {
-                let current = self.state.log.current_sequence();
-                // Distinguish "never existed" (seq > current) vs "evicted".
+                // Classify against the log frontier: with a decoupled engine the key/value
+                // frontier (`current_sequence`) can trail sequences that are already durably
+                // logged, and an acknowledged empty batch in that window must report
+                // "evicted", not "never existed".
+                let current = self.state.log.log_sequence();
                 if seq > current {
                     Err(self.batch_not_found_error())
                 } else {
@@ -1260,6 +1263,8 @@ mod tests {
     #[derive(Default)]
     struct FakeEngineState {
         current_sequence: u64,
+        /// Log frontier when it runs ahead of `current_sequence` (decoupled apply).
+        log_sequence: Option<u64>,
         batches: BTreeMap<u64, Option<Vec<(Bytes, Bytes)>>>,
         oldest_retained: Option<u64>,
         publish_on_get_batch: Option<PublishDuringReplay>,
@@ -1327,6 +1332,10 @@ mod tests {
 
         fn set_oldest_retained(&self, oldest_retained: Option<u64>) {
             self.state.lock().expect("lock").oldest_retained = oldest_retained;
+        }
+
+        fn set_log_sequence(&self, sequence_number: u64) {
+            self.state.lock().expect("lock").log_sequence = Some(sequence_number);
         }
 
         fn publish_live(
@@ -1480,6 +1489,11 @@ mod tests {
                 .lock()
                 .map(|state| state.oldest_retained)
                 .map_err(|e| e.to_string())
+        }
+
+        fn log_sequence(&self) -> u64 {
+            let state = self.state.lock().expect("lock");
+            state.log_sequence.unwrap_or(state.current_sequence)
         }
     }
 
@@ -2156,6 +2170,52 @@ mod tests {
                 .expect("stream should terminate")
                 .is_none(),
             "stream must terminate after surfacing the replay hole",
+        );
+    }
+
+    /// Fetches one batch through the stream `Get` RPC handler.
+    async fn get_batch_response<B: Log>(
+        connect: &StreamConnect<B>,
+        sequence_number: u64,
+    ) -> connectrpc::ServiceResult<PreEncoded<StreamGetResponse>> {
+        let bytes = exoware_proto::log::stream::v1::GetRequest {
+            sequence_number,
+            ..Default::default()
+        }
+        .encode_to_vec();
+        let request = buffa::view::OwnedView::<GetRequestView<'static>>::decode(bytes.into())
+            .expect("decode get request");
+        StreamApi::get(connect, Context::default(), request).await
+    }
+
+    #[tokio::test]
+    async fn get_batch_classifies_against_log_frontier_not_applied() {
+        // A decoupled engine: key/value state applied through 3, log durable through 10.
+        // Sequence 7 was acknowledged but has no log row (an empty batch), so it must be
+        // reported as evicted — "not found" is reserved for sequences beyond the log.
+        let engine = Arc::new(FakeEngine::default());
+        engine.set_current_sequence(3);
+        engine.set_log_sequence(10);
+        engine.set_oldest_retained(Some(2));
+
+        let connect = StreamConnect::new(AppState::new(engine));
+
+        let evicted = get_batch_response(&connect, 7)
+            .await
+            .expect_err("logged-but-missing batch must error");
+        let decoded = decode_connect_error(&evicted).expect("decode connect error");
+        assert_eq!(
+            decoded.error_info.expect("error info").reason,
+            crate::stream::REASON_BATCH_EVICTED,
+        );
+
+        let not_found = get_batch_response(&connect, 11)
+            .await
+            .expect_err("beyond-log batch must error");
+        let decoded = decode_connect_error(&not_found).expect("decode connect error");
+        assert_eq!(
+            decoded.error_info.expect("error info").reason,
+            crate::stream::REASON_BATCH_NOT_FOUND,
         );
     }
 

--- a/server/src/connect.rs
+++ b/server/src/connect.rs
@@ -439,11 +439,15 @@ where
     }
 
     fn consistency_not_ready_error(&self, required: u64, current: u64) -> ConnectError {
+        // Engines may acknowledge writes before their read view covers them (e.g. the simulator
+        // applies key/value rows in the background), so a fenced read racing its own write is
+        // expected to land here briefly. Suggest a short retry delay: catch-up is typically
+        // milliseconds, and clients honoring this hint would otherwise stall far longer.
         let err = with_retry_info_detail(
             ConnectError::aborted("minimum consistency token is not yet visible"),
             RetryInfo {
                 retry_delay: Some(buffa_types::google::protobuf::Duration::from(
-                    std::time::Duration::from_secs(1),
+                    std::time::Duration::from_millis(50),
                 ))
                 .into(),
                 ..Default::default()

--- a/server/src/engine.rs
+++ b/server/src/engine.rs
@@ -174,6 +174,15 @@ pub trait Log: Sequence {
     /// empty. Surfaced in `BATCH_EVICTED` error details so clients know where
     /// to resume from.
     fn oldest_retained_batch(&self) -> impl Future<Output = Result<Option<u64>, String>> + Send;
+
+    /// Highest sequence number durably appended to this log. Defaults to the
+    /// process's visible sequence frontier; engines whose key/value state
+    /// trails the log (e.g. background apply) must override this so stream
+    /// RPCs classify missing batches against the log frontier, not the
+    /// key/value one.
+    fn log_sequence(&self) -> u64 {
+        self.current_sequence()
+    }
 }
 
 /// Compatibility facade for backends that serve every store capability.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #88.

Ingest now acknowledges a write as soon as its replay-log row (`LOG_CF`) and the sequence frontier (`META_CF`) are durable via one synced RocksDB write. How the current-state key/value rows land depends on the wave's payload size:

- **Small waves (<= 16 KiB of key/value payload) apply inline**: the rows ride the same synced commit batch. Duplicating a few kilobytes into the WAL costs less than a second RocksDB write-group cycle plus a cross-thread handoff, so small-value workloads keep the single-write profile of the current store.
- **Large waves defer**: a background `apply` thread writes the rows afterwards with the **RocksDB WAL disabled** for the default column family. The replay log already is the write-ahead log for that data, so large payloads never make a second trip through the WAL and never extend the fsync on the ingest critical path.

The size gate is where the crossover actually sits: benchmarking the always-deferred design showed small-value high-concurrency ingest paying ~5% for the extra write call while saving almost no WAL bytes, and large-value ingest gaining 9-16% for the opposite reason. Gating per wave keeps both ends.

## Consistency model

Two frontiers result:

- **Logged frontier** — returned to writers and used by the stream service, which reads `LOG_CF` directly. `Subscribe`/`GetBatch` behavior is unchanged, and `Log` grows a `log_sequence()` hook (defaulting to `current_sequence()` for coupled engines) so stream RPCs classify missing batches against the log frontier: an acknowledged empty batch in the logged-but-not-applied window reports `BATCH_EVICTED`, never `BATCH_NOT_FOUND`.
- **Applied frontier** — what `Sequence::current_sequence` now reports. Query RPCs gated on `min_sequence_number` reject reads the key/value state does not cover yet with the existing `CONSISTENCY_NOT_READY` error (no blocking); anything at or below the applied frontier is fully covered. Unfenced reads may briefly miss the newest acknowledged writes (no read-your-writes), and state above the applied frontier may be partially visible — both allowed by the issue discussion.

An inline wave whose predecessors are all applied advances the applied frontier directly on the commit thread (no channel round-trip); the handoff to the apply thread only happens when apply is behind, since frontier order must follow sequence order. Frontier updates go through a shared monotonic fetch-max so the two publishers can never rewind each other.

The `CONSISTENCY_NOT_READY` `RetryInfo` hint drops from 1s to 50ms: catch-up is typically sub-millisecond now, and clients honoring the old hint would stall far longer than necessary.

## Crash safety (nothing is ever unrecoverable)

The replay log is the source of truth; the key/value state is a derived view that can always be rebuilt. An applied-frontier marker in a new `kv_meta` CF records how far the durable key/value state is known to reach; on open, log rows in `(recovered marker, logged frontier]` are replayed into the default CF (idempotent last-writer-wins puts, in sequence order) before serving. The marker may **under-claim** — replay then re-applies rows whose effects already survived — but can never **over-claim**:

- The marker is only written by no-WAL batches, and every such batch carries the key/value rows it claims. The default and `kv_meta` CFs both skip the WAL and the DB opens with `atomic_flush` enabled, so their durable states are always cut at the same write-batch boundary: a recovered marker cannot claim no-WAL rows the default CF lost.
- Inline-applied rows travel through the synced WAL, so they are recoverable whether or not any marker covers them. Inline waves advance the in-memory frontier without touching the durable marker; the apply thread persists a catch-up marker every 4096 sequences to bound how much log a crash replays, and a clean shutdown catches the marker up so reopen has nothing to replay.
- Sequence pruning persists the applied marker, flushes the no-WAL CFs, and never prunes at or above the applied frontier, so replay source rows cannot be deleted out from under the marker. Prune also waits for the apply thread to catch up to the frontier observed at call time (prune is rare and best-effort, per issue discussion).
- If a background apply write fails, it retries with backoff; meanwhile the applied frontier stalls, fenced reads return `CONSISTENCY_NOT_READY`, and a restart recovers via replay.

## Why not serve the log from the RocksDB WAL directly?

Considered (and it is exposed as `DB::get_updates_since`), but it is not obviously correct:

1. WAL file retention is driven by memtable flushes (or time/size-based archival), not by the compact service's `Sequence` prune policy, so replay retention could not be enforced.
2. `GetBatch(seq)` needs point lookups by application sequence; the WAL is keyed by RocksDB internal seqnos (one per key write, interleaved with prune deletes and marker writes), so we would still need a mapping index and linear scans.
3. With the WAL disabled for large key/value writes (the point of this change), the WAL would contain only the log rows anyway — i.e., `LOG_CF` reimplemented inside WAL files with worse indexing.

## Benchmarks

`exoware-workload` (from `michael/add-workloads`, ported to main's SDK API) against release builds of main and this branch on a 4-core cloud VM. Because run-to-run variance on this box is large (main-vs-main spreads exceed 10%), all contested configs were measured as **order-alternating paired A/B runs**; tables report the paired mean delta with a 95% confidence interval. `fsync+2ms` rows use an `LD_PRELOAD` shim adding 2ms to every `fsync`/`fdatasync` to emulate slower cloud block storage.

### Jumbo batches (250k keys per request — the target workload)

Bulk ingest via `workload load` with `--batch-size 250000` (each put is one ~48 MB request of 250k x 160 B entries), concurrency 4:

| keys/run | fsync | pairs | main keys/s | branch keys/s | paired delta (95% CI) | disk bytes/key |
|---|---|---|---|---|---|---|
| 10M | native | 5 | 708k | 777k | **+7.8% +/- 5.6** | 904 -> 710 (**-21%**) |
| 2.5M | +2ms | 3 | 639k | 745k | **+17.1% +/- 7.7** | 817 -> 561 (**-31%**) |

Requests this large always take the deferred no-WAL path (48 MB >> the 16 KiB inline cap), which is exactly where the decoupling wins: the payload no longer makes a second trip through the WAL, and key/value application overlaps the next request's log fsync instead of extending it.

### Per-op scenarios (small requests)

| scenario | conc | value | fsync | pairs | paired delta (95% CI) |
|---|---|---|---|---|---|
| ingest-burst | 32 | 4 KiB | native | 7 | **+15.0% +/- 4.7** |
| ingest-burst | 32 | 4 KiB | +2ms | 5 | -0.1% +/- 1.3 |
| write-heavy | 32 | 160 B | native | 20 | +1.2% +/- 1.5 |
| ingest-burst | 32 | 160 B | native | 20 | -1.0% +/- 1.6 |
| write-heavy | 32 | 160 B | +2ms | 5 | +0.1% +/- 2.3 |
| write-heavy | 4 | 160 B | +2ms | 5 | -1.2% +/- 1.8 |

- **Large payloads: +8-17% throughput while physically writing 21-31% less.** Also confirmed per-op: a 4 KiB ingest-burst writes 12,690 vs 16,734 bytes/op (`/proc/<pid>/io`).
- **Small-value workloads: parity.** Every small-value config's confidence interval includes zero. The always-deferred intermediate design regressed these configs by a statistically significant 4-6% (paired medians, n=7-20); the inline gate eliminated that.
- Under 2ms fsync, small-request configs are fsync-bound and indistinguishable; jumbo requests still gain +17% because each 48 MB request paid for its payload twice in the WAL on main.

## Crash recovery validation

`kill -9` on the simulator mid-ingest, restart on the same directory, then `workload validate --mode overlap-ledger-verify`. Four cases, exercising both apply paths:

- **Inline path**: 160-200 B ledger values (every wave under the inline cap) — 30,144 acked writes verified present.
- **Deferred path**: 24-32 KiB ledger values — 30,140 acked writes verified present.
- **Mixed under load**: ledger appends interleaved with a concurrent 16-way 24 KiB ingest-burst (apply queue busy, 1.2 GB written) — 2,935 acked ledger writes verified present after replay.
- **Jumbo requests**: killed mid-load of 250k-key requests; reopen + recovery replay took 1.5 s and a post-recovery overlap-ledger pass verified clean.

## Testing

- `cargo test --workspace` — all green (44 suites, 0 failures).
- New simulator unit tests cover: small waves applying inline in the synced batch (readable with no apply work, marker-only handoff), oversized waves deferring (not visible until the apply write), recovery replay after lost no-WAL state, replay from an under-claiming marker restoring inline waves, replay across log gaps (empty batches), and reopen-after-prune not needing pruned rows.
- New server test covers `GetBatch` classification when the log frontier runs ahead of the applied frontier (evicted vs not-found).
- `cargo clippy --all-targets` on the touched crates, `cargo fmt --all -- --check`, and `cargo doc -D warnings` — clean.
- Tests that asserted read-your-writes now fence explicitly: direct-store tests use the new `RocksStore::wait_for_applied`, HTTP e2e/integration tests use a `min_sequence_number` probe barrier, and the QMDB e2e upload helpers fence on the receipt's store sequence number (a 767-op upload surfaced the race as `WatermarkTooLow`).

## Notes

- `RocksStore::open` now returns `Result<Self, String>` (recovery can fail for non-`rocksdb::Error` reasons) and `RocksConfig` gains `kv_meta_cf_options`.
- Existing databases are not migrated (per discussion); a fresh directory is expected.
- Follow-up candidates: apply key prune policies via compaction filters to remove prune overhead entirely, and #63 (flat-file sequence storage) to take the log itself out of RocksDB.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f38be-17ce-74ba-a46d-6baa33d88936"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f38be-17ce-74ba-a46d-6baa33d88936"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

