### PR TITLE
[simulator] Flat-file staged ingest: parallel durable uploads, sequence-by-rename, async WAL-less RocksDB

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2723,6 +2723,7 @@ dependencies = [
  "clap",
  "commonware-codec",
  "connectrpc",
+ "crc32fast",
  "exoware-sdk",
  "exoware-server",
  "http",

--- a/examples/simulator/Cargo.toml
+++ b/examples/simulator/Cargo.toml
@@ -14,6 +14,7 @@ documentation = "https://docs.rs/exoware-simulator"
 axum = { workspace = true }
 buffa = { workspace = true }
 bytes = { workspace = true }
+crc32fast = "1"
 exoware-sdk = { workspace = true }
 exoware-server = { workspace = true }
 reqwest = { workspace = true }

--- a/examples/simulator/Cargo.toml
+++ b/examples/simulator/Cargo.toml
@@ -34,3 +34,7 @@ tempfile = { workspace = true }
 [[bin]]
 name = "simulator"
 path = "src/main.rs"
+
+[[bench]]
+name = "ingest_load"
+harness = false

--- a/examples/simulator/benches/ingest_load.rs
+++ b/examples/simulator/benches/ingest_load.rs
@@ -14,6 +14,12 @@
 //!   Upper bound for what the disk + RocksDB can do with zero ordering or durability work.
 //! - `raw-sync`: concurrent RocksDB writes with `sync=true` on every write (RocksDB group
 //!   commit only). Shows what naive per-request fsync costs.
+//! - `flatfile`: the real [`exoware_simulator::FlatFileRocksStore`] engine. Each upload is
+//!   written and fsynced to its own checksummed flat file (parallel durability, no shared log);
+//!   a sequencer assigns sequence numbers by renaming files and fsyncing the directory once per
+//!   wave; applier threads populate RocksDB (WAL disabled) from a bounded in-memory queue.
+//! - `flatfile-nodb`: prototype of the same ack path with the RocksDB apply skipped; isolates
+//!   the durability path (file write + fsync + rename + dir fsync) as the design's ceiling.
 //!
 //! Usage (all flags optional):
 //!   cargo bench -p exoware-simulator --bench ingest_load -- \
@@ -29,15 +35,19 @@
 //! `--tuned` sizes RocksDB for bulk ingest (512 MiB write buffers, 8 background jobs, relaxed
 //! L0 stall thresholds) to separate pipeline costs from stock-option write stalls.
 
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::Arc;
+use std::sync::{mpsc, Arc, Mutex};
+use std::thread;
 use std::time::{Duration, Instant};
 
 use bytes::Bytes;
 use exoware_server::Ingest;
 use exoware_simulator::{
-    CommitDurability, RocksConfig, RocksStore, RocksWritePipelineConfig, UnorderedRocksConfig,
-    UnorderedRocksStore,
+    CommitDurability, FlatFileConfig, FlatFileRocksStore, RocksConfig, RocksStore,
+    RocksWritePipelineConfig, UnorderedRocksConfig, UnorderedRocksStore,
 };
 use tempfile::tempdir;
 
@@ -50,6 +60,8 @@ enum Mode {
     UnorderedUw,
     RawNoSync,
     RawSync,
+    FlatFile,
+    FlatFileNoDb,
 }
 
 impl Mode {
@@ -62,6 +74,8 @@ impl Mode {
             "unordered-uw" => Some(Self::UnorderedUw),
             "raw-nosync" => Some(Self::RawNoSync),
             "raw-sync" => Some(Self::RawSync),
+            "flatfile" => Some(Self::FlatFile),
+            "flatfile-nodb" => Some(Self::FlatFileNoDb),
             _ => None,
         }
     }
@@ -75,6 +89,8 @@ impl Mode {
             Self::UnorderedUw => "unordered-uw",
             Self::RawNoSync => "raw-nosync",
             Self::RawSync => "raw-sync",
+            Self::FlatFile => "flatfile",
+            Self::FlatFileNoDb => "flatfile-nodb",
         }
     }
 }
@@ -85,6 +101,8 @@ enum Engine {
     Ordered(RocksStore),
     Unordered(UnorderedRocksStore),
     Raw { db: Arc<rocksdb::DB>, sync: bool },
+    FlatFile(FlatFileRocksStore),
+    FlatAck(Arc<FlatAckPipeline>),
 }
 
 impl Engine {
@@ -107,6 +125,135 @@ impl Engine {
                 .await
                 .map_err(|e| e.to_string())?
             }
+            Self::FlatFile(store) => store.put_batch(kvs).await.map(|_| ()),
+            Self::FlatAck(pipeline) => pipeline.put_batch(kvs).await.map(|_| ()),
+        }
+    }
+}
+
+/// Max tickets sequenced (renamed + acked) per directory fsync.
+const FLAT_MAX_WAVE: usize = 4096;
+
+/// A durable (written + fsynced) flat file waiting for its sequence number.
+struct FlatAckTicket {
+    tmp_path: PathBuf,
+    ack: tokio::sync::oneshot::Sender<u64>,
+}
+
+/// Ack-path-only prototype of the flat-file design: checksummed file write + fsync per upload,
+/// then a sequencer that renames a wave of files and fsyncs the directory once before acking.
+/// No RocksDB apply happens (files are deleted at sequencing time), so this isolates the
+/// durability path as the design's ceiling.
+struct FlatAckPipeline {
+    staging: PathBuf,
+    next_id: AtomicU64,
+    sender: Mutex<Option<mpsc::Sender<FlatAckTicket>>>,
+    sequencer: Mutex<Option<thread::JoinHandle<()>>>,
+}
+
+impl FlatAckPipeline {
+    fn open(root: &std::path::Path) -> Arc<Self> {
+        let staging = root.join("staging");
+        std::fs::create_dir_all(&staging).expect("create staging dir");
+        let (tx, rx) = mpsc::channel::<FlatAckTicket>();
+        let sequencer_staging = staging.clone();
+        let sequencer_handle = thread::Builder::new()
+            .name("bench-flat-sequencer".to_string())
+            .spawn(move || run_flat_ack_sequencer(sequencer_staging, rx))
+            .expect("spawn sequencer");
+        Arc::new(Self {
+            staging,
+            next_id: AtomicU64::new(0),
+            sender: Mutex::new(Some(tx)),
+            sequencer: Mutex::new(Some(sequencer_handle)),
+        })
+    }
+
+    async fn put_batch(&self, kvs: Vec<(Bytes, Bytes)>) -> Result<u64, String> {
+        // Phase 1 (parallel across callers): durable, checksummed flat file under a temp name.
+        let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+        let tmp_path = self.staging.join(format!("{id:020}.tmp"));
+        let write_path = tmp_path.clone();
+        tokio::task::spawn_blocking(move || {
+            let mut payload_len = 4usize;
+            for (k, v) in &kvs {
+                payload_len += 8 + k.len() + v.len();
+            }
+            let mut buf = Vec::with_capacity(payload_len + 4);
+            buf.extend_from_slice(&(kvs.len() as u32).to_le_bytes());
+            for (k, v) in &kvs {
+                buf.extend_from_slice(&(k.len() as u32).to_le_bytes());
+                buf.extend_from_slice(&(v.len() as u32).to_le_bytes());
+                buf.extend_from_slice(k.as_ref());
+                buf.extend_from_slice(v.as_ref());
+            }
+            let crc = crc32fast::hash(&buf);
+            buf.extend_from_slice(&crc.to_le_bytes());
+            let mut file = File::create(&write_path).map_err(|e| e.to_string())?;
+            file.write_all(&buf).map_err(|e| e.to_string())?;
+            file.sync_all().map_err(|e| e.to_string())
+        })
+        .await
+        .map_err(|e| e.to_string())??;
+
+        // Phase 2: wait for the sequencer to rename the file to its sequence number.
+        let (ack_tx, ack_rx) = tokio::sync::oneshot::channel();
+        self.sender
+            .lock()
+            .map_err(|e| e.to_string())?
+            .as_ref()
+            .ok_or_else(|| "sequencer stopped".to_string())?
+            .send(FlatAckTicket {
+                tmp_path,
+                ack: ack_tx,
+            })
+            .map_err(|_| "sequencer stopped".to_string())?;
+        ack_rx
+            .await
+            .map_err(|_| "sequencer dropped ack".to_string())
+    }
+}
+
+impl Drop for FlatAckPipeline {
+    fn drop(&mut self) {
+        if let Ok(mut sender) = self.sender.lock() {
+            sender.take();
+        }
+        if let Ok(mut handle) = self.sequencer.lock() {
+            if let Some(handle) = handle.take() {
+                let _ = handle.join();
+            }
+        }
+    }
+}
+
+fn run_flat_ack_sequencer(staging: PathBuf, receiver: mpsc::Receiver<FlatAckTicket>) {
+    let dir_handle = File::open(&staging).expect("open staging dir");
+    let mut next_seq = 1u64;
+    while let Ok(first) = receiver.recv() {
+        let mut wave = vec![first];
+        while wave.len() < FLAT_MAX_WAVE {
+            match receiver.try_recv() {
+                Ok(ticket) => wave.push(ticket),
+                Err(_) => break,
+            }
+        }
+
+        // Assign sequence numbers by renaming within the staging directory, then make the whole
+        // wave's renames durable with one directory fsync before acking anyone.
+        let mut sequenced = Vec::with_capacity(wave.len());
+        for ticket in wave {
+            let seq = next_seq;
+            next_seq += 1;
+            let seq_path = staging.join(format!("{seq:020}.seq"));
+            std::fs::rename(&ticket.tmp_path, &seq_path).expect("rename to sequence");
+            sequenced.push((seq, seq_path, ticket));
+        }
+        dir_handle.sync_all().expect("fsync staging dir");
+
+        for (seq, seq_path, ticket) in sequenced {
+            let _ = ticket.ack.send(seq);
+            let _ = std::fs::remove_file(&seq_path);
         }
     }
 }
@@ -214,6 +361,16 @@ async fn run_cell(config: &CellConfig) -> CellResult {
                 sync: config.mode == Mode::RawSync,
             }
         }
+        Mode::FlatFile => {
+            let mut flat = FlatFileConfig::default();
+            if config.tuned {
+                flat.db_options = tuned_db_options();
+                flat.default_cf_options = tuned_cf_options();
+                flat.log_cf_options = tuned_cf_options();
+            }
+            Engine::FlatFile(FlatFileRocksStore::open(dir.path(), Some(flat)).expect("open"))
+        }
+        Mode::FlatFileNoDb => Engine::FlatAck(FlatAckPipeline::open(dir.path())),
     };
 
     let recording = Arc::new(AtomicBool::new(false));

--- a/examples/simulator/benches/ingest_load.rs
+++ b/examples/simulator/benches/ingest_load.rs
@@ -1,0 +1,284 @@
+//! Ingest load benchmark: measures `put_batch` throughput and latency under concurrent load.
+//!
+//! Modes:
+//! - `ordered`: the production [`exoware_simulator::RocksStore`] write pipeline (contiguous
+//!   sequence numbers assigned before a single synced commit per group).
+//! - `unordered`: the experimental [`exoware_simulator::UnorderedRocksStore`] pipeline
+//!   (concurrent unsynced data writes, sequence numbers assigned after by a tiny synced write).
+//! - `raw-nosync`: concurrent RocksDB writes without sync, sequence numbers, or a batch log.
+//!   Upper bound for what the disk + RocksDB can do with zero ordering or durability work.
+//! - `raw-sync`: concurrent RocksDB writes with `sync=true` on every write (RocksDB group
+//!   commit only). Shows what naive per-request fsync costs.
+//!
+//! Usage (all flags optional):
+//!   cargo bench -p exoware-simulator --bench ingest_load -- \
+//!     [--modes ordered,unordered,raw-nosync,raw-sync] [--concurrency 1,8,64,256] \
+//!     [--value-sizes 128,1024,16384] [--kvs-per-put 1] [--measure-secs 5] [--warmup-secs 1]
+
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use bytes::Bytes;
+use exoware_server::Ingest;
+use exoware_simulator::{RocksStore, UnorderedRocksStore};
+use tempfile::tempdir;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Mode {
+    Ordered,
+    Unordered,
+    RawNoSync,
+    RawSync,
+}
+
+impl Mode {
+    fn parse(s: &str) -> Option<Self> {
+        match s {
+            "ordered" => Some(Self::Ordered),
+            "unordered" => Some(Self::Unordered),
+            "raw-nosync" => Some(Self::RawNoSync),
+            "raw-sync" => Some(Self::RawSync),
+            _ => None,
+        }
+    }
+
+    fn name(&self) -> &'static str {
+        match self {
+            Self::Ordered => "ordered",
+            Self::Unordered => "unordered",
+            Self::RawNoSync => "raw-nosync",
+            Self::RawSync => "raw-sync",
+        }
+    }
+}
+
+/// One engine under test, reduced to the put path.
+#[derive(Clone)]
+enum Engine {
+    Ordered(RocksStore),
+    Unordered(UnorderedRocksStore),
+    Raw { db: Arc<rocksdb::DB>, sync: bool },
+}
+
+impl Engine {
+    async fn put_batch(&self, kvs: Vec<(Bytes, Bytes)>) -> Result<(), String> {
+        match self {
+            Self::Ordered(store) => store.put_batch(kvs).await.map(|_| ()),
+            Self::Unordered(store) => store.put_batch(kvs).await.map(|_| ()),
+            Self::Raw { db, sync } => {
+                let db = db.clone();
+                let sync = *sync;
+                tokio::task::spawn_blocking(move || {
+                    let mut batch = rocksdb::WriteBatch::default();
+                    for (k, v) in &kvs {
+                        batch.put(k.as_ref(), v.as_ref());
+                    }
+                    let mut options = rocksdb::WriteOptions::default();
+                    options.set_sync(sync);
+                    db.write_opt(batch, &options).map_err(|e| e.to_string())
+                })
+                .await
+                .map_err(|e| e.to_string())?
+            }
+        }
+    }
+}
+
+struct CellConfig {
+    mode: Mode,
+    concurrency: usize,
+    value_size: usize,
+    kvs_per_put: usize,
+    warmup: Duration,
+    measure: Duration,
+}
+
+struct CellResult {
+    puts: u64,
+    elapsed: Duration,
+    latencies_us: Vec<u64>,
+}
+
+fn percentile(sorted_us: &[u64], p: f64) -> f64 {
+    if sorted_us.is_empty() {
+        return 0.0;
+    }
+    let rank = (p * (sorted_us.len() - 1) as f64).round() as usize;
+    sorted_us[rank.min(sorted_us.len() - 1)] as f64 / 1000.0
+}
+
+async fn run_cell(config: &CellConfig) -> CellResult {
+    let dir = tempdir().expect("tempdir");
+    let engine = match config.mode {
+        Mode::Ordered => Engine::Ordered(RocksStore::open(dir.path(), None).expect("open")),
+        Mode::Unordered => {
+            Engine::Unordered(UnorderedRocksStore::open(dir.path(), None).expect("open"))
+        }
+        Mode::RawNoSync | Mode::RawSync => {
+            let mut options = rocksdb::Options::default();
+            options.create_if_missing(true);
+            Engine::Raw {
+                db: Arc::new(rocksdb::DB::open(&options, dir.path()).expect("open")),
+                sync: config.mode == Mode::RawSync,
+            }
+        }
+    };
+
+    let recording = Arc::new(AtomicBool::new(false));
+    let stop = Arc::new(AtomicBool::new(false));
+    let next_task = Arc::new(AtomicU64::new(0));
+    let mut workers = Vec::with_capacity(config.concurrency);
+    for _ in 0..config.concurrency {
+        let engine = engine.clone();
+        let recording = recording.clone();
+        let stop = stop.clone();
+        let task_id = next_task.fetch_add(1, Ordering::Relaxed);
+        let value = Bytes::from(vec![0xAB; config.value_size]);
+        let kvs_per_put = config.kvs_per_put;
+        workers.push(tokio::spawn(async move {
+            let mut latencies_us = Vec::new();
+            let mut puts = 0u64;
+            let mut op = 0u64;
+            while !stop.load(Ordering::Relaxed) {
+                let mut kvs = Vec::with_capacity(kvs_per_put);
+                for i in 0..kvs_per_put {
+                    let mut key = [0u8; 20];
+                    key[..8].copy_from_slice(&task_id.to_be_bytes());
+                    key[8..16].copy_from_slice(&op.to_be_bytes());
+                    key[16..20].copy_from_slice(&(i as u32).to_be_bytes());
+                    kvs.push((Bytes::copy_from_slice(&key), value.clone()));
+                }
+                op += 1;
+                let started = Instant::now();
+                engine.put_batch(kvs).await.expect("put");
+                if recording.load(Ordering::Relaxed) {
+                    puts += 1;
+                    latencies_us.push(started.elapsed().as_micros() as u64);
+                }
+            }
+            (puts, latencies_us)
+        }));
+    }
+
+    tokio::time::sleep(config.warmup).await;
+    recording.store(true, Ordering::Relaxed);
+    let measure_started = Instant::now();
+    tokio::time::sleep(config.measure).await;
+    recording.store(false, Ordering::Relaxed);
+    let elapsed = measure_started.elapsed();
+    stop.store(true, Ordering::Relaxed);
+
+    let mut puts = 0u64;
+    let mut latencies_us = Vec::new();
+    for worker in workers {
+        let (worker_puts, worker_latencies) = worker.await.expect("worker");
+        puts += worker_puts;
+        latencies_us.extend(worker_latencies);
+    }
+    latencies_us.sort_unstable();
+    CellResult {
+        puts,
+        elapsed,
+        latencies_us,
+    }
+}
+
+fn parse_list<T: std::str::FromStr>(value: &str) -> Vec<T>
+where
+    T::Err: std::fmt::Debug,
+{
+    value
+        .split(',')
+        .map(|part| part.trim().parse().expect("parse list element"))
+        .collect()
+}
+
+fn main() {
+    let mut modes = vec![Mode::Ordered, Mode::Unordered, Mode::RawNoSync, Mode::RawSync];
+    let mut concurrency = vec![1usize, 8, 64, 256];
+    let mut value_sizes = vec![128usize, 1024, 16384];
+    let mut kvs_per_put = 1usize;
+    let mut measure_secs = 5u64;
+    let mut warmup_secs = 1u64;
+
+    let args: Vec<String> = std::env::args().collect();
+    let mut i = 1;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--modes" => {
+                i += 1;
+                modes = args[i]
+                    .split(',')
+                    .map(|m| Mode::parse(m.trim()).expect("unknown mode"))
+                    .collect();
+            }
+            "--concurrency" => {
+                i += 1;
+                concurrency = parse_list(&args[i]);
+            }
+            "--value-sizes" => {
+                i += 1;
+                value_sizes = parse_list(&args[i]);
+            }
+            "--kvs-per-put" => {
+                i += 1;
+                kvs_per_put = args[i].parse().expect("kvs per put");
+            }
+            "--measure-secs" => {
+                i += 1;
+                measure_secs = args[i].parse().expect("measure secs");
+            }
+            "--warmup-secs" => {
+                i += 1;
+                warmup_secs = args[i].parse().expect("warmup secs");
+            }
+            // `cargo bench` passes --bench through to the harness; ignore it.
+            "--bench" => {}
+            other => panic!("unknown argument: {other}"),
+        }
+        i += 1;
+    }
+
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .expect("runtime");
+
+    println!(
+        "{:<11} {:>5} {:>7} {:>4} | {:>9} {:>9} | {:>8} {:>8} {:>8} {:>9}",
+        "mode", "conc", "vsize", "kvs", "puts/s", "MiB/s", "p50 ms", "p95 ms", "p99 ms", "max ms"
+    );
+    for &mode in &modes {
+        for &conc in &concurrency {
+            for &value_size in &value_sizes {
+                let config = CellConfig {
+                    mode,
+                    concurrency: conc,
+                    value_size,
+                    kvs_per_put,
+                    warmup: Duration::from_secs(warmup_secs),
+                    measure: Duration::from_secs(measure_secs),
+                };
+                let result = runtime.block_on(run_cell(&config));
+                let seconds = result.elapsed.as_secs_f64();
+                let puts_per_sec = result.puts as f64 / seconds;
+                let mib_per_sec = puts_per_sec * (kvs_per_put * (value_size + 20)) as f64
+                    / (1024.0 * 1024.0);
+                println!(
+                    "{:<11} {:>5} {:>7} {:>4} | {:>9.0} {:>9.1} | {:>8.2} {:>8.2} {:>8.2} {:>9.2}",
+                    mode.name(),
+                    conc,
+                    value_size,
+                    kvs_per_put,
+                    puts_per_sec,
+                    mib_per_sec,
+                    percentile(&result.latencies_us, 0.50),
+                    percentile(&result.latencies_us, 0.95),
+                    percentile(&result.latencies_us, 0.99),
+                    percentile(&result.latencies_us, 1.0),
+                );
+            }
+        }
+    }
+}

--- a/examples/simulator/benches/ingest_load.rs
+++ b/examples/simulator/benches/ingest_load.rs
@@ -5,6 +5,8 @@
 //!   sequence numbers assigned before a single synced commit per group).
 //! - `unordered`: the experimental [`exoware_simulator::UnorderedRocksStore`] pipeline
 //!   (concurrent unsynced data writes, sequence numbers assigned after by a tiny synced write).
+//! - `unordered-uw`: same store with RocksDB's `unordered_write=true`, which relaxes RocksDB's
+//!   internal write ordering to admit more memtable concurrency.
 //! - `raw-nosync`: concurrent RocksDB writes without sync, sequence numbers, or a batch log.
 //!   Upper bound for what the disk + RocksDB can do with zero ordering or durability work.
 //! - `raw-sync`: concurrent RocksDB writes with `sync=true` on every write (RocksDB group
@@ -12,7 +14,7 @@
 //!
 //! Usage (all flags optional):
 //!   cargo bench -p exoware-simulator --bench ingest_load -- \
-//!     [--modes ordered,unordered,raw-nosync,raw-sync] [--concurrency 1,8,64,256] \
+//!     [--modes ordered,unordered,unordered-uw,raw-nosync,raw-sync] [--concurrency 1,8,64,256] \
 //!     [--value-sizes 128,1024,16384] [--kvs-per-put 1] [--measure-secs 5] [--warmup-secs 1]
 
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -21,13 +23,14 @@ use std::time::{Duration, Instant};
 
 use bytes::Bytes;
 use exoware_server::Ingest;
-use exoware_simulator::{RocksStore, UnorderedRocksStore};
+use exoware_simulator::{RocksStore, UnorderedRocksConfig, UnorderedRocksStore};
 use tempfile::tempdir;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum Mode {
     Ordered,
     Unordered,
+    UnorderedUw,
     RawNoSync,
     RawSync,
 }
@@ -37,6 +40,7 @@ impl Mode {
         match s {
             "ordered" => Some(Self::Ordered),
             "unordered" => Some(Self::Unordered),
+            "unordered-uw" => Some(Self::UnorderedUw),
             "raw-nosync" => Some(Self::RawNoSync),
             "raw-sync" => Some(Self::RawSync),
             _ => None,
@@ -47,6 +51,7 @@ impl Mode {
         match self {
             Self::Ordered => "ordered",
             Self::Unordered => "unordered",
+            Self::UnorderedUw => "unordered-uw",
             Self::RawNoSync => "raw-nosync",
             Self::RawSync => "raw-sync",
         }
@@ -114,6 +119,11 @@ async fn run_cell(config: &CellConfig) -> CellResult {
         Mode::Ordered => Engine::Ordered(RocksStore::open(dir.path(), None).expect("open")),
         Mode::Unordered => {
             Engine::Unordered(UnorderedRocksStore::open(dir.path(), None).expect("open"))
+        }
+        Mode::UnorderedUw => {
+            let mut config = UnorderedRocksConfig::default();
+            config.db_options.set_unordered_write(true);
+            Engine::Unordered(UnorderedRocksStore::open(dir.path(), Some(config)).expect("open"))
         }
         Mode::RawNoSync | Mode::RawSync => {
             let mut options = rocksdb::Options::default();
@@ -195,7 +205,13 @@ where
 }
 
 fn main() {
-    let mut modes = vec![Mode::Ordered, Mode::Unordered, Mode::RawNoSync, Mode::RawSync];
+    let mut modes = vec![
+        Mode::Ordered,
+        Mode::Unordered,
+        Mode::UnorderedUw,
+        Mode::RawNoSync,
+        Mode::RawSync,
+    ];
     let mut concurrency = vec![1usize, 8, 64, 256];
     let mut value_sizes = vec![128usize, 1024, 16384];
     let mut kvs_per_put = 1usize;
@@ -263,8 +279,8 @@ fn main() {
                 let result = runtime.block_on(run_cell(&config));
                 let seconds = result.elapsed.as_secs_f64();
                 let puts_per_sec = result.puts as f64 / seconds;
-                let mib_per_sec = puts_per_sec * (kvs_per_put * (value_size + 20)) as f64
-                    / (1024.0 * 1024.0);
+                let mib_per_sec =
+                    puts_per_sec * (kvs_per_put * (value_size + 20)) as f64 / (1024.0 * 1024.0);
                 println!(
                     "{:<11} {:>5} {:>7} {:>4} | {:>9.0} {:>9.1} | {:>8.2} {:>8.2} {:>8.2} {:>9.2}",
                     mode.name(),

--- a/examples/simulator/benches/ingest_load.rs
+++ b/examples/simulator/benches/ingest_load.rs
@@ -3,10 +3,13 @@
 //! Modes:
 //! - `ordered`: the production [`exoware_simulator::RocksStore`] write pipeline (contiguous
 //!   sequence numbers assigned before a single synced commit per group).
+//! - `ordered-nowal`: same pipeline with `CommitDurability::NoWalFlush` (WAL disabled; each
+//!   commit group is made durable by one atomic memtable flush instead of a WAL fsync).
 //! - `unordered`: the experimental [`exoware_simulator::UnorderedRocksStore`] pipeline
 //!   (concurrent unsynced data writes, sequence numbers assigned after by a tiny synced write).
-//! - `unordered-uw`: same store with RocksDB's `unordered_write=true`, which relaxes RocksDB's
-//!   internal write ordering to admit more memtable concurrency.
+//! - `unordered-nowal`: unordered pipeline with `CommitDurability::NoWalFlush`.
+//! - `unordered-uw`: unordered pipeline with RocksDB's `unordered_write=true`, which relaxes
+//!   RocksDB's internal write ordering to admit more memtable concurrency.
 //! - `raw-nosync`: concurrent RocksDB writes without sync, sequence numbers, or a batch log.
 //!   Upper bound for what the disk + RocksDB can do with zero ordering or durability work.
 //! - `raw-sync`: concurrent RocksDB writes with `sync=true` on every write (RocksDB group
@@ -14,8 +17,17 @@
 //!
 //! Usage (all flags optional):
 //!   cargo bench -p exoware-simulator --bench ingest_load -- \
-//!     [--modes ordered,unordered,unordered-uw,raw-nosync,raw-sync] [--concurrency 1,8,64,256] \
-//!     [--value-sizes 128,1024,16384] [--kvs-per-put 1] [--measure-secs 5] [--warmup-secs 1]
+//!     [--modes ordered,ordered-nowal,unordered,unordered-nowal,unordered-uw,raw-nosync,raw-sync] \
+//!     [--concurrency 1,8,64,256] [--value-sizes 128,1024,16384] [--kvs-per-put 1] \
+//!     [--measure-secs 5] [--warmup-secs 1]
+//!
+//! Large-batch ingest (the primary production shape, 250k+ keys per put):
+//!   cargo bench -p exoware-simulator --bench ingest_load -- \
+//!     --modes ordered,ordered-nowal,unordered,unordered-nowal,raw-nosync \
+//!     --concurrency 1,4 --value-sizes 128 --kvs-per-put 250000 --measure-secs 20
+//!
+//! `--tuned` sizes RocksDB for bulk ingest (512 MiB write buffers, 8 background jobs, relaxed
+//! L0 stall thresholds) to separate pipeline costs from stock-option write stalls.
 
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
@@ -23,13 +35,18 @@ use std::time::{Duration, Instant};
 
 use bytes::Bytes;
 use exoware_server::Ingest;
-use exoware_simulator::{RocksStore, UnorderedRocksConfig, UnorderedRocksStore};
+use exoware_simulator::{
+    CommitDurability, RocksConfig, RocksStore, RocksWritePipelineConfig, UnorderedRocksConfig,
+    UnorderedRocksStore,
+};
 use tempfile::tempdir;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum Mode {
     Ordered,
+    OrderedNoWal,
     Unordered,
+    UnorderedNoWal,
     UnorderedUw,
     RawNoSync,
     RawSync,
@@ -39,7 +56,9 @@ impl Mode {
     fn parse(s: &str) -> Option<Self> {
         match s {
             "ordered" => Some(Self::Ordered),
+            "ordered-nowal" => Some(Self::OrderedNoWal),
             "unordered" => Some(Self::Unordered),
+            "unordered-nowal" => Some(Self::UnorderedNoWal),
             "unordered-uw" => Some(Self::UnorderedUw),
             "raw-nosync" => Some(Self::RawNoSync),
             "raw-sync" => Some(Self::RawSync),
@@ -50,7 +69,9 @@ impl Mode {
     fn name(&self) -> &'static str {
         match self {
             Self::Ordered => "ordered",
+            Self::OrderedNoWal => "ordered-nowal",
             Self::Unordered => "unordered",
+            Self::UnorderedNoWal => "unordered-nowal",
             Self::UnorderedUw => "unordered-uw",
             Self::RawNoSync => "raw-nosync",
             Self::RawSync => "raw-sync",
@@ -97,6 +118,24 @@ struct CellConfig {
     kvs_per_put: usize,
     warmup: Duration,
     measure: Duration,
+    tuned: bool,
+}
+
+/// Bulk-ingest RocksDB options: large write buffers so flushes are infrequent and well-sized,
+/// more background jobs so flush/compaction keeps up, and relaxed L0 stall thresholds so the
+/// pipelines under test are measured instead of stock-option write stalls.
+fn tuned_db_options() -> rocksdb::Options {
+    let mut options = rocksdb::Options::default();
+    options.set_write_buffer_size(512 * 1024 * 1024);
+    options.set_max_write_buffer_number(4);
+    options.set_max_background_jobs(8);
+    options.set_level_zero_slowdown_writes_trigger(40);
+    options.set_level_zero_stop_writes_trigger(60);
+    options
+}
+
+fn tuned_cf_options() -> rocksdb::Options {
+    tuned_db_options()
 }
 
 struct CellResult {
@@ -115,18 +154,60 @@ fn percentile(sorted_us: &[u64], p: f64) -> f64 {
 
 async fn run_cell(config: &CellConfig) -> CellResult {
     let dir = tempdir().expect("tempdir");
+    let ordered_config = |durability: CommitDurability| {
+        let mut ordered = RocksConfig {
+            write_pipeline: RocksWritePipelineConfig {
+                durability,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        if config.tuned {
+            ordered.db_options = tuned_db_options();
+            ordered.default_cf_options = tuned_cf_options();
+        }
+        ordered
+    };
+    let unordered_config = |durability: CommitDurability| {
+        let mut unordered = UnorderedRocksConfig {
+            durability,
+            ..Default::default()
+        };
+        if config.tuned {
+            unordered.db_options = tuned_db_options();
+            unordered.default_cf_options = tuned_cf_options();
+            unordered.staged_cf_options = tuned_cf_options();
+        }
+        unordered
+    };
     let engine = match config.mode {
-        Mode::Ordered => Engine::Ordered(RocksStore::open(dir.path(), None).expect("open")),
+        Mode::Ordered => {
+            let config = ordered_config(CommitDurability::SyncWal);
+            Engine::Ordered(RocksStore::open(dir.path(), Some(config)).expect("open"))
+        }
+        Mode::OrderedNoWal => {
+            let config = ordered_config(CommitDurability::NoWalFlush);
+            Engine::Ordered(RocksStore::open(dir.path(), Some(config)).expect("open"))
+        }
         Mode::Unordered => {
-            Engine::Unordered(UnorderedRocksStore::open(dir.path(), None).expect("open"))
+            let config = unordered_config(CommitDurability::SyncWal);
+            Engine::Unordered(UnorderedRocksStore::open(dir.path(), Some(config)).expect("open"))
+        }
+        Mode::UnorderedNoWal => {
+            let config = unordered_config(CommitDurability::NoWalFlush);
+            Engine::Unordered(UnorderedRocksStore::open(dir.path(), Some(config)).expect("open"))
         }
         Mode::UnorderedUw => {
-            let mut config = UnorderedRocksConfig::default();
+            let mut config = unordered_config(CommitDurability::SyncWal);
             config.db_options.set_unordered_write(true);
             Engine::Unordered(UnorderedRocksStore::open(dir.path(), Some(config)).expect("open"))
         }
         Mode::RawNoSync | Mode::RawSync => {
-            let mut options = rocksdb::Options::default();
+            let mut options = if config.tuned {
+                tuned_db_options()
+            } else {
+                rocksdb::Options::default()
+            };
             options.create_if_missing(true);
             Engine::Raw {
                 db: Arc::new(rocksdb::DB::open(&options, dir.path()).expect("open")),
@@ -217,6 +298,7 @@ fn main() {
     let mut kvs_per_put = 1usize;
     let mut measure_secs = 5u64;
     let mut warmup_secs = 1u64;
+    let mut tuned = false;
 
     let args: Vec<String> = std::env::args().collect();
     let mut i = 1;
@@ -249,6 +331,7 @@ fn main() {
                 i += 1;
                 warmup_secs = args[i].parse().expect("warmup secs");
             }
+            "--tuned" => tuned = true,
             // `cargo bench` passes --bench through to the harness; ignore it.
             "--bench" => {}
             other => panic!("unknown argument: {other}"),
@@ -275,6 +358,7 @@ fn main() {
                     kvs_per_put,
                     warmup: Duration::from_secs(warmup_secs),
                     measure: Duration::from_secs(measure_secs),
+                    tuned,
                 };
                 let result = runtime.block_on(run_cell(&config));
                 let seconds = result.elapsed.as_secs_f64();

--- a/examples/simulator/src/flatfile.rs
+++ b/examples/simulator/src/flatfile.rs
@@ -1,0 +1,1150 @@
+//! Flat-file staged ingest: durable uploads land as checksummed flat files, sequence numbers are
+//! assigned by renaming those files, and a WAL-less RocksDB instance is populated asynchronously.
+//!
+//! Write path:
+//! 1. Each `put_batch` call encodes its batch into one checksummed flat file under a temporary
+//!    name in `staging/` and fsyncs it. Concurrent uploads write independent files, so the
+//!    expensive part of durability runs fully in parallel instead of through a single shared WAL.
+//! 2. A sequencer thread drains a wave of completed uploads, assigns each the next contiguous
+//!    sequence number by renaming its file to `<seq>.seq` (same directory), makes the whole wave
+//!    durable with one directory fsync, and acks every caller. The per-wave commit cost is one
+//!    metadata fsync, independent of payload size.
+//! 3. Applier threads populate RocksDB (WAL disabled on every write) from a bounded in-memory
+//!    queue: the batch data is handed over in memory at sequencing time, so the flat files are
+//!    never re-read except during crash recovery. Each apply writes the current-state rows plus
+//!    the replay-log row (`log[seq] = GetResponse`); the contiguous applied frontier is recorded
+//!    in the `meta` CF and published to readers.
+//!
+//! Durability and recovery: the flat files are the write-ahead log. RocksDB contents strictly
+//! lag them and are made durable by an atomic multi-CF memtable flush every
+//! [`FlatFileConfig::flush_gc_bytes`] applied bytes (plus a best-effort flush on clean shutdown);
+//! only files at or beneath the flushed applied frontier are deleted. On open, `.tmp` files
+//! (never sequenced, never acked) are deleted, `.seq` files beneath the recovered frontier are
+//! garbage-collected, and the contiguous run of `.seq` files above it is checksum-verified and
+//! reapplied - reapplying is idempotent because batches are applied in sequence order. Sequenced
+//! files past a gap were never acked (a wave's renames are fsynced before any of its acks) and
+//! are deleted so their numbers can be reassigned.
+//!
+//! Read visibility: acks happen at sequencing time, before the batch reaches RocksDB. To keep
+//! "everything at or beneath a published sequence number is complete and queryable" true, every
+//! read gates on the applied frontier: it waits until the frontier reaches the durable (acked)
+//! sequence observed at call entry, then serves from RocksDB. `current_sequence` reports the
+//! applied frontier. The wait is bounded by the in-memory apply queue
+//! ([`FlatFileConfig::max_queued_apply_bytes`]), which backpressures ingest when appliers lag.
+//!
+//! Semantics vs. the ordered [`crate::RocksStore`]:
+//! - No unsequenced junk can appear in query results: data enters RocksDB only after its
+//!   sequence number is assigned. A crashed upload leaves at most a dead `.tmp` file, deleted on
+//!   the next open. (The unordered store's "keys that are never part of a sequence" caveat does
+//!   not exist here.)
+//! - With `appliers = 1` batches are applied in exact sequence order, so replaying the log
+//!   always reproduces the materialized state. With the default parallel appliers, two racing
+//!   `put_batch` calls that write the *same key* may be applied out of order relative to their
+//!   sequence numbers (the same caveat as [`crate::UnorderedRocksStore`]).
+//! - Prune mutations are ordinary (WAL-backed, unsynced) RocksDB writes; a crash can undo a
+//!   recent prune, which a subsequent policy run re-applies.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs::{self, File};
+use std::io::Write;
+use std::num::NonZeroUsize;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{mpsc, Arc, Condvar, Mutex};
+use std::thread;
+
+use buffa::Message;
+use bytes::Bytes;
+use exoware_sdk::log::stream::v1::GetResponse as StreamGetResponse;
+use exoware_sdk::prune_policy::{PolicyScope, PrunePolicyDocument, RetainPolicy};
+use exoware_server::{Ingest, Log, LogBatch, Prune, Query, QueryExtra, Sequence};
+use rocksdb::{ColumnFamily, ColumnFamilyDescriptor, IteratorMode, Options, WriteOptions, DB};
+use tokio::sync::{oneshot, watch};
+use tracing::{debug, error};
+
+use crate::rocks::{
+    collect_key_prune_deletes, flush_all_cfs, sequence_from_log_key, sequence_log_key,
+    RocksRangeScanCursor, LOG_CF, META_CF, SEQ_META_KEY,
+};
+use crate::unordered::{encode_staged_value, staged_value_with_sequence};
+
+const STAGING_DIR: &str = "staging";
+const DB_DIR: &str = "db";
+const TMP_SUFFIX: &str = ".tmp";
+const SEQ_SUFFIX: &str = ".seq";
+const DEFAULT_MAX_TICKETS_PER_WAVE: usize = 4096;
+const DEFAULT_MAX_QUEUED_APPLY_BYTES: usize = 512 * 1024 * 1024;
+const DEFAULT_FLUSH_GC_BYTES: usize = 256 * 1024 * 1024;
+const DEFAULT_APPLIERS: usize = 4;
+
+/// Options for [`FlatFileRocksStore::open`].
+pub struct FlatFileConfig {
+    /// Database-wide options for the serving RocksDB instance.
+    pub db_options: Options,
+    /// Options for the default column family, which stores the current key-value state.
+    pub default_cf_options: Options,
+    /// Options for the metadata column family.
+    pub meta_cf_options: Options,
+    /// Options for the replay-log column family.
+    pub log_cf_options: Options,
+    /// Maximum uploads sequenced (renamed and acked) per directory fsync.
+    pub max_tickets_per_wave: NonZeroUsize,
+    /// Bound on batch bytes buffered in memory between the sequencer and the appliers. When the
+    /// appliers fall behind, the sequencer blocks on handoff, which stalls subsequent waves and
+    /// backpressures ingest.
+    pub max_queued_apply_bytes: NonZeroUsize,
+    /// Applied bytes between explicit atomic flushes. Each flush makes the applied frontier
+    /// durable in RocksDB and lets the flat files beneath it be deleted, so this bounds both
+    /// recovery replay work and staging-directory disk usage.
+    pub flush_gc_bytes: NonZeroUsize,
+    /// RocksDB applier threads. With more than one, racing same-key writers may be applied out
+    /// of sequence order (see module docs); with exactly one, apply order is strict.
+    pub appliers: NonZeroUsize,
+}
+
+impl Default for FlatFileConfig {
+    fn default() -> Self {
+        Self {
+            db_options: Options::default(),
+            default_cf_options: Options::default(),
+            meta_cf_options: Options::default(),
+            log_cf_options: Options::default(),
+            max_tickets_per_wave: NonZeroUsize::new(DEFAULT_MAX_TICKETS_PER_WAVE)
+                .expect("default wave limit must be nonzero"),
+            max_queued_apply_bytes: NonZeroUsize::new(DEFAULT_MAX_QUEUED_APPLY_BYTES)
+                .expect("default apply queue bound must be nonzero"),
+            flush_gc_bytes: NonZeroUsize::new(DEFAULT_FLUSH_GC_BYTES)
+                .expect("default flush threshold must be nonzero"),
+            appliers: NonZeroUsize::new(DEFAULT_APPLIERS)
+                .expect("default applier count must be nonzero"),
+        }
+    }
+}
+
+/// A durable (written and fsynced) flat file waiting for its sequence number.
+struct Ticket {
+    tmp_path: PathBuf,
+    /// Decoded rows, kept so the applier never re-reads the flat file.
+    kvs: Vec<(Bytes, Bytes)>,
+    /// Staged (sequence-less) replay payload; `None` when the batch logs nothing.
+    payload: Option<Arc<Vec<u8>>>,
+    /// Approximate in-memory size, charged against the apply queue bound.
+    bytes: usize,
+    response: oneshot::Sender<Result<u64, String>>,
+}
+
+/// A sequenced batch queued for the RocksDB appliers.
+struct ApplyTask {
+    sequence: u64,
+    kvs: Vec<(Bytes, Bytes)>,
+    payload: Option<Arc<Vec<u8>>>,
+    bytes: usize,
+}
+
+/// Apply-side bookkeeping guarded by one mutex; the applied-frontier watch value is only
+/// mutated while this lock is held, which keeps frontier advances and marker writes monotone.
+struct ApplyProgress {
+    /// Completed sequence numbers above the contiguous frontier (out-of-order applier finishes).
+    completed: BTreeSet<u64>,
+    /// Applied bytes since the last explicit flush; drives flush + file GC.
+    bytes_since_flush: u64,
+    /// True while some applier thread is running the (slow) flush + GC pass.
+    flush_running: bool,
+}
+
+struct Shared {
+    db: Arc<DB>,
+    staging: PathBuf,
+    /// Highest acked sequence number (its flat file rename has been fsynced).
+    durable: AtomicU64,
+    /// Publishes the contiguous applied frontier to gated readers.
+    applied_tx: watch::Sender<u64>,
+    progress: Mutex<ApplyProgress>,
+    /// Bytes handed to appliers but not yet applied, bounded by `max_queued_apply_bytes`.
+    queued_bytes: Mutex<usize>,
+    queued_bytes_drained: Condvar,
+    max_queued_apply_bytes: usize,
+    flush_gc_bytes: u64,
+    /// Set when an applier hits an unrecoverable error; gated reads fail instead of hanging.
+    apply_failed: AtomicBool,
+}
+
+/// Owns the ingest threads; dropped once, when the last store clone goes away.
+struct Pipeline {
+    sender: Mutex<Option<mpsc::Sender<Ticket>>>,
+    sequencer: Mutex<Option<thread::JoinHandle<()>>>,
+    appliers: Mutex<Vec<thread::JoinHandle<()>>>,
+    /// Kept to run a best-effort final flush after the threads drain.
+    db: Arc<DB>,
+}
+
+impl Drop for Pipeline {
+    fn drop(&mut self) {
+        if let Ok(mut sender) = self.sender.lock() {
+            sender.take();
+        }
+        if let Ok(mut handle) = self.sequencer.lock() {
+            if let Some(handle) = handle.take() {
+                let _ = handle.join();
+            }
+        }
+        if let Ok(mut handles) = self.appliers.lock() {
+            for handle in handles.drain(..) {
+                let _ = handle.join();
+            }
+        }
+        // Make the applied frontier durable so the next open can skip file replay. Failure is
+        // fine: un-flushed applies are replayed from their (still present) flat files.
+        let _ = flush_all_cfs(&self.db);
+    }
+}
+
+/// Store that stages uploads in flat files, sequences them by rename, and serves reads from an
+/// asynchronously populated, WAL-less RocksDB instance.
+///
+/// Not wire-compatible with [`crate::RocksStore`] or [`crate::UnorderedRocksStore`] databases:
+/// the DB lives under a `db/` subdirectory next to the `staging/` file area.
+#[derive(Clone)]
+pub struct FlatFileRocksStore {
+    db: Arc<DB>,
+    shared: Arc<Shared>,
+    applied_rx: watch::Receiver<u64>,
+    pipeline: Arc<Pipeline>,
+    file_counter: Arc<AtomicU64>,
+}
+
+impl FlatFileRocksStore {
+    /// Open the store, recovering any sequenced-but-unapplied flat files left by a crash.
+    pub fn open(path: &Path, config: Option<FlatFileConfig>) -> Result<Self, String> {
+        let FlatFileConfig {
+            mut db_options,
+            default_cf_options,
+            meta_cf_options,
+            log_cf_options,
+            max_tickets_per_wave,
+            max_queued_apply_bytes,
+            flush_gc_bytes,
+            appliers,
+        } = config.unwrap_or_default();
+
+        let staging = path.join(STAGING_DIR);
+        fs::create_dir_all(&staging).map_err(|e| format!("create staging dir: {e}"))?;
+
+        db_options.create_if_missing(true);
+        db_options.create_missing_column_families(true);
+        // Every write is WAL-less; durability comes from the flat files plus periodic flushes.
+        // Flushes must be atomic across CFs or a crash could persist the applied-frontier marker
+        // without the data and log rows beneath it.
+        db_options.set_atomic_flush(true);
+
+        let db = Arc::new(
+            DB::open_cf_descriptors(
+                &db_options,
+                path.join(DB_DIR),
+                vec![
+                    ColumnFamilyDescriptor::new(
+                        rocksdb::DEFAULT_COLUMN_FAMILY_NAME,
+                        default_cf_options,
+                    ),
+                    ColumnFamilyDescriptor::new(META_CF, meta_cf_options),
+                    ColumnFamilyDescriptor::new(LOG_CF, log_cf_options),
+                ],
+            )
+            .map_err(|e| format!("open rocksdb: {e}"))?,
+        );
+
+        let meta_cf = db
+            .cf_handle(META_CF)
+            .expect("meta CF must exist (created on open)");
+        let flushed_frontier = match db
+            .get_cf(meta_cf, SEQ_META_KEY)
+            .map_err(|e| e.to_string())?
+        {
+            Some(bytes) if bytes.len() == 8 => u64::from_le_bytes(bytes.try_into().unwrap()),
+            _ => 0,
+        };
+        let frontier = recover_staging(&db, &staging, flushed_frontier)?;
+
+        let (applied_tx, applied_rx) = watch::channel(frontier);
+        let shared = Arc::new(Shared {
+            db: db.clone(),
+            staging: staging.clone(),
+            durable: AtomicU64::new(frontier),
+            applied_tx,
+            progress: Mutex::new(ApplyProgress {
+                completed: BTreeSet::new(),
+                bytes_since_flush: 0,
+                flush_running: false,
+            }),
+            queued_bytes: Mutex::new(0),
+            queued_bytes_drained: Condvar::new(),
+            max_queued_apply_bytes: max_queued_apply_bytes.get(),
+            flush_gc_bytes: flush_gc_bytes.get() as u64,
+            apply_failed: AtomicBool::new(false),
+        });
+
+        let (apply_tx, apply_rx) = mpsc::channel::<ApplyTask>();
+        let apply_rx = Arc::new(Mutex::new(apply_rx));
+        let applier_handles = (0..appliers.get())
+            .map(|i| {
+                let shared = shared.clone();
+                let apply_rx = apply_rx.clone();
+                thread::Builder::new()
+                    .name(format!("simulator-flat-applier-{i}"))
+                    .spawn(move || run_applier(shared, apply_rx))
+                    .map_err(|e| format!("spawn applier: {e}"))
+            })
+            .collect::<Result<Vec<_>, String>>()?;
+
+        let (ticket_tx, ticket_rx) = mpsc::channel::<Ticket>();
+        let sequencer_shared = shared.clone();
+        let staging_dir_handle =
+            File::open(&staging).map_err(|e| format!("open staging dir: {e}"))?;
+        let sequencer_handle = thread::Builder::new()
+            .name("simulator-flat-sequencer".to_string())
+            .spawn(move || {
+                run_sequencer(
+                    sequencer_shared,
+                    staging_dir_handle,
+                    ticket_rx,
+                    apply_tx,
+                    max_tickets_per_wave.get(),
+                )
+            })
+            .map_err(|e| format!("spawn sequencer: {e}"))?;
+
+        Ok(Self {
+            db: db.clone(),
+            shared,
+            applied_rx,
+            pipeline: Arc::new(Pipeline {
+                sender: Mutex::new(Some(ticket_tx)),
+                sequencer: Mutex::new(Some(sequencer_handle)),
+                appliers: Mutex::new(applier_handles),
+                db,
+            }),
+            file_counter: Arc::new(AtomicU64::new(0)),
+        })
+    }
+
+    fn log_cf(&self) -> &ColumnFamily {
+        self.db
+            .cf_handle(LOG_CF)
+            .expect("log CF must exist (created on open)")
+    }
+
+    /// Waits until the applied frontier reaches `target`, so RocksDB can serve everything at or
+    /// beneath it. Fails (instead of hanging) if an applier died.
+    async fn wait_applied(&self, target: u64) -> Result<(), String> {
+        if *self.applied_rx.borrow() >= target {
+            return Ok(());
+        }
+        let mut rx = self.applied_rx.clone();
+        let shared = self.shared.clone();
+        let applied = rx
+            .wait_for(move |applied| {
+                *applied >= target || shared.apply_failed.load(Ordering::Relaxed)
+            })
+            .await
+            .map_err(|_| "flatfile applier stopped".to_string())?;
+        if *applied >= target {
+            Ok(())
+        } else {
+            Err(
+                "flatfile applier failed; reads beyond the applied frontier are unavailable"
+                    .to_string(),
+            )
+        }
+    }
+
+    /// Gates a read on everything acked before the call started.
+    async fn wait_read_visible(&self) -> Result<(), String> {
+        let durable = self.shared.durable.load(Ordering::Acquire);
+        self.wait_applied(durable).await
+    }
+
+    /// Deletes current rows without touching sequence metadata or the replay log.
+    fn delete_keys(&self, keys: &[Bytes]) -> Result<(), rocksdb::Error> {
+        if keys.is_empty() {
+            return Ok(());
+        }
+        let mut batch = rocksdb::WriteBatch::default();
+        for k in keys {
+            batch.delete(k.as_ref());
+        }
+        self.db.write(batch)
+    }
+
+    /// Deletes replay-log rows below `cutoff_exclusive`.
+    fn prune_log(&self, cutoff_exclusive: u64) -> Result<(), String> {
+        if cutoff_exclusive == 0 {
+            return Ok(());
+        }
+        let log_cf = self.log_cf();
+        let mut batch = rocksdb::WriteBatch::default();
+        for item in self.db.iterator_cf(log_cf, IteratorMode::Start) {
+            let (key, _) = item.map_err(|e| e.to_string())?;
+            if key.as_ref() >= sequence_log_key(cutoff_exclusive).as_slice() {
+                break;
+            }
+            batch.delete_cf(log_cf, key.as_ref());
+        }
+        self.db.write(batch).map_err(|e| e.to_string())
+    }
+
+    fn apply_prune_policies_inner(&self, document: PrunePolicyDocument) -> Result<(), String> {
+        for policy in &document.policies {
+            match &policy.scope {
+                PolicyScope::Keys(scope) => {
+                    let deletes =
+                        collect_key_prune_deletes(self.db.clone(), scope, &policy.retain)?;
+                    self.delete_keys(&deletes).map_err(|e| e.to_string())?;
+                }
+                PolicyScope::Sequence => {
+                    self.apply_sequence_prune_policy(&policy.retain)?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Computes the replay-log cutoff for a sequence policy and prunes only log rows.
+    fn apply_sequence_prune_policy(&self, retain: &RetainPolicy) -> Result<(), String> {
+        let current = *self.applied_rx.borrow();
+        let cutoff_exclusive = match retain {
+            RetainPolicy::KeepLatest { count } => {
+                let count = *count as u64;
+                current.saturating_add(1).saturating_sub(count)
+            }
+            RetainPolicy::GreaterThan { threshold } => threshold.saturating_add(1),
+            RetainPolicy::GreaterThanOrEqual { threshold } => *threshold,
+            RetainPolicy::DropAll => current.saturating_add(1),
+        };
+        self.prune_log(cutoff_exclusive)
+    }
+}
+
+/// Boot-time staging recovery. Deletes `.tmp` files and already-applied `.seq` files, reapplies
+/// the contiguous run of `.seq` files above the flushed frontier (checksum-verified, in order),
+/// and deletes sequenced files past a gap (never acked, so their numbers will be reassigned).
+/// Returns the recovered applied frontier.
+fn recover_staging(db: &DB, staging: &Path, flushed_frontier: u64) -> Result<u64, String> {
+    let mut sequenced = BTreeMap::new();
+    let entries = fs::read_dir(staging).map_err(|e| format!("read staging dir: {e}"))?;
+    for entry in entries {
+        let entry = entry.map_err(|e| format!("read staging dir: {e}"))?;
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else {
+            continue;
+        };
+        if name.ends_with(TMP_SUFFIX) {
+            fs::remove_file(entry.path()).map_err(|e| format!("delete tmp file: {e}"))?;
+        } else if let Some(stem) = name.strip_suffix(SEQ_SUFFIX) {
+            let seq = stem
+                .parse::<u64>()
+                .map_err(|_| format!("unparseable sequenced file name: {name}"))?;
+            if seq <= flushed_frontier {
+                fs::remove_file(entry.path()).map_err(|e| format!("delete applied file: {e}"))?;
+            } else {
+                sequenced.insert(seq, entry.path());
+            }
+        }
+    }
+
+    let mut frontier = flushed_frontier;
+    while let Some(path) = sequenced.remove(&(frontier + 1)) {
+        frontier += 1;
+        replay_file(db, frontier, &path)?;
+    }
+    write_applied_marker(db, frontier)?;
+    // Anything left is past a gap: its wave's directory fsync never completed, so no caller was
+    // acked at or beyond it. Delete so the numbers can be reassigned.
+    for (_, path) in sequenced {
+        fs::remove_file(&path).map_err(|e| format!("delete unacked sequenced file: {e}"))?;
+    }
+    Ok(frontier)
+}
+
+/// Reapplies one sequenced flat file: verifies its checksum, decodes the staged payload, and
+/// applies it exactly as the in-memory path would have.
+fn replay_file(db: &DB, sequence: u64, path: &Path) -> Result<(), String> {
+    let bytes = fs::read(path).map_err(|e| format!("read sequenced file {path:?}: {e}"))?;
+    if bytes.len() < 4 {
+        return Err(format!("sequenced file {path:?} is truncated"));
+    }
+    let (payload, crc_bytes) = bytes.split_at(bytes.len() - 4);
+    let expected = u32::from_le_bytes(crc_bytes.try_into().unwrap());
+    if crc32fast::hash(payload) != expected {
+        return Err(format!(
+            "sequenced file {path:?} failed checksum verification"
+        ));
+    }
+    let kvs = if payload.is_empty() {
+        Vec::new()
+    } else {
+        StreamGetResponse::decode_from_slice(payload)
+            .map_err(|e| format!("decode sequenced file {path:?}: {e}"))?
+            .entries
+            .into_iter()
+            .map(|entry| (Bytes::from(entry.key), entry.value))
+            .collect()
+    };
+    let payload = (!payload.is_empty()).then(|| Arc::new(payload.to_vec()));
+    write_apply_batch(db, sequence, &kvs, payload.as_deref())
+}
+
+/// Writes one batch's current-state rows and replay-log row, WAL-less.
+fn write_apply_batch(
+    db: &DB,
+    sequence: u64,
+    kvs: &[(Bytes, Bytes)],
+    payload: Option<&Vec<u8>>,
+) -> Result<(), String> {
+    let mut batch = rocksdb::WriteBatch::default();
+    for (k, v) in kvs {
+        batch.put(k.as_ref(), v.as_ref());
+    }
+    if let Some(payload) = payload {
+        let log_cf = db
+            .cf_handle(LOG_CF)
+            .expect("log CF must exist (created on open)");
+        batch.put_cf(
+            log_cf,
+            sequence_log_key(sequence),
+            staged_value_with_sequence(sequence, payload),
+        );
+    }
+    let mut options = WriteOptions::default();
+    options.disable_wal(true);
+    db.write_opt(batch, &options).map_err(|e| e.to_string())
+}
+
+/// Records the contiguous applied frontier in the meta CF (WAL-less). Callers must keep marker
+/// writes monotone; with atomic flushes this guarantees a recovered marker never exceeds the
+/// recovered data.
+fn write_applied_marker(db: &DB, frontier: u64) -> Result<(), String> {
+    let meta_cf = db
+        .cf_handle(META_CF)
+        .expect("meta CF must exist (created on open)");
+    let mut batch = rocksdb::WriteBatch::default();
+    batch.put_cf(meta_cf, SEQ_META_KEY, frontier.to_le_bytes());
+    let mut options = WriteOptions::default();
+    options.disable_wal(true);
+    db.write_opt(batch, &options).map_err(|e| e.to_string())
+}
+
+/// Drains waves of durable uploads, assigns contiguous sequence numbers by rename, commits each
+/// wave with one directory fsync, acks the callers, and hands the batches to the appliers.
+fn run_sequencer(
+    shared: Arc<Shared>,
+    staging_dir: File,
+    receiver: mpsc::Receiver<Ticket>,
+    applier: mpsc::Sender<ApplyTask>,
+    max_tickets_per_wave: usize,
+) {
+    let mut next = shared.durable.load(Ordering::Acquire);
+    while let Ok(first) = receiver.recv() {
+        let mut wave = vec![first];
+        while wave.len() < max_tickets_per_wave {
+            match receiver.try_recv() {
+                Ok(ticket) => wave.push(ticket),
+                Err(_) => break,
+            }
+        }
+
+        // Rename every file in the wave, then make all the renames durable with one directory
+        // fsync before acking anyone. On failure the whole wave is failed and `next` is left
+        // unchanged: leftover renamed files are either overwritten when their numbers are
+        // reassigned or discarded as past-a-gap during recovery (no caller was acked).
+        let mut renamed = Vec::with_capacity(wave.len());
+        let mut failure: Option<String> = None;
+        let mut failed = Vec::new();
+        for ticket in wave {
+            if failure.is_some() {
+                failed.push(ticket);
+                continue;
+            }
+            let seq = next + renamed.len() as u64 + 1;
+            let seq_path = shared.staging.join(format!("{seq:020}{SEQ_SUFFIX}"));
+            match fs::rename(&ticket.tmp_path, &seq_path) {
+                Ok(()) => renamed.push((seq, ticket)),
+                Err(e) => {
+                    failure = Some(format!("rename staged file: {e}"));
+                    failed.push(ticket);
+                }
+            }
+        }
+        if failure.is_none() {
+            if let Err(e) = staging_dir.sync_all() {
+                failure = Some(format!("fsync staging dir: {e}"));
+            }
+        }
+        if let Some(failure) = failure {
+            for (_, ticket) in renamed {
+                let _ = ticket.response.send(Err(failure.clone()));
+            }
+            for ticket in failed {
+                let _ = ticket.response.send(Err(failure.clone()));
+            }
+            continue;
+        }
+
+        next += renamed.len() as u64;
+        // Publish durability before the acks so a reader racing an acked caller always gates on
+        // a frontier at least as high as that caller's sequence.
+        shared.durable.store(next, Ordering::Release);
+        debug!(requests = renamed.len(), sequence = next, "sequenced wave");
+        for (sequence, ticket) in renamed {
+            let Ticket {
+                kvs,
+                payload,
+                bytes,
+                response,
+                ..
+            } = ticket;
+            let _ = response.send(Ok(sequence));
+            // Bounded in-memory handoff: block (stalling subsequent waves, i.e. backpressuring
+            // ingest) while the appliers have too many bytes outstanding.
+            {
+                let mut queued = shared
+                    .queued_bytes
+                    .lock()
+                    .expect("apply queue lock poisoned");
+                while *queued > shared.max_queued_apply_bytes {
+                    queued = shared
+                        .queued_bytes_drained
+                        .wait(queued)
+                        .expect("apply queue lock poisoned");
+                }
+                *queued += bytes;
+            }
+            // If the appliers are gone the batch is still acked and durable in its flat file;
+            // the next open replays it.
+            if applier
+                .send(ApplyTask {
+                    sequence,
+                    kvs,
+                    payload,
+                    bytes,
+                })
+                .is_err()
+            {
+                return;
+            }
+        }
+    }
+}
+
+/// Applies sequenced batches to RocksDB and advances the contiguous applied frontier. On an
+/// unrecoverable error the thread marks the store failed and exits; acked data stays safe in the
+/// flat files and is replayed on the next open.
+fn run_applier(shared: Arc<Shared>, receiver: Arc<Mutex<mpsc::Receiver<ApplyTask>>>) {
+    loop {
+        let received = receiver
+            .lock()
+            .expect("apply receiver lock poisoned")
+            .recv();
+        let Ok(task) = received else {
+            return;
+        };
+        let result = write_apply_batch(
+            &shared.db,
+            task.sequence,
+            &task.kvs,
+            task.payload.as_deref(),
+        )
+        .and_then(|()| {
+            release_queued_bytes(&shared, task.bytes);
+            complete_apply(&shared, task.sequence, task.bytes as u64)
+        });
+        if let Err(e) = result {
+            error!(sequence = task.sequence, error = %e, "flatfile apply failed");
+            shared.apply_failed.store(true, Ordering::Relaxed);
+            // Wake gated readers so they observe the failure instead of waiting forever.
+            let current = *shared.applied_tx.borrow();
+            shared.applied_tx.send_replace(current);
+            return;
+        }
+    }
+}
+
+fn release_queued_bytes(shared: &Shared, bytes: usize) {
+    let mut queued = shared
+        .queued_bytes
+        .lock()
+        .expect("apply queue lock poisoned");
+    *queued = queued.saturating_sub(bytes);
+    shared.queued_bytes_drained.notify_all();
+}
+
+/// Marks one sequence applied, advances the contiguous frontier (persisting the marker and
+/// waking gated readers), and periodically runs the flush + file GC pass.
+fn complete_apply(shared: &Shared, sequence: u64, bytes: u64) -> Result<(), String> {
+    let mut gc_cutoff = None;
+    {
+        let mut progress = shared
+            .progress
+            .lock()
+            .expect("apply progress lock poisoned");
+        progress.completed.insert(sequence);
+        let mut frontier = *shared.applied_tx.borrow();
+        let mut advanced = false;
+        while progress.completed.remove(&(frontier + 1)) {
+            frontier += 1;
+            advanced = true;
+        }
+        progress.bytes_since_flush += bytes;
+        if advanced {
+            // Persist and publish under the lock so marker writes stay monotone.
+            write_applied_marker(&shared.db, frontier)?;
+            shared.applied_tx.send_replace(frontier);
+        }
+        if progress.bytes_since_flush >= shared.flush_gc_bytes && !progress.flush_running {
+            progress.flush_running = true;
+            progress.bytes_since_flush = 0;
+            gc_cutoff = Some(*shared.applied_tx.borrow());
+        }
+    }
+    if let Some(cutoff) = gc_cutoff {
+        // The atomic flush persists a marker >= cutoff, so files at or beneath it are no longer
+        // needed for recovery. Other appliers keep applying while this runs.
+        let result = flush_all_cfs(&shared.db);
+        if result.is_ok() {
+            gc_staging(&shared.staging, cutoff);
+        }
+        shared
+            .progress
+            .lock()
+            .expect("apply progress lock poisoned")
+            .flush_running = false;
+        result?;
+    }
+    Ok(())
+}
+
+/// Deletes sequenced flat files at or beneath the flushed frontier. Best-effort: anything left
+/// behind is cleaned up by the next open.
+fn gc_staging(staging: &Path, cutoff: u64) {
+    let Ok(entries) = fs::read_dir(staging) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else {
+            continue;
+        };
+        if let Some(stem) = name.strip_suffix(SEQ_SUFFIX) {
+            if let Ok(seq) = stem.parse::<u64>() {
+                if seq <= cutoff {
+                    let _ = fs::remove_file(entry.path());
+                }
+            }
+        }
+    }
+}
+
+impl Sequence for FlatFileRocksStore {
+    fn current_sequence(&self) -> u64 {
+        *self.applied_rx.borrow()
+    }
+}
+
+impl Ingest for FlatFileRocksStore {
+    async fn put_batch(&self, kvs: Vec<(Bytes, Bytes)>) -> Result<u64, String> {
+        // Phase 1 (parallel across callers): encode the batch into one checksummed flat file
+        // under a temporary name and fsync it. This is the only payload-sized durability cost.
+        let id = self.file_counter.fetch_add(1, Ordering::Relaxed);
+        let tmp_path = self.shared.staging.join(format!("{id:020}{TMP_SUFFIX}"));
+        let write_path = tmp_path.clone();
+        let (kvs, payload, bytes) = tokio::task::spawn_blocking(move || {
+            let payload = encode_staged_value(&kvs);
+            let payload_bytes = payload.as_deref().unwrap_or(&[]);
+            let crc = crc32fast::hash(payload_bytes);
+            let mut file = File::create(&write_path).map_err(|e| e.to_string())?;
+            file.write_all(payload_bytes).map_err(|e| e.to_string())?;
+            file.write_all(&crc.to_le_bytes())
+                .map_err(|e| e.to_string())?;
+            file.sync_all().map_err(|e| e.to_string())?;
+            let bytes = payload_bytes.len() + 64;
+            Ok::<_, String>((kvs, payload.map(Arc::new), bytes))
+        })
+        .await
+        .map_err(|e| format!("flatfile write task failed: {e}"))??;
+
+        // Phase 2: wait for the sequencer to rename the file to its sequence number and fsync
+        // the directory. The RocksDB apply happens after the ack, off the latency path.
+        let (response, result) = oneshot::channel();
+        self.pipeline
+            .sender
+            .lock()
+            .map_err(|e| format!("flatfile sequencer lock poisoned: {e}"))?
+            .as_ref()
+            .ok_or_else(|| "flatfile sequencer stopped".to_string())?
+            .send(Ticket {
+                tmp_path,
+                kvs,
+                payload,
+                bytes,
+                response,
+            })
+            .map_err(|_| "flatfile sequencer stopped".to_string())?;
+        result
+            .await
+            .map_err(|_| "flatfile sequencer stopped before sequencing write".to_string())?
+    }
+}
+
+impl Query for FlatFileRocksStore {
+    type RangeScan = RocksRangeScanCursor;
+
+    async fn get(&self, key: Bytes) -> Result<(Option<Bytes>, QueryExtra), String> {
+        self.wait_read_visible().await?;
+        self.db
+            .get(&key)
+            .map(|value| (value.map(Bytes::from), QueryExtra::default()))
+            .map_err(|e| e.to_string())
+    }
+
+    async fn range_scan(
+        &self,
+        start: Bytes,
+        end: Bytes,
+        limit: usize,
+        forward: bool,
+    ) -> Result<Self::RangeScan, String> {
+        self.wait_read_visible().await?;
+        Ok(RocksRangeScanCursor::new(
+            self.db.clone(),
+            start,
+            end,
+            limit,
+            forward,
+        ))
+    }
+
+    async fn get_many(
+        &self,
+        keys: Vec<Bytes>,
+    ) -> Result<(Vec<(Bytes, Option<Bytes>)>, QueryExtra), String> {
+        self.wait_read_visible().await?;
+        let results = self.db.multi_get(keys.iter().map(|key| key.as_ref()));
+        let entries = keys
+            .into_iter()
+            .zip(results)
+            .map(|(k, r)| {
+                let value = r.map_err(|e| e.to_string())?;
+                Ok((k, value.map(Bytes::from)))
+            })
+            .collect::<Result<Vec<_>, String>>()?;
+        Ok((entries, QueryExtra::default()))
+    }
+}
+
+impl Prune for FlatFileRocksStore {
+    async fn apply_prune_policies(&self, document: PrunePolicyDocument) -> Result<(), String> {
+        self.wait_read_visible().await?;
+        self.apply_prune_policies_inner(document)
+    }
+}
+
+impl Log for FlatFileRocksStore {
+    async fn get_batch(&self, sequence_number: u64) -> Result<Option<LogBatch>, String> {
+        // Only wait for batches that are known durable; anything beyond the acked frontier is
+        // legitimately not-found.
+        let durable = self.shared.durable.load(Ordering::Acquire);
+        self.wait_applied(sequence_number.min(durable)).await?;
+        let value = match self
+            .db
+            .get_cf(self.log_cf(), sequence_log_key(sequence_number))
+            .map_err(|e| e.to_string())?
+        {
+            Some(value) => value,
+            None => return Ok(None),
+        };
+        Ok(Some(LogBatch::from_response_bytes(sequence_number, value)))
+    }
+
+    async fn oldest_retained_batch(&self) -> Result<Option<u64>, String> {
+        self.wait_read_visible().await?;
+        let mut it = self.db.iterator_cf(self.log_cf(), IteratorMode::Start);
+        match it.next() {
+            None => Ok(None),
+            Some(item) => {
+                let (key, _) = item.map_err(|e| e.to_string())?;
+                sequence_from_log_key(key.as_ref()).map(Some)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeSet;
+
+    use tempfile::tempdir;
+
+    fn batch_entries(batch: LogBatch) -> Vec<(Bytes, Bytes)> {
+        batch
+            .decode_response()
+            .expect("decode batch response")
+            .entries
+            .into_iter()
+            .map(|entry| (Bytes::from(entry.key), entry.value))
+            .collect()
+    }
+
+    /// Writes a sequenced flat file the way a crashed process would have left it.
+    fn write_sequenced_file(staging: &Path, sequence: u64, kvs: &[(Bytes, Bytes)]) {
+        let payload = encode_staged_value(kvs).unwrap_or_default();
+        let crc = crc32fast::hash(&payload);
+        let mut bytes = payload;
+        bytes.extend_from_slice(&crc.to_le_bytes());
+        fs::write(staging.join(format!("{sequence:020}{SEQ_SUFFIX}")), bytes)
+            .expect("write sequenced file");
+    }
+
+    #[tokio::test]
+    async fn put_batch_assigns_monotonic_sequences_and_logs_batches() {
+        let dir = tempdir().expect("tempdir");
+        let store = FlatFileRocksStore::open(dir.path(), None).expect("open store");
+
+        let s1 = store
+            .put_batch(vec![(Bytes::from_static(b"a"), Bytes::from_static(b"1"))])
+            .await
+            .expect("put");
+        let s2 = store
+            .put_batch(vec![(Bytes::from_static(b"b"), Bytes::from_static(b"2"))])
+            .await
+            .expect("put");
+        assert_eq!(s1, 1);
+        assert_eq!(s2, 2);
+        assert_eq!(
+            store.get(Bytes::from_static(b"a")).await.expect("get").0,
+            Some(Bytes::from_static(b"1"))
+        );
+        assert_eq!(
+            batch_entries(store.get_batch(1).await.expect("get").expect("retained")),
+            vec![(Bytes::from_static(b"a"), Bytes::from_static(b"1"))]
+        );
+        assert_eq!(
+            batch_entries(store.get_batch(2).await.expect("get").expect("retained")),
+            vec![(Bytes::from_static(b"b"), Bytes::from_static(b"2"))]
+        );
+        assert_eq!(
+            store.oldest_retained_batch().await.expect("oldest"),
+            Some(1)
+        );
+        // Reads gated on the acked frontier, so by now it must be applied and published.
+        assert_eq!(store.current_sequence(), 2);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn concurrent_puts_keep_all_rows_in_sequence_logs() {
+        let dir = tempdir().expect("tempdir");
+        let store = FlatFileRocksStore::open(dir.path(), None).expect("open store");
+        let mut puts = Vec::new();
+        for i in 0u8..32 {
+            let store = store.clone();
+            puts.push(tokio::spawn(async move {
+                store
+                    .put_batch(vec![(Bytes::from(vec![i]), Bytes::from(vec![i + 1]))])
+                    .await
+                    .expect("put")
+            }));
+        }
+
+        let mut sequences = BTreeSet::new();
+        for put in puts {
+            sequences.insert(put.await.expect("put task"));
+        }
+        assert_eq!(sequences, (1..=32).collect::<BTreeSet<_>>());
+
+        let mut logged_keys = BTreeSet::new();
+        for sequence in 1..=32 {
+            let batch = store
+                .get_batch(sequence)
+                .await
+                .expect("get batch")
+                .expect("batch retained");
+            for (key, value) in batch_entries(batch) {
+                assert_eq!(value.as_ref(), &[key[0] + 1]);
+                assert_eq!(
+                    store.get(key.clone()).await.expect("get").0,
+                    Some(value.clone())
+                );
+                logged_keys.insert(key[0]);
+            }
+        }
+        assert_eq!(logged_keys, (0u8..32).collect::<BTreeSet<_>>());
+        assert_eq!(store.current_sequence(), 32);
+    }
+
+    #[tokio::test]
+    async fn empty_batches_take_a_sequence_number_without_a_log_row() {
+        let dir = tempdir().expect("tempdir");
+        let store = FlatFileRocksStore::open(dir.path(), None).expect("open store");
+        let s1 = store.put_batch(Vec::new()).await.expect("put");
+        assert_eq!(s1, 1);
+        assert!(store.get_batch(1).await.expect("get").is_none());
+        let s2 = store
+            .put_batch(vec![(Bytes::from_static(b"a"), Bytes::from_static(b"1"))])
+            .await
+            .expect("put");
+        assert_eq!(s2, 2);
+        assert!(store.get_batch(2).await.expect("get").is_some());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn state_persists_across_reopen() {
+        let dir = tempdir().expect("tempdir");
+        {
+            let store = FlatFileRocksStore::open(dir.path(), None).expect("open store");
+            let mut puts = Vec::new();
+            for i in 0u8..16 {
+                let store = store.clone();
+                puts.push(tokio::spawn(async move {
+                    store
+                        .put_batch(vec![(Bytes::from(vec![i]), Bytes::from(vec![i + 1]))])
+                        .await
+                        .expect("put")
+                }));
+            }
+            let mut sequences = BTreeSet::new();
+            for put in puts {
+                sequences.insert(put.await.expect("put task"));
+            }
+            assert_eq!(sequences, (1..=16).collect::<BTreeSet<_>>());
+        }
+
+        let reopened = FlatFileRocksStore::open(dir.path(), None).expect("reopen store");
+        assert_eq!(reopened.current_sequence(), 16);
+        let mut logged_keys = BTreeSet::new();
+        for sequence in 1..=16 {
+            let batch = reopened
+                .get_batch(sequence)
+                .await
+                .expect("get batch")
+                .expect("batch retained");
+            for (key, value) in batch_entries(batch) {
+                assert_eq!(value.as_ref(), &[key[0] + 1]);
+                assert_eq!(
+                    reopened.get(key.clone()).await.expect("get").0,
+                    Some(value.clone())
+                );
+                logged_keys.insert(key[0]);
+            }
+        }
+        assert_eq!(logged_keys, (0u8..16).collect::<BTreeSet<_>>());
+        let s17 = reopened
+            .put_batch(vec![(Bytes::from_static(b"z"), Bytes::from_static(b"9"))])
+            .await
+            .expect("put");
+        assert_eq!(s17, 17);
+    }
+
+    #[tokio::test]
+    async fn open_replays_staged_files_and_discards_junk() {
+        let dir = tempdir().expect("tempdir");
+        {
+            let store = FlatFileRocksStore::open(dir.path(), None).expect("open store");
+            store
+                .put_batch(vec![(Bytes::from_static(b"a"), Bytes::from_static(b"1"))])
+                .await
+                .expect("put");
+            store
+                .put_batch(vec![(Bytes::from_static(b"b"), Bytes::from_static(b"2"))])
+                .await
+                .expect("put");
+        }
+        let staging = dir.path().join(STAGING_DIR);
+        // Model a crash: sequence 3 was renamed + fsynced (acked) but never applied; sequence 5
+        // is past a gap (its wave's dir fsync never completed, nobody was acked); one upload
+        // never got sequenced at all.
+        write_sequenced_file(
+            &staging,
+            3,
+            &[(Bytes::from_static(b"c"), Bytes::from_static(b"3"))],
+        );
+        write_sequenced_file(
+            &staging,
+            5,
+            &[(Bytes::from_static(b"x"), Bytes::from_static(b"x"))],
+        );
+        fs::write(staging.join(format!("{:020}{TMP_SUFFIX}", 99)), b"junk").expect("write tmp");
+
+        let reopened = FlatFileRocksStore::open(dir.path(), None).expect("reopen store");
+        assert_eq!(reopened.current_sequence(), 3);
+        assert_eq!(
+            reopened.get(Bytes::from_static(b"c")).await.expect("get").0,
+            Some(Bytes::from_static(b"3"))
+        );
+        assert_eq!(
+            batch_entries(reopened.get_batch(3).await.expect("get").expect("retained")),
+            vec![(Bytes::from_static(b"c"), Bytes::from_static(b"3"))]
+        );
+        // The gap file and the unsequenced upload are gone; their data never becomes visible.
+        assert_eq!(
+            reopened.get(Bytes::from_static(b"x")).await.expect("get").0,
+            None
+        );
+        assert!(!staging.join(format!("{:020}{SEQ_SUFFIX}", 5)).exists());
+        assert!(!staging.join(format!("{:020}{TMP_SUFFIX}", 99)).exists());
+        // Sequence 4 (the gap) and 5 are reassigned to new writes.
+        let s4 = reopened
+            .put_batch(vec![(Bytes::from_static(b"d"), Bytes::from_static(b"4"))])
+            .await
+            .expect("put");
+        assert_eq!(s4, 4);
+    }
+
+    #[tokio::test]
+    async fn open_rejects_corrupt_sequenced_files() {
+        let dir = tempdir().expect("tempdir");
+        {
+            let store = FlatFileRocksStore::open(dir.path(), None).expect("open store");
+            store
+                .put_batch(vec![(Bytes::from_static(b"a"), Bytes::from_static(b"1"))])
+                .await
+                .expect("put");
+        }
+        let staging = dir.path().join(STAGING_DIR);
+        let payload = encode_staged_value(&[(Bytes::from_static(b"c"), Bytes::from_static(b"3"))])
+            .expect("payload");
+        let mut bytes = payload;
+        bytes.extend_from_slice(&0xDEADBEEFu32.to_le_bytes());
+        fs::write(staging.join(format!("{:020}{SEQ_SUFFIX}", 2)), bytes).expect("write corrupt");
+
+        let error = match FlatFileRocksStore::open(dir.path(), None) {
+            Ok(_) => panic!("open must fail on a corrupt sequenced file"),
+            Err(error) => error,
+        };
+        assert!(error.contains("checksum"), "unexpected error: {error}");
+    }
+
+    #[tokio::test]
+    async fn sequence_prune_removes_log_rows_but_not_state() {
+        let dir = tempdir().expect("tempdir");
+        let store = FlatFileRocksStore::open(dir.path(), None).expect("open store");
+        for i in 0u8..3 {
+            store
+                .put_batch(vec![(Bytes::from(vec![i]), Bytes::from(vec![i]))])
+                .await
+                .expect("put");
+        }
+
+        store.prune_log(3).expect("prune");
+
+        assert!(store.get_batch(1).await.expect("get").is_none());
+        assert!(store.get_batch(2).await.expect("get").is_none());
+        assert!(store.get_batch(3).await.expect("get").is_some());
+        assert_eq!(
+            store.oldest_retained_batch().await.expect("oldest"),
+            Some(3)
+        );
+        assert_eq!(
+            store.get(Bytes::from(vec![0u8])).await.expect("get").0,
+            Some(Bytes::from(vec![0u8]))
+        );
+    }
+}

--- a/examples/simulator/src/lib.rs
+++ b/examples/simulator/src/lib.rs
@@ -5,7 +5,7 @@ pub mod server;
 pub mod unordered;
 
 pub use exoware_server::{connect_stack, AppState, Ingest, Log, Prune, Query, Sequence};
-pub use rocks::{RocksConfig, RocksStore, RocksWritePipelineConfig};
+pub use rocks::{CommitDurability, RocksConfig, RocksStore, RocksWritePipelineConfig};
 pub use rocksdb;
 pub use server::{run, spawn_for_test, CMD, RUN_CMD};
 pub use unordered::{UnorderedRocksConfig, UnorderedRocksStore};

--- a/examples/simulator/src/lib.rs
+++ b/examples/simulator/src/lib.rs
@@ -1,4 +1,9 @@
 //! In-process store API simulator (naive RocksDB).
+//!
+//! The server (`run` / `spawn_for_test`) uses [`UnorderedRocksStore`] with
+//! [`CommitDurability::NoWalFlush`]: concurrent WAL-less data writes with sequence numbers
+//! assigned after the fact, made durable per commit wave by one atomic memtable flush. The
+//! ordered [`RocksStore`] pipeline remains available as a library type.
 
 pub mod rocks;
 pub mod server;

--- a/examples/simulator/src/lib.rs
+++ b/examples/simulator/src/lib.rs
@@ -2,8 +2,10 @@
 
 pub mod rocks;
 pub mod server;
+pub mod unordered;
 
 pub use exoware_server::{connect_stack, AppState, Ingest, Log, Prune, Query, Sequence};
 pub use rocks::{RocksConfig, RocksStore, RocksWritePipelineConfig};
 pub use rocksdb;
 pub use server::{run, spawn_for_test, CMD, RUN_CMD};
+pub use unordered::{UnorderedRocksConfig, UnorderedRocksStore};

--- a/examples/simulator/src/lib.rs
+++ b/examples/simulator/src/lib.rs
@@ -1,15 +1,19 @@
 //! In-process store API simulator (naive RocksDB).
 //!
-//! The server (`run` / `spawn_for_test`) uses [`UnorderedRocksStore`] with
-//! [`CommitDurability::NoWalFlush`]: concurrent WAL-less data writes with sequence numbers
-//! assigned after the fact, made durable per commit wave by one atomic memtable flush. The
-//! ordered [`RocksStore`] pipeline remains available as a library type.
+//! The server (`run` / `spawn_for_test`) uses [`FlatFileRocksStore`]: uploads are made durable
+//! as parallel checksummed flat files, sequence numbers are assigned by file renames committed
+//! with one directory fsync per wave, and a WAL-less RocksDB instance is populated
+//! asynchronously to serve reads (which gate on the applied frontier). The ordered
+//! [`RocksStore`] pipeline and the experimental [`UnorderedRocksStore`] remain available as
+//! library types.
 
+pub mod flatfile;
 pub mod rocks;
 pub mod server;
 pub mod unordered;
 
 pub use exoware_server::{connect_stack, AppState, Ingest, Log, Prune, Query, Sequence};
+pub use flatfile::{FlatFileConfig, FlatFileRocksStore};
 pub use rocks::{CommitDurability, RocksConfig, RocksStore, RocksWritePipelineConfig};
 pub use rocksdb;
 pub use server::{run, spawn_for_test, CMD, RUN_CMD};

--- a/examples/simulator/src/rocks.rs
+++ b/examples/simulator/src/rocks.rs
@@ -32,10 +32,10 @@ use rocksdb::{
 use tokio::sync::oneshot;
 use tracing::debug;
 
-const META_CF: &str = "meta";
-const SEQ_META_KEY: &[u8] = b"sequence";
-const LOG_CF: &str = "log";
-const LOG_BATCH_KEY_LEN: usize = 8;
+pub(crate) const META_CF: &str = "meta";
+pub(crate) const SEQ_META_KEY: &[u8] = b"sequence";
+pub(crate) const LOG_CF: &str = "log";
+pub(crate) const LOG_BATCH_KEY_LEN: usize = 8;
 const PRUNE_SCAN_BATCH_SIZE: usize = 4096;
 const DEFAULT_COMMIT_COALESCE_MAX_BATCH_BYTES: usize = 16 * 1024 * 1024;
 type RocksIterItem = Result<(Box<[u8]>, Box<[u8]>), rocksdb::Error>;
@@ -63,7 +63,7 @@ impl OwnedRocksIterator {
     }
 }
 
-struct RocksRangeScanState {
+pub(crate) struct RocksRangeScanState {
     iterator: OwnedRocksIterator,
     start: Bytes,
     end: Bytes,
@@ -75,7 +75,7 @@ struct RocksRangeScanState {
 
 impl RocksRangeScanState {
     /// Creates an iterator positioned at the first row that may belong to the requested range.
-    fn new(db: Arc<DB>, start: Bytes, end: Bytes, limit: usize, forward: bool) -> Self {
+    pub(crate) fn new(db: Arc<DB>, start: Bytes, end: Bytes, limit: usize, forward: bool) -> Self {
         let mode = if forward {
             IteratorMode::From(start.as_ref(), Direction::Forward)
         } else if end.is_empty() {
@@ -95,7 +95,7 @@ impl RocksRangeScanState {
     }
 
     /// Reads one page from the existing RocksDB iterator and stops at the range or item limit.
-    fn next_batch(&mut self, max_items: usize) -> Result<Vec<(Bytes, Bytes)>, String> {
+    pub(crate) fn next_batch(&mut self, max_items: usize) -> Result<Vec<(Bytes, Bytes)>, String> {
         if max_items == 0 || self.done {
             return Ok(Vec::new());
         }
@@ -143,7 +143,7 @@ pub struct RocksRangeScanCursor {
 
 impl RocksRangeScanCursor {
     /// Stores scan state in an `Option` so it can be moved into `spawn_blocking` per page.
-    fn new(db: Arc<DB>, start: Bytes, end: Bytes, limit: usize, forward: bool) -> Self {
+    pub(crate) fn new(db: Arc<DB>, start: Bytes, end: Bytes, limit: usize, forward: bool) -> Self {
         Self {
             state: Some(RocksRangeScanState::new(db, start, end, limit, forward)),
         }
@@ -169,7 +169,7 @@ impl RangeScan for RocksRangeScanCursor {
     }
 }
 
-struct KeyEntry {
+pub(crate) struct KeyEntry {
     key: Bytes,
     order_value: Vec<u8>,
 }
@@ -276,6 +276,60 @@ fn keys_to_delete(
         }
         RetainPolicy::DropAll => Ok(entries.iter().map(|e| e.key.clone()).collect()),
     }
+}
+
+/// Scans matching current keys in bounded chunks, groups them, and returns non-retained keys.
+/// Shared by the ordered and unordered stores' key-scoped prune policies.
+pub(crate) fn collect_key_prune_deletes(
+    db: Arc<DB>,
+    scope: &KeysScope,
+    retain: &RetainPolicy,
+) -> Result<Vec<Bytes>, String> {
+    let codec = KeyCodec::new(scope.selector.reserved_bits, scope.selector.prefix);
+    let regex = compile_payload_regex(&scope.selector.payload_regex)
+        .map_err(|e| format!("policy: {e}"))?;
+
+    let (start, end) = codec.prefix_bounds();
+    let mut rows = RocksRangeScanState::new(db, start, end, usize::MAX, true);
+    let mut groups: BTreeMap<Vec<u8>, Vec<KeyEntry>> = BTreeMap::new();
+
+    loop {
+        let batch = rows.next_batch(PRUNE_SCAN_BATCH_SIZE)?;
+        if batch.is_empty() {
+            break;
+        }
+
+        for (key, _value) in batch {
+            if !codec.matches(&key) {
+                continue;
+            }
+            let payload_len = codec.payload_capacity_bytes_for_key_len(key.len());
+            let payload = match codec.read_payload(&key, 0, payload_len) {
+                Ok(payload) => payload,
+                Err(_) => continue,
+            };
+            if !regex.is_match(&payload) {
+                continue;
+            }
+
+            let group_key = match extract_group_key(&payload, &regex, scope) {
+                Some(group_key) => group_key,
+                None => continue,
+            };
+            let order_value = extract_order_value(&payload, &regex, scope).unwrap_or_default();
+
+            groups
+                .entry(group_key)
+                .or_default()
+                .push(KeyEntry { key, order_value });
+        }
+    }
+
+    let mut all_deletes = Vec::new();
+    for (_group_key, entries) in groups {
+        all_deletes.extend(keys_to_delete(entries, scope, retain)?);
+    }
+    Ok(all_deletes)
 }
 
 struct WriteRequest {
@@ -820,50 +874,7 @@ impl RocksStore {
         scope: &KeysScope,
         retain: &RetainPolicy,
     ) -> Result<(), String> {
-        let codec = KeyCodec::new(scope.selector.reserved_bits, scope.selector.prefix);
-        let regex = compile_payload_regex(&scope.selector.payload_regex)
-            .map_err(|e| format!("policy: {e}"))?;
-
-        let (start, end) = codec.prefix_bounds();
-        let mut rows = RocksRangeScanState::new(self.db.clone(), start, end, usize::MAX, true);
-        let mut groups: BTreeMap<Vec<u8>, Vec<KeyEntry>> = BTreeMap::new();
-
-        loop {
-            let batch = rows.next_batch(PRUNE_SCAN_BATCH_SIZE)?;
-            if batch.is_empty() {
-                break;
-            }
-
-            for (key, _value) in batch {
-                if !codec.matches(&key) {
-                    continue;
-                }
-                let payload_len = codec.payload_capacity_bytes_for_key_len(key.len());
-                let payload = match codec.read_payload(&key, 0, payload_len) {
-                    Ok(payload) => payload,
-                    Err(_) => continue,
-                };
-                if !regex.is_match(&payload) {
-                    continue;
-                }
-
-                let group_key = match extract_group_key(&payload, &regex, scope) {
-                    Some(group_key) => group_key,
-                    None => continue,
-                };
-                let order_value = extract_order_value(&payload, &regex, scope).unwrap_or_default();
-
-                groups
-                    .entry(group_key)
-                    .or_default()
-                    .push(KeyEntry { key, order_value });
-            }
-        }
-
-        let mut all_deletes = Vec::new();
-        for (_group_key, entries) in groups {
-            all_deletes.extend(keys_to_delete(entries, scope, retain)?);
-        }
+        let all_deletes = collect_key_prune_deletes(self.db.clone(), scope, retain)?;
         self.delete_keys(&all_deletes).map_err(|e| e.to_string())
     }
 
@@ -976,12 +987,12 @@ impl Log for RocksStore {
 }
 
 /// Encodes a sequence number as a log-CF key that preserves numeric order in RocksDB.
-fn sequence_log_key(sequence: u64) -> [u8; LOG_BATCH_KEY_LEN] {
+pub(crate) fn sequence_log_key(sequence: u64) -> [u8; LOG_BATCH_KEY_LEN] {
     sequence.to_be_bytes()
 }
 
 /// Decodes a log-CF key back into the sequence number it indexes.
-fn sequence_from_log_key(key: &[u8]) -> Result<u64, String> {
+pub(crate) fn sequence_from_log_key(key: &[u8]) -> Result<u64, String> {
     if key.len() != LOG_BATCH_KEY_LEN {
         return Err(format!("log CF key has unexpected length {}", key.len()));
     }

--- a/examples/simulator/src/rocks.rs
+++ b/examples/simulator/src/rocks.rs
@@ -746,7 +746,7 @@ fn write_sequence_batch_no_wal(db: &DB, batch: rocksdb::WriteBatch) -> Result<()
 }
 
 /// Atomically flushes the default, meta, and log column families.
-fn flush_all_cfs(db: &DB) -> Result<(), String> {
+pub(crate) fn flush_all_cfs(db: &DB) -> Result<(), String> {
     let meta_cf = db
         .cf_handle(META_CF)
         .expect("meta CF must exist (created on open)");

--- a/examples/simulator/src/rocks.rs
+++ b/examples/simulator/src/rocks.rs
@@ -26,8 +26,8 @@ use exoware_server::{
 };
 use regex::bytes::Regex;
 use rocksdb::{
-    ColumnFamily, ColumnFamilyDescriptor, DBIterator, Direction, IteratorMode, Options,
-    WriteOptions, DB,
+    ColumnFamily, ColumnFamilyDescriptor, DBIterator, Direction, FlushOptions, IteratorMode,
+    Options, WriteOptions, DB,
 };
 use tokio::sync::oneshot;
 use tracing::debug;
@@ -381,9 +381,18 @@ impl Writer {
         let commit_db = db.clone();
         let commit_sequence = sequence.clone();
         let commit_epoch = epoch.clone();
+        let durability = write_pipeline.durability;
         let commit = thread::Builder::new()
             .name("simulator-rocks-commit".to_string())
-            .spawn(move || run_commit(commit_db, commit_sequence, commit_epoch, group_receiver))
+            .spawn(move || {
+                run_commit(
+                    commit_db,
+                    commit_sequence,
+                    commit_epoch,
+                    group_receiver,
+                    durability,
+                )
+            })
             .expect("failed to spawn RocksDB commit worker");
 
         let prepare = thread::Builder::new()
@@ -571,10 +580,11 @@ fn run_commit(
     sequence: Arc<AtomicU64>,
     epoch: Arc<AtomicU64>,
     receiver: mpsc::Receiver<PreparedWrite>,
+    durability: CommitDurability,
 ) {
     let mut committed = sequence.load(Ordering::Acquire);
     while let Ok(group) = receiver.recv() {
-        committed = commit_group(&db, &sequence, &epoch, committed, group);
+        committed = commit_group(&db, &sequence, &epoch, committed, group, durability);
     }
 }
 
@@ -585,6 +595,7 @@ fn commit_group(
     epoch: &AtomicU64,
     committed: u64,
     group: PreparedWrite,
+    durability: CommitDurability,
 ) -> u64 {
     if group.writes.is_empty() {
         return committed;
@@ -603,7 +614,7 @@ fn commit_group(
 
     let requests = group.writes.len();
     let batch_bytes = group.batch_bytes;
-    match write_prepared_group(db, group) {
+    match write_prepared_group(db, group, durability) {
         Ok((writes, last_sequence)) => {
             // Release so `current_sequence` readers only observe rows that are already durable.
             sequence.store(last_sequence, Ordering::Release);
@@ -626,11 +637,13 @@ fn commit_group(
     }
 }
 
-/// Commits one prepared group with a single synced write. Returns the group's writes alongside its
-/// last sequence number on success, or the writes and the error on failure.
+/// Commits one prepared group with a single synced write (or a WAL-less write plus atomic flush).
+/// Returns the group's writes alongside its last sequence number on success, or the writes and the
+/// error on failure.
 fn write_prepared_group(
     db: &DB,
     group: PreparedWrite,
+    durability: CommitDurability,
 ) -> Result<(Vec<AssignedWrite>, u64), (Vec<AssignedWrite>, String)> {
     let PreparedWrite { writes, batch, .. } = group;
     let last_sequence = match writes.last() {
@@ -641,7 +654,11 @@ fn write_prepared_group(
         Ok(batch) => batch,
         Err(error) => return Err((writes, error)),
     };
-    match write_sequence_batch(db, batch) {
+    let result = match durability {
+        CommitDurability::SyncWal => write_sequence_batch(db, batch),
+        CommitDurability::NoWalFlush => write_sequence_batch_no_wal(db, batch),
+    };
+    match result {
         Ok(()) => Ok((writes, last_sequence)),
         Err(error) => Err((writes, error)),
     }
@@ -715,6 +732,36 @@ fn write_sequence_batch(db: &DB, batch: rocksdb::WriteBatch) -> Result<(), Strin
         .map_err(|e| e.to_string())
 }
 
+/// Writes a sequence batch without the WAL, then atomically flushes every column family the batch
+/// touched so the group is durable (as SST files) before its sequence numbers are published.
+///
+/// Requires the DB to be opened with `set_atomic_flush(true)`: the tri-CF flush must land as one
+/// unit or a crash could persist the meta frontier without the data/log rows beneath it.
+fn write_sequence_batch_no_wal(db: &DB, batch: rocksdb::WriteBatch) -> Result<(), String> {
+    let mut write_options = WriteOptions::default();
+    write_options.disable_wal(true);
+    db.write_opt(batch, &write_options)
+        .map_err(|e| e.to_string())?;
+    flush_all_cfs(db)
+}
+
+/// Atomically flushes the default, meta, and log column families.
+fn flush_all_cfs(db: &DB) -> Result<(), String> {
+    let meta_cf = db
+        .cf_handle(META_CF)
+        .expect("meta CF must exist (created on open)");
+    let log_cf = db
+        .cf_handle(LOG_CF)
+        .expect("log CF must exist (created on open)");
+    let default_cf = db
+        .cf_handle(rocksdb::DEFAULT_COLUMN_FAMILY_NAME)
+        .expect("default CF must exist");
+    let mut flush_options = FlushOptions::default();
+    flush_options.set_wait(true);
+    db.flush_cfs_opt(&[&default_cf, &meta_cf, &log_cf], &flush_options)
+        .map_err(|e| e.to_string())
+}
+
 /// Sends the same assignment failure to every request in a wave.
 fn fail_requests(requests: Vec<WriteRequest>, error: String) {
     for request in requests {
@@ -736,11 +783,29 @@ fn complete_assigned_writes(writes: Vec<AssignedWrite>) {
     }
 }
 
+/// How a committed group is made durable before its sequence numbers are published.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum CommitDurability {
+    /// WAL-backed writes, fsync'd once per commit group (default).
+    #[default]
+    SyncWal,
+    /// WAL-less writes made durable by an atomic memtable flush per commit group.
+    ///
+    /// Every payload byte skips the WAL, halving the bytes that must reach the disk before an
+    /// ack; the ack barrier becomes one L0 file per column family per commit group instead of a
+    /// WAL fsync. Only sensible for large-batch ingest (hundreds of thousands of keys per put),
+    /// where each flush produces well-sized files. Under small-batch load it degrades into a
+    /// storm of tiny L0 files and compaction debt.
+    NoWalFlush,
+}
+
 /// Application-level write pipeline options used by [`RocksStore::open`].
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct RocksWritePipelineConfig {
     /// Soft maximum RocksDB `WriteBatch` size before cutting a prepared commit group.
     pub max_commit_batch_bytes: NonZeroUsize,
+    /// How each commit group is made durable before its callers are acked.
+    pub durability: CommitDurability,
 }
 
 impl Default for RocksWritePipelineConfig {
@@ -748,6 +813,7 @@ impl Default for RocksWritePipelineConfig {
         Self {
             max_commit_batch_bytes: NonZeroUsize::new(DEFAULT_COMMIT_COALESCE_MAX_BATCH_BYTES)
                 .expect("default commit batch byte limit must be nonzero"),
+            durability: CommitDurability::default(),
         }
     }
 }
@@ -790,6 +856,12 @@ impl RocksStore {
 
         db_options.create_if_missing(true);
         db_options.create_missing_column_families(true);
+        if write_pipeline.durability == CommitDurability::NoWalFlush {
+            // WAL-less durability publishes a frontier only after flushing all CFs touched by the
+            // commit group; the flush must be atomic across CFs or a crash could persist the meta
+            // frontier without the rows beneath it.
+            db_options.set_atomic_flush(true);
+        }
 
         let cf_default =
             ColumnFamilyDescriptor::new(rocksdb::DEFAULT_COLUMN_FAMILY_NAME, default_cf_options);
@@ -1160,6 +1232,7 @@ mod tests {
             RocksWritePipelineConfig {
                 max_commit_batch_bytes: NonZeroUsize::new(DEFAULT_COMMIT_COALESCE_MAX_BATCH_BYTES,)
                     .expect("nonzero"),
+                durability: CommitDurability::SyncWal,
             }
         );
         assert_eq!(
@@ -1258,7 +1331,14 @@ mod tests {
 
         // A group that cannot commit (modeled with an already-failed batch) at sequences 1 and 2.
         let (group, receivers) = failing_group(0, &[(1, b"a", b"1"), (2, b"b", b"2")], "disk full");
-        let committed = commit_group(&store.db, &store.sequence, &epoch, 0, group);
+        let committed = commit_group(
+            &store.db,
+            &store.sequence,
+            &epoch,
+            0,
+            group,
+            CommitDurability::SyncWal,
+        );
 
         // Nothing was published, and the epoch advanced so the abandoned numbers can be re-used.
         assert_eq!(committed, 0);
@@ -1275,7 +1355,14 @@ mod tests {
         let (write_x, result_x) = assigned_write_with_response(1, b"x", b"24");
         let (write_y, result_y) = assigned_write_with_response(2, b"y", b"25");
         let group = prepared_write(&store.db, 1, vec![write_x, write_y]);
-        let committed = commit_group(&store.db, &store.sequence, &epoch, committed, group);
+        let committed = commit_group(
+            &store.db,
+            &store.sequence,
+            &epoch,
+            committed,
+            group,
+            CommitDurability::SyncWal,
+        );
 
         assert_eq!(committed, 2);
         assert_eq!(store.current_sequence(), 2);
@@ -1300,7 +1387,14 @@ mod tests {
 
         let (write, result) = assigned_write_with_response(1, b"a", b"1");
         let group = prepared_write(&store.db, 0, vec![write]);
-        let committed = commit_group(&store.db, &store.sequence, &epoch, 0, group);
+        let committed = commit_group(
+            &store.db,
+            &store.sequence,
+            &epoch,
+            0,
+            group,
+            CommitDurability::SyncWal,
+        );
 
         assert_eq!(committed, 0);
         assert_eq!(store.current_sequence(), 0);
@@ -1322,7 +1416,14 @@ mod tests {
         for attempt in [b"first" as &[u8], b"second"] {
             let current = epoch.load(Ordering::Acquire);
             let (group, receivers) = failing_group(current, &[(1, b"k", b"v")], "boom");
-            let committed = commit_group(&store.db, &store.sequence, &epoch, 0, group);
+            let committed = commit_group(
+                &store.db,
+                &store.sequence,
+                &epoch,
+                0,
+                group,
+                CommitDurability::SyncWal,
+            );
             assert_eq!(
                 committed, 0,
                 "attempt {attempt:?} must not advance the frontier"
@@ -1337,7 +1438,14 @@ mod tests {
         let current = epoch.load(Ordering::Acquire);
         let (write, result) = assigned_write_with_response(1, b"k", b"v");
         let group = prepared_write(&store.db, current, vec![write]);
-        let committed = commit_group(&store.db, &store.sequence, &epoch, 0, group);
+        let committed = commit_group(
+            &store.db,
+            &store.sequence,
+            &epoch,
+            0,
+            group,
+            CommitDurability::SyncWal,
+        );
         assert_eq!(committed, 1);
         assert_eq!(result.await.expect("response"), Ok(1));
         assert_eq!(store.current_sequence(), 1);
@@ -1365,7 +1473,14 @@ mod tests {
         );
 
         let (failed, receivers) = failing_group(0, &[(1, b"k", b"failed")], "boom");
-        let committed = commit_group(&store.db, &store.sequence, &epoch, 0, failed);
+        let committed = commit_group(
+            &store.db,
+            &store.sequence,
+            &epoch,
+            0,
+            failed,
+            CommitDurability::SyncWal,
+        );
         assert_eq!(committed, 0);
         assert_eq!(store.current_sequence(), 0);
         assert_eq!(epoch.load(Ordering::Acquire), 1);
@@ -1375,7 +1490,14 @@ mod tests {
 
         let (write, result) = assigned_write_with_response(1, b"k", b"new");
         let group = prepared_write(&store.db, 1, vec![write]);
-        let committed = commit_group(&store.db, &store.sequence, &epoch, committed, group);
+        let committed = commit_group(
+            &store.db,
+            &store.sequence,
+            &epoch,
+            committed,
+            group,
+            CommitDurability::SyncWal,
+        );
 
         assert_eq!(committed, 1);
         assert_eq!(result.await.expect("response"), Ok(1));
@@ -1394,6 +1516,7 @@ mod tests {
             Some(RocksConfig {
                 write_pipeline: RocksWritePipelineConfig {
                     max_commit_batch_bytes: NonZeroUsize::new(1).expect("nonzero"),
+                    durability: CommitDurability::SyncWal,
                 },
                 ..Default::default()
             }),
@@ -1406,6 +1529,58 @@ mod tests {
             .expect("put");
         assert_eq!(sequence, 1);
         assert_eq!(store.current_sequence(), 1);
+    }
+
+    #[tokio::test]
+    async fn no_wal_flush_store_persists_across_reopen() {
+        let config = || RocksConfig {
+            write_pipeline: RocksWritePipelineConfig {
+                durability: CommitDurability::NoWalFlush,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let dir = tempdir().expect("tempdir");
+        {
+            let store = RocksStore::open(dir.path(), Some(config())).expect("open db");
+            let s1 = store
+                .put_batch(vec![(Bytes::from_static(b"a"), Bytes::from_static(b"1"))])
+                .await
+                .expect("put");
+            let s2 = store
+                .put_batch(vec![(Bytes::from_static(b"b"), Bytes::from_static(b"2"))])
+                .await
+                .expect("put");
+            assert_eq!(s1, 1);
+            assert_eq!(s2, 2);
+        }
+
+        // Durability came from the per-commit atomic flush, not the (disabled) WAL.
+        let reopened = RocksStore::open(dir.path(), Some(config())).expect("reopen db");
+        assert_eq!(reopened.current_sequence(), 2);
+        assert_eq!(
+            reopened.db.get(b"a").expect("get a").as_deref(),
+            Some(&b"1"[..])
+        );
+        assert_eq!(
+            reopened.db.get(b"b").expect("get b").as_deref(),
+            Some(&b"2"[..])
+        );
+        assert_eq!(
+            batch_entries(
+                reopened
+                    .get_batch(2)
+                    .await
+                    .expect("get batch")
+                    .expect("retained")
+            ),
+            vec![(Bytes::from_static(b"b"), Bytes::from_static(b"2"))]
+        );
+        let s3 = reopened
+            .put_batch(vec![(Bytes::from_static(b"c"), Bytes::from_static(b"3"))])
+            .await
+            .expect("put");
+        assert_eq!(s3, 3);
     }
 
     #[tokio::test]
@@ -1480,7 +1655,14 @@ mod tests {
 
         assert_eq!(prepared.writes.len(), 3);
         assert!(prepared.batch_bytes > 0);
-        let committed = commit_group(&store.db, &store.sequence, &epoch, 0, prepared);
+        let committed = commit_group(
+            &store.db,
+            &store.sequence,
+            &epoch,
+            0,
+            prepared,
+            CommitDurability::SyncWal,
+        );
         assert_eq!(committed, 3);
 
         assert_eq!(store.current_sequence(), 3);

--- a/examples/simulator/src/rocks.rs
+++ b/examples/simulator/src/rocks.rs
@@ -286,8 +286,8 @@ pub(crate) fn collect_key_prune_deletes(
     retain: &RetainPolicy,
 ) -> Result<Vec<Bytes>, String> {
     let codec = KeyCodec::new(scope.selector.reserved_bits, scope.selector.prefix);
-    let regex = compile_payload_regex(&scope.selector.payload_regex)
-        .map_err(|e| format!("policy: {e}"))?;
+    let regex =
+        compile_payload_regex(&scope.selector.payload_regex).map_err(|e| format!("policy: {e}"))?;
 
     let (start, end) = codec.prefix_bounds();
     let mut rows = RocksRangeScanState::new(db, start, end, usize::MAX, true);

--- a/examples/simulator/src/server.rs
+++ b/examples/simulator/src/server.rs
@@ -1,9 +1,10 @@
 //! HTTP server entrypoints.
 //!
-//! The server runs on [`UnorderedRocksStore`] with [`CommitDurability::NoWalFlush`]: data is
-//! written to RocksDB concurrently without a WAL, and sequence numbers are assigned after the
-//! fact by a sequencer whose atomic memtable flush is the durability barrier for each ack. This
-//! roughly doubles large-batch ingest throughput over the ordered WAL-backed pipeline (see
+//! The server runs on [`FlatFileRocksStore`]: uploads become durable as parallel checksummed
+//! flat files (fsync per upload, off the shared commit path), sequence numbers are assigned by
+//! renaming those files with one directory fsync per wave, and a WAL-less RocksDB instance is
+//! populated asynchronously to serve reads. This roughly triples large-batch ingest throughput
+//! over the ordered WAL-backed pipeline and cuts ack latency by ~4x (see
 //! `benches/ingest_load.rs`). The ordered [`crate::RocksStore`] remains available as a library
 //! type for callers that need strict same-key ordering between state and log.
 
@@ -18,8 +19,7 @@ use tracing::info;
 
 use exoware_server::{connect_stack, AppState};
 
-use crate::rocks::CommitDurability;
-use crate::unordered::{UnorderedRocksConfig, UnorderedRocksStore};
+use crate::flatfile::FlatFileRocksStore;
 
 pub const CMD: &str = "server";
 pub const RUN_CMD: &str = "run";
@@ -28,15 +28,9 @@ async fn health() -> &'static str {
     "ok"
 }
 
-/// Opens the simulator's engine: unordered ingest with WAL-less, flush-backed durability.
-fn open_engine(directory: &Path) -> Result<UnorderedRocksStore, rocksdb::Error> {
-    UnorderedRocksStore::open(
-        directory,
-        Some(UnorderedRocksConfig {
-            durability: CommitDurability::NoWalFlush,
-            ..Default::default()
-        }),
-    )
+/// Opens the simulator's engine: flat-file staged ingest with async WAL-less RocksDB apply.
+fn open_engine(directory: &Path) -> Result<FlatFileRocksStore, String> {
+    FlatFileRocksStore::open(directory, None)
 }
 
 /// Run the store simulator until the process is interrupted.

--- a/examples/simulator/src/server.rs
+++ b/examples/simulator/src/server.rs
@@ -1,4 +1,11 @@
 //! HTTP server entrypoints.
+//!
+//! The server runs on [`UnorderedRocksStore`] with [`CommitDurability::NoWalFlush`]: data is
+//! written to RocksDB concurrently without a WAL, and sequence numbers are assigned after the
+//! fact by a sequencer whose atomic memtable flush is the durability barrier for each ack. This
+//! roughly doubles large-batch ingest throughput over the ordered WAL-backed pipeline (see
+//! `benches/ingest_load.rs`). The ordered [`crate::RocksStore`] remains available as a library
+//! type for callers that need strict same-key ordering between state and log.
 
 use std::net::SocketAddr;
 use std::path::Path;
@@ -11,7 +18,8 @@ use tracing::info;
 
 use exoware_server::{connect_stack, AppState};
 
-use crate::RocksStore;
+use crate::rocks::CommitDurability;
+use crate::unordered::{UnorderedRocksConfig, UnorderedRocksStore};
 
 pub const CMD: &str = "server";
 pub const RUN_CMD: &str = "run";
@@ -20,12 +28,23 @@ async fn health() -> &'static str {
     "ok"
 }
 
+/// Opens the simulator's engine: unordered ingest with WAL-less, flush-backed durability.
+fn open_engine(directory: &Path) -> Result<UnorderedRocksStore, rocksdb::Error> {
+    UnorderedRocksStore::open(
+        directory,
+        Some(UnorderedRocksConfig {
+            durability: CommitDurability::NoWalFlush,
+            ..Default::default()
+        }),
+    )
+}
+
 /// Run the store simulator until the process is interrupted.
 pub async fn run(
     directory: &std::path::Path,
     port: u16,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    let engine = Arc::new(RocksStore::open(directory, None)?);
+    let engine = Arc::new(open_engine(directory)?);
     let state = AppState::new(engine);
     let connect = connect_stack(state);
 
@@ -45,7 +64,7 @@ pub async fn run(
 pub async fn spawn_for_test(
     data_dir: &Path,
 ) -> Result<(tokio::task::JoinHandle<()>, String), Box<dyn std::error::Error + Send + Sync>> {
-    let engine = Arc::new(RocksStore::open(data_dir, None)?);
+    let engine = Arc::new(open_engine(data_dir)?);
     let state = AppState::new(engine);
     let connect = connect_stack(state);
     let app = Router::new()

--- a/examples/simulator/src/server.rs
+++ b/examples/simulator/src/server.rs
@@ -4,7 +4,7 @@
 //! flat files (fsync per upload, off the shared commit path), sequence numbers are assigned by
 //! renaming those files with one directory fsync per wave, and a WAL-less RocksDB instance is
 //! populated asynchronously to serve reads. This roughly triples large-batch ingest throughput
-//! over the ordered WAL-backed pipeline and cuts ack latency by ~4x (see
+//! over the ordered WAL-backed pipeline and cuts ack latency by ~3x (see
 //! `benches/ingest_load.rs`). The ordered [`crate::RocksStore`] remains available as a library
 //! type for callers that need strict same-key ordering between state and log.
 

--- a/examples/simulator/src/unordered.rs
+++ b/examples/simulator/src/unordered.rs
@@ -21,17 +21,20 @@
 //! every batch at or beneath it is durable and queryable, so `min_sequence_number` reads and
 //! stream replay behave exactly as with the ordered store.
 //!
-//! Known semantic differences from the ordered pipeline (acceptable for an investigation
-//! prototype; see PR description for discussion):
+//! Known semantic differences from the ordered pipeline (acceptable for the simulator; see the
+//! PR description for discussion):
 //! - Two concurrent `put_batch` calls that write the *same key* may be applied to the
 //!   current-state CF in a different order than their assigned sequence numbers, so replaying the
 //!   log can disagree with the materialized state for racing same-key writers.
 //! - Data rows become visible to point/range reads as soon as the unsynced write lands (before
 //!   their sequence number is published). The ordered store has the same window, just narrower.
-//! - A crash (or a failed sequence assignment) can leave junk behind: data rows and staged
-//!   payloads whose write survived but whose sequence assignment never happened. These batches
-//!   were never acked and never published, so the sequence contract holds; the junk is simply
-//!   never referenced. No recovery/garbage-collection pass is attempted.
+//! - **Unsequenced keys**: a batch whose phase-1 write lands but whose sequence assignment never
+//!   completes (crash, failed pointer write) leaves its keys in the current state without any
+//!   sequence number referencing them. Such keys are readable by point/range queries but never
+//!   appear in the log or on a stream: replaying the log does not reproduce them. The caller was
+//!   never acked, so if it retries, the retry overwrites the same keys under a real sequence
+//!   number and the anomaly heals; if it never retries, the junk keys simply persist. No
+//!   recovery/garbage-collection pass is attempted.
 
 use std::num::NonZeroUsize;
 use std::path::Path;

--- a/examples/simulator/src/unordered.rs
+++ b/examples/simulator/src/unordered.rs
@@ -346,7 +346,8 @@ impl UnorderedRocksStore {
         for policy in &document.policies {
             match &policy.scope {
                 PolicyScope::Keys(scope) => {
-                    let deletes = collect_key_prune_deletes(self.db.clone(), scope, &policy.retain)?;
+                    let deletes =
+                        collect_key_prune_deletes(self.db.clone(), scope, &policy.retain)?;
                     self.delete_keys(&deletes).map_err(|e| e.to_string())?;
                 }
                 PolicyScope::Sequence => {
@@ -654,7 +655,10 @@ mod tests {
             batch_entries(store.get_batch(2).await.expect("get").expect("retained")),
             vec![(Bytes::from_static(b"b"), Bytes::from_static(b"2"))]
         );
-        assert_eq!(store.oldest_retained_batch().await.expect("oldest"), Some(1));
+        assert_eq!(
+            store.oldest_retained_batch().await.expect("oldest"),
+            Some(1)
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
@@ -732,11 +736,9 @@ mod tests {
             // pointer row or frontier update.
             let staged_cf = store.staged_cf();
             let orphan_ticket = [0xEEu8; TICKET_LEN];
-            let staged_value = encode_staged_value(&[(
-                Bytes::from_static(b"orphan"),
-                Bytes::from_static(b"o"),
-            )])
-            .expect("staged value");
+            let staged_value =
+                encode_staged_value(&[(Bytes::from_static(b"orphan"), Bytes::from_static(b"o"))])
+                    .expect("staged value");
             let mut batch = rocksdb::WriteBatch::default();
             batch.put(b"orphan", b"o");
             batch.put_cf(staged_cf, orphan_ticket, staged_value);
@@ -777,7 +779,10 @@ mod tests {
         assert!(store.get_batch(1).await.expect("get").is_none());
         assert!(store.get_batch(2).await.expect("get").is_none());
         assert!(store.get_batch(3).await.expect("get").is_some());
-        assert_eq!(store.oldest_retained_batch().await.expect("oldest"), Some(3));
+        assert_eq!(
+            store.oldest_retained_batch().await.expect("oldest"),
+            Some(3)
+        );
         // Staged payloads for pruned batches must be gone too.
         let staged_rows = store
             .db

--- a/examples/simulator/src/unordered.rs
+++ b/examples/simulator/src/unordered.rs
@@ -1,0 +1,793 @@
+//! Experimental "unordered ingest" storage for the simulator.
+//!
+//! The production [`crate::RocksStore`] serializes every ingest through a prepare/commit pipeline
+//! that assigns contiguous sequence numbers *before* the data is written and then commits each
+//! group with one synced write. This store inverts that: data is written to RocksDB concurrently
+//! (unordered, unsynced) and sequence numbers are assigned *after* the data write completes by a
+//! sequencer that fsyncs only a tiny pointer batch.
+//!
+//! Write path:
+//! 1. Each `put_batch` call generates a unique 16-byte ticket, then performs one unsynced,
+//!    WAL-backed RocksDB write containing its current-state rows (default CF) plus one staged
+//!    replay-log row keyed by the ticket (`staged` CF). Concurrent callers hit RocksDB directly,
+//!    so its internal write-group batching and concurrent memtable inserts apply.
+//! 2. A single sequencer thread drains completed tickets, assigns each the next contiguous
+//!    sequence number, and commits one synced write containing only `log[seq] = ticket` pointer
+//!    rows plus the sequence-frontier meta row. Because every write shares the RocksDB WAL, this
+//!    fsync also makes the (already written) data rows for those tickets durable: syncing the WAL
+//!    persists everything appended before it.
+//!
+//! Invariant preserved: a sequence number is only published (and returned to the caller) once
+//! every batch at or beneath it is durable and queryable, so `min_sequence_number` reads and
+//! stream replay behave exactly as with the ordered store.
+//!
+//! Known semantic differences from the ordered pipeline (acceptable for an investigation
+//! prototype; see PR description for discussion):
+//! - Two concurrent `put_batch` calls that write the *same key* may be applied to the
+//!   current-state CF in a different order than their assigned sequence numbers, so replaying the
+//!   log can disagree with the materialized state for racing same-key writers.
+//! - Data rows become visible to point/range reads as soon as the unsynced write lands (before
+//!   their sequence number is published). The ordered store has the same window, just narrower.
+//! - A crash can leave staged batches whose data write survived (via a later WAL sync) but whose
+//!   sequence assignment did not. [`UnorderedRocksStore::open`] adopts these orphans by assigning
+//!   them fresh sequence numbers, restoring the "no data without a sequence" invariant. A caller
+//!   that never received an ack may therefore observe its write published after a restart.
+
+use std::collections::HashSet;
+use std::num::NonZeroUsize;
+use std::path::Path;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{mpsc, Arc, Mutex};
+use std::thread;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use buffa::Message;
+use bytes::Bytes;
+use exoware_sdk::common::kv::v1::Entry;
+use exoware_sdk::log::stream::v1::GetResponse as StreamGetResponse;
+use exoware_sdk::prune_policy::{PolicyScope, PrunePolicyDocument, RetainPolicy};
+use exoware_server::{Ingest, Log, LogBatch, Prune, Query, QueryExtra, Sequence};
+use rocksdb::{ColumnFamily, ColumnFamilyDescriptor, IteratorMode, Options, WriteOptions, DB};
+use tokio::sync::oneshot;
+use tracing::debug;
+
+use crate::rocks::{
+    collect_key_prune_deletes, sequence_log_key, RocksRangeScanCursor, LOG_CF, META_CF,
+    SEQ_META_KEY,
+};
+
+const STAGED_CF: &str = "staged";
+const TICKET_LEN: usize = 16;
+const DEFAULT_MAX_TICKETS_PER_COMMIT: usize = 65_536;
+
+/// A completed unsynced data write waiting for its sequence number.
+struct Ticket {
+    id: [u8; TICKET_LEN],
+    /// False when the batch produced no replay-log payload (nothing staged).
+    staged: bool,
+    response: oneshot::Sender<Result<u64, String>>,
+}
+
+struct Sequencer {
+    sender: Mutex<Option<mpsc::Sender<Ticket>>>,
+    handle: Mutex<Option<thread::JoinHandle<()>>>,
+}
+
+impl Sequencer {
+    fn start(db: Arc<DB>, sequence: Arc<AtomicU64>, max_tickets_per_commit: usize) -> Self {
+        let (sender, receiver) = mpsc::channel();
+        let handle = thread::Builder::new()
+            .name("simulator-rocks-sequencer".to_string())
+            .spawn(move || run_sequencer(db, sequence, receiver, max_tickets_per_commit))
+            .expect("failed to spawn RocksDB sequencer");
+        Self {
+            sender: Mutex::new(Some(sender)),
+            handle: Mutex::new(Some(handle)),
+        }
+    }
+
+    fn submit(&self, ticket: Ticket) -> Result<(), String> {
+        self.sender
+            .lock()
+            .map_err(|e| format!("rocks sequencer lock poisoned: {e}"))?
+            .as_ref()
+            .ok_or_else(|| "rocks sequencer stopped".to_string())?
+            .send(ticket)
+            .map_err(|_| "rocks sequencer stopped".to_string())
+    }
+}
+
+impl Drop for Sequencer {
+    fn drop(&mut self) {
+        if let Ok(mut sender) = self.sender.lock() {
+            sender.take();
+        }
+        if let Ok(mut handle) = self.handle.lock() {
+            if let Some(handle) = handle.take() {
+                let _ = handle.join();
+            }
+        }
+    }
+}
+
+/// Drains waves of completed tickets, assigns contiguous sequence numbers in completion order,
+/// and publishes each wave with one small synced write.
+fn run_sequencer(
+    db: Arc<DB>,
+    sequence: Arc<AtomicU64>,
+    receiver: mpsc::Receiver<Ticket>,
+    max_tickets_per_commit: usize,
+) {
+    while let Ok(first) = receiver.recv() {
+        let mut tickets = vec![first];
+        while tickets.len() < max_tickets_per_commit {
+            match receiver.try_recv() {
+                Ok(ticket) => tickets.push(ticket),
+                Err(_) => break,
+            }
+        }
+        commit_tickets(&db, &sequence, tickets);
+    }
+}
+
+/// Assigns sequence numbers to one wave and commits the pointer rows + frontier with a synced
+/// write. On success the frontier is published and each caller receives its sequence number.
+fn commit_tickets(db: &DB, sequence: &AtomicU64, tickets: Vec<Ticket>) {
+    let base = sequence.load(Ordering::Acquire);
+    let Some(last) = base.checked_add(tickets.len() as u64) else {
+        fail_tickets(db, tickets, "rocks sequence number overflowed".to_string());
+        return;
+    };
+
+    let log_cf = db
+        .cf_handle(LOG_CF)
+        .expect("log CF must exist (created on open)");
+    let meta_cf = db
+        .cf_handle(META_CF)
+        .expect("meta CF must exist (created on open)");
+    let mut batch = rocksdb::WriteBatch::default();
+    for (offset, ticket) in tickets.iter().enumerate() {
+        if ticket.staged {
+            let seq = base + offset as u64 + 1;
+            batch.put_cf(log_cf, sequence_log_key(seq), ticket.id);
+        }
+    }
+    batch.put_cf(meta_cf, SEQ_META_KEY, last.to_le_bytes());
+
+    let mut options = WriteOptions::default();
+    options.set_sync(true);
+    match db.write_opt(batch, &options) {
+        Ok(()) => {
+            // Release so `current_sequence` readers only observe rows that are already durable.
+            sequence.store(last, Ordering::Release);
+            debug!(
+                requests = tickets.len(),
+                sequence = last,
+                "committed sequence assignment batch"
+            );
+            for (offset, ticket) in tickets.into_iter().enumerate() {
+                let _ = ticket.response.send(Ok(base + offset as u64 + 1));
+            }
+        }
+        Err(e) => fail_tickets(db, tickets, e.to_string()),
+    }
+}
+
+/// Fails every ticket in a wave and best-effort deletes their staged rows so a later restart does
+/// not adopt batches whose callers were already told the write failed.
+fn fail_tickets(db: &DB, tickets: Vec<Ticket>, error: String) {
+    let staged_cf = db
+        .cf_handle(STAGED_CF)
+        .expect("staged CF must exist (created on open)");
+    let mut cleanup = rocksdb::WriteBatch::default();
+    for ticket in &tickets {
+        if ticket.staged {
+            cleanup.delete_cf(staged_cf, ticket.id);
+        }
+    }
+    let _ = db.write(cleanup);
+    for ticket in tickets {
+        let _ = ticket.response.send(Err(error.clone()));
+    }
+}
+
+/// Options for [`UnorderedRocksStore::open`].
+pub struct UnorderedRocksConfig {
+    /// Database-wide options.
+    pub db_options: Options,
+    /// Options for the default column family, which stores the current key-value state.
+    pub default_cf_options: Options,
+    /// Options for the metadata column family.
+    pub meta_cf_options: Options,
+    /// Options for the sequence-pointer log column family.
+    pub log_cf_options: Options,
+    /// Options for the staged batch-payload column family.
+    pub staged_cf_options: Options,
+    /// Maximum tickets folded into one synced sequence-assignment write.
+    pub max_tickets_per_commit: NonZeroUsize,
+}
+
+impl Default for UnorderedRocksConfig {
+    fn default() -> Self {
+        Self {
+            db_options: Options::default(),
+            default_cf_options: Options::default(),
+            meta_cf_options: Options::default(),
+            log_cf_options: Options::default(),
+            staged_cf_options: Options::default(),
+            max_tickets_per_commit: NonZeroUsize::new(DEFAULT_MAX_TICKETS_PER_COMMIT)
+                .expect("default ticket commit limit must be nonzero"),
+        }
+    }
+}
+
+/// RocksDB-backed store that writes data concurrently and assigns sequence numbers afterwards.
+///
+/// Not wire-compatible with a database created by [`crate::RocksStore`]: the `log` column family
+/// holds ticket pointers here instead of encoded batch payloads.
+#[derive(Clone)]
+pub struct UnorderedRocksStore {
+    db: Arc<DB>,
+    sequence: Arc<AtomicU64>,
+    sequencer: Arc<Sequencer>,
+    boot_nonce: u64,
+    ticket_counter: Arc<AtomicU64>,
+}
+
+impl UnorderedRocksStore {
+    /// Open the store, creating column families as needed and adopting any staged batches that
+    /// were written before a crash but never assigned a sequence number.
+    pub fn open(path: &Path, config: Option<UnorderedRocksConfig>) -> Result<Self, rocksdb::Error> {
+        let UnorderedRocksConfig {
+            mut db_options,
+            default_cf_options,
+            meta_cf_options,
+            log_cf_options,
+            staged_cf_options,
+            max_tickets_per_commit,
+        } = config.unwrap_or_default();
+
+        db_options.create_if_missing(true);
+        db_options.create_missing_column_families(true);
+
+        let db = Arc::new(DB::open_cf_descriptors(
+            &db_options,
+            path,
+            vec![
+                ColumnFamilyDescriptor::new(
+                    rocksdb::DEFAULT_COLUMN_FAMILY_NAME,
+                    default_cf_options,
+                ),
+                ColumnFamilyDescriptor::new(META_CF, meta_cf_options),
+                ColumnFamilyDescriptor::new(LOG_CF, log_cf_options),
+                ColumnFamilyDescriptor::new(STAGED_CF, staged_cf_options),
+            ],
+        )?);
+        let meta_cf = db
+            .cf_handle(META_CF)
+            .expect("meta CF must exist (created on open)");
+        let mut seq = match db.get_cf(meta_cf, SEQ_META_KEY)? {
+            Some(bytes) if bytes.len() == 8 => u64::from_le_bytes(bytes.try_into().unwrap()),
+            _ => 0,
+        };
+        seq = adopt_orphaned_batches(&db, seq)?;
+
+        let sequence = Arc::new(AtomicU64::new(seq));
+        let sequencer = Arc::new(Sequencer::start(
+            db.clone(),
+            sequence.clone(),
+            max_tickets_per_commit.get(),
+        ));
+        let boot_nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_nanos() as u64)
+            .unwrap_or(0);
+        Ok(Self {
+            db,
+            sequence,
+            sequencer,
+            boot_nonce,
+            ticket_counter: Arc::new(AtomicU64::new(0)),
+        })
+    }
+
+    fn log_cf(&self) -> &ColumnFamily {
+        self.db
+            .cf_handle(LOG_CF)
+            .expect("log CF must exist (created on open)")
+    }
+
+    fn staged_cf(&self) -> &ColumnFamily {
+        self.db
+            .cf_handle(STAGED_CF)
+            .expect("staged CF must exist (created on open)")
+    }
+
+    fn next_ticket(&self) -> [u8; TICKET_LEN] {
+        let counter = self.ticket_counter.fetch_add(1, Ordering::Relaxed);
+        let mut id = [0u8; TICKET_LEN];
+        id[..8].copy_from_slice(&self.boot_nonce.to_be_bytes());
+        id[8..].copy_from_slice(&counter.to_be_bytes());
+        id
+    }
+
+    /// Deletes current rows without touching sequence metadata or the replay log.
+    fn delete_keys(&self, keys: &[Bytes]) -> Result<(), rocksdb::Error> {
+        if keys.is_empty() {
+            return Ok(());
+        }
+        let mut batch = rocksdb::WriteBatch::default();
+        for k in keys {
+            batch.delete(k.as_ref());
+        }
+        self.db.write(batch)
+    }
+
+    /// Deletes pointer rows below `cutoff_exclusive` together with their staged payloads.
+    fn prune_log(&self, cutoff_exclusive: u64) -> Result<(), String> {
+        if cutoff_exclusive == 0 {
+            return Ok(());
+        }
+        let log_cf = self.log_cf();
+        let staged_cf = self.staged_cf();
+        let mut batch = rocksdb::WriteBatch::default();
+        for item in self.db.iterator_cf(log_cf, IteratorMode::Start) {
+            let (key, ticket) = item.map_err(|e| e.to_string())?;
+            if key.as_ref() >= sequence_log_key(cutoff_exclusive).as_slice() {
+                break;
+            }
+            batch.delete_cf(staged_cf, ticket.as_ref());
+            batch.delete_cf(log_cf, key.as_ref());
+        }
+        self.db.write(batch).map_err(|e| e.to_string())
+    }
+
+    fn apply_prune_policies_inner(&self, document: PrunePolicyDocument) -> Result<(), String> {
+        for policy in &document.policies {
+            match &policy.scope {
+                PolicyScope::Keys(scope) => {
+                    let deletes = collect_key_prune_deletes(self.db.clone(), scope, &policy.retain)?;
+                    self.delete_keys(&deletes).map_err(|e| e.to_string())?;
+                }
+                PolicyScope::Sequence => {
+                    self.apply_sequence_prune_policy(&policy.retain)?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Computes the replay-log cutoff for a sequence policy and prunes only log rows.
+    fn apply_sequence_prune_policy(&self, retain: &RetainPolicy) -> Result<(), String> {
+        let current = self.sequence.load(Ordering::Acquire);
+        let cutoff_exclusive = match retain {
+            RetainPolicy::KeepLatest { count } => {
+                let count = *count as u64;
+                current.saturating_add(1).saturating_sub(count)
+            }
+            RetainPolicy::GreaterThan { threshold } => threshold.saturating_add(1),
+            RetainPolicy::GreaterThanOrEqual { threshold } => *threshold,
+            RetainPolicy::DropAll => current.saturating_add(1),
+        };
+        self.prune_log(cutoff_exclusive)
+    }
+}
+
+/// Assigns sequence numbers (with one synced write) to staged batches that have no pointer row.
+/// Phase-1 writes are atomic, so a surviving staged row implies its data rows survived with it;
+/// adopting the batch restores the invariant that all queryable data sits beneath the frontier.
+fn adopt_orphaned_batches(db: &Arc<DB>, mut seq: u64) -> Result<u64, rocksdb::Error> {
+    let log_cf = db
+        .cf_handle(LOG_CF)
+        .expect("log CF must exist (created on open)");
+    let staged_cf = db
+        .cf_handle(STAGED_CF)
+        .expect("staged CF must exist (created on open)");
+    let meta_cf = db
+        .cf_handle(META_CF)
+        .expect("meta CF must exist (created on open)");
+
+    let mut assigned = HashSet::new();
+    for item in db.iterator_cf(log_cf, IteratorMode::Start) {
+        let (_, ticket) = item?;
+        assigned.insert(ticket.to_vec());
+    }
+
+    let mut batch = rocksdb::WriteBatch::default();
+    let mut adopted = 0usize;
+    for item in db.iterator_cf(staged_cf, IteratorMode::Start) {
+        let (ticket, _) = item?;
+        if assigned.contains(ticket.as_ref()) {
+            continue;
+        }
+        seq = seq
+            .checked_add(1)
+            .expect("rocks sequence number overflowed during recovery");
+        batch.put_cf(log_cf, sequence_log_key(seq), ticket.as_ref());
+        adopted += 1;
+    }
+    if adopted == 0 {
+        return Ok(seq);
+    }
+    batch.put_cf(meta_cf, SEQ_META_KEY, seq.to_le_bytes());
+    let mut options = WriteOptions::default();
+    options.set_sync(true);
+    db.write_opt(batch, &options)?;
+    debug!(adopted, sequence = seq, "adopted orphaned staged batches");
+    Ok(seq)
+}
+
+/// Encodes the staged replay payload: a `log.stream.v1.GetResponse` with the sequence number
+/// left unset (it is unknown until assignment). Returns `None` when there is nothing to log.
+fn encode_staged_value(kvs: &[(Bytes, Bytes)]) -> Option<Vec<u8>> {
+    if kvs.is_empty() {
+        return None;
+    }
+    let entries = kvs
+        .iter()
+        .map(|(key, value)| Entry {
+            key: key.to_vec(),
+            value: value.clone(),
+            ..Default::default()
+        })
+        .collect::<Vec<_>>();
+    Some(
+        StreamGetResponse {
+            entries,
+            ..Default::default()
+        }
+        .encode_to_vec(),
+    )
+}
+
+/// Builds the wire bytes of a `GetResponse` with `sequence_number` set by prefixing the staged
+/// (sequence-less) encoding with the field-1 varint. Field 1 is always encoded first by the
+/// generator, so this is equivalent to re-encoding the message with the sequence filled in.
+fn staged_value_with_sequence(sequence: u64, staged: &[u8]) -> Vec<u8> {
+    let mut bytes = Vec::with_capacity(staged.len() + 11);
+    if sequence != 0 {
+        bytes.push(0x08); // field 1, varint wire type
+        let mut v = sequence;
+        while v >= 0x80 {
+            bytes.push((v as u8) | 0x80);
+            v >>= 7;
+        }
+        bytes.push(v as u8);
+    }
+    bytes.extend_from_slice(staged);
+    bytes
+}
+
+impl Sequence for UnorderedRocksStore {
+    fn current_sequence(&self) -> u64 {
+        self.sequence.load(Ordering::Acquire)
+    }
+}
+
+impl Ingest for UnorderedRocksStore {
+    async fn put_batch(&self, kvs: Vec<(Bytes, Bytes)>) -> Result<u64, String> {
+        let ticket = self.next_ticket();
+        let staged_value = encode_staged_value(&kvs);
+        let staged = staged_value.is_some();
+
+        // Phase 1: unsynced, WAL-backed write of the data rows plus the staged payload. Runs on
+        // the blocking pool so concurrent callers reach RocksDB's write groups in parallel.
+        let db = self.db.clone();
+        tokio::task::spawn_blocking(move || {
+            let mut batch = rocksdb::WriteBatch::default();
+            for (k, v) in &kvs {
+                batch.put(k.as_ref(), v.as_ref());
+            }
+            if let Some(staged_value) = staged_value {
+                let staged_cf = db
+                    .cf_handle(STAGED_CF)
+                    .expect("staged CF must exist (created on open)");
+                batch.put_cf(staged_cf, ticket, staged_value);
+            }
+            db.write(batch).map_err(|e| e.to_string())
+        })
+        .await
+        .map_err(|e| format!("rocks data write task failed: {e}"))??;
+
+        // Phase 2: hand the completed ticket to the sequencer and wait for the synced sequence
+        // assignment that publishes this batch.
+        let (response, result) = oneshot::channel();
+        self.sequencer.submit(Ticket {
+            id: ticket,
+            staged,
+            response,
+        })?;
+        result
+            .await
+            .map_err(|_| "rocks sequencer stopped before completing write".to_string())?
+    }
+}
+
+impl Query for UnorderedRocksStore {
+    type RangeScan = RocksRangeScanCursor;
+
+    async fn get(&self, key: Bytes) -> Result<(Option<Bytes>, QueryExtra), String> {
+        self.db
+            .get(&key)
+            .map(|value| (value.map(Bytes::from), QueryExtra::default()))
+            .map_err(|e| e.to_string())
+    }
+
+    async fn range_scan(
+        &self,
+        start: Bytes,
+        end: Bytes,
+        limit: usize,
+        forward: bool,
+    ) -> Result<Self::RangeScan, String> {
+        Ok(RocksRangeScanCursor::new(
+            self.db.clone(),
+            start,
+            end,
+            limit,
+            forward,
+        ))
+    }
+
+    async fn get_many(
+        &self,
+        keys: Vec<Bytes>,
+    ) -> Result<(Vec<(Bytes, Option<Bytes>)>, QueryExtra), String> {
+        let results = self.db.multi_get(keys.iter().map(|key| key.as_ref()));
+        let entries = keys
+            .into_iter()
+            .zip(results)
+            .map(|(k, r)| {
+                let value = r.map_err(|e| e.to_string())?;
+                Ok((k, value.map(Bytes::from)))
+            })
+            .collect::<Result<Vec<_>, String>>()?;
+        Ok((entries, QueryExtra::default()))
+    }
+}
+
+impl Prune for UnorderedRocksStore {
+    async fn apply_prune_policies(&self, document: PrunePolicyDocument) -> Result<(), String> {
+        self.apply_prune_policies_inner(document)
+    }
+}
+
+impl Log for UnorderedRocksStore {
+    async fn get_batch(&self, sequence_number: u64) -> Result<Option<LogBatch>, String> {
+        let ticket = match self
+            .db
+            .get_cf(self.log_cf(), sequence_log_key(sequence_number))
+            .map_err(|e| e.to_string())?
+        {
+            Some(ticket) => ticket,
+            None => return Ok(None),
+        };
+        let staged = match self
+            .db
+            .get_cf(self.staged_cf(), &ticket)
+            .map_err(|e| e.to_string())?
+        {
+            Some(staged) => staged,
+            None => return Ok(None),
+        };
+        Ok(Some(LogBatch::from_response_bytes(
+            sequence_number,
+            staged_value_with_sequence(sequence_number, &staged),
+        )))
+    }
+
+    async fn oldest_retained_batch(&self) -> Result<Option<u64>, String> {
+        let mut it = self.db.iterator_cf(self.log_cf(), IteratorMode::Start);
+        match it.next() {
+            None => Ok(None),
+            Some(item) => {
+                let (key, _) = item.map_err(|e| e.to_string())?;
+                crate::rocks::sequence_from_log_key(key.as_ref()).map(Some)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeSet;
+
+    use buffa::Message;
+    use tempfile::tempdir;
+
+    fn batch_entries(batch: LogBatch) -> Vec<(Bytes, Bytes)> {
+        batch
+            .decode_response()
+            .expect("decode batch response")
+            .entries
+            .into_iter()
+            .map(|entry| (Bytes::from(entry.key), entry.value))
+            .collect()
+    }
+
+    #[test]
+    fn staged_value_prefix_matches_reencoding() {
+        for sequence in [1u64, 127, 128, 300, u64::MAX] {
+            let kvs = vec![(Bytes::from_static(b"key"), Bytes::from_static(b"value"))];
+            let staged = encode_staged_value(&kvs).expect("staged value");
+            let combined = staged_value_with_sequence(sequence, &staged);
+            let expected = StreamGetResponse {
+                sequence_number: sequence,
+                entries: vec![Entry {
+                    key: b"key".to_vec(),
+                    value: Bytes::from_static(b"value"),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }
+            .encode_to_vec();
+            assert_eq!(combined, expected, "sequence {sequence}");
+        }
+    }
+
+    #[tokio::test]
+    async fn put_batch_assigns_monotonic_sequences_and_logs_batches() {
+        let dir = tempdir().expect("tempdir");
+        let store = UnorderedRocksStore::open(dir.path(), None).expect("open db");
+
+        let s1 = store
+            .put_batch(vec![(Bytes::from_static(b"a"), Bytes::from_static(b"1"))])
+            .await
+            .expect("put");
+        let s2 = store
+            .put_batch(vec![(Bytes::from_static(b"b"), Bytes::from_static(b"2"))])
+            .await
+            .expect("put");
+        assert_eq!(s1, 1);
+        assert_eq!(s2, 2);
+        assert_eq!(store.current_sequence(), 2);
+        assert_eq!(
+            store.get(Bytes::from_static(b"a")).await.expect("get").0,
+            Some(Bytes::from_static(b"1"))
+        );
+        assert_eq!(
+            batch_entries(store.get_batch(1).await.expect("get").expect("retained")),
+            vec![(Bytes::from_static(b"a"), Bytes::from_static(b"1"))]
+        );
+        assert_eq!(
+            batch_entries(store.get_batch(2).await.expect("get").expect("retained")),
+            vec![(Bytes::from_static(b"b"), Bytes::from_static(b"2"))]
+        );
+        assert_eq!(store.oldest_retained_batch().await.expect("oldest"), Some(1));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn concurrent_puts_keep_all_rows_in_sequence_logs() {
+        let dir = tempdir().expect("tempdir");
+        let store = UnorderedRocksStore::open(dir.path(), None).expect("open db");
+        let mut puts = Vec::new();
+        for i in 0u8..32 {
+            let store = store.clone();
+            puts.push(tokio::spawn(async move {
+                store
+                    .put_batch(vec![(Bytes::from(vec![i]), Bytes::from(vec![i + 1]))])
+                    .await
+                    .expect("put")
+            }));
+        }
+
+        let mut sequences = BTreeSet::new();
+        for put in puts {
+            sequences.insert(put.await.expect("put task"));
+        }
+        // Every request receives its own contiguous sequence number.
+        assert_eq!(sequences, (1..=32).collect::<BTreeSet<_>>());
+        assert_eq!(store.current_sequence(), 32);
+
+        let mut logged_keys = BTreeSet::new();
+        for sequence in 1..=32 {
+            let batch = store
+                .get_batch(sequence)
+                .await
+                .expect("get batch")
+                .expect("batch retained");
+            for (key, value) in batch_entries(batch) {
+                assert_eq!(value.as_ref(), &[key[0] + 1]);
+                logged_keys.insert(key[0]);
+            }
+        }
+        assert_eq!(logged_keys, (0u8..32).collect::<BTreeSet<_>>());
+    }
+
+    #[tokio::test]
+    async fn sequence_persists_across_reopen() {
+        let dir = tempdir().expect("tempdir");
+        {
+            let store = UnorderedRocksStore::open(dir.path(), None).expect("open db");
+            store
+                .put_batch(vec![(Bytes::from_static(b"a"), Bytes::from_static(b"1"))])
+                .await
+                .expect("put");
+            store
+                .put_batch(vec![(Bytes::from_static(b"b"), Bytes::from_static(b"2"))])
+                .await
+                .expect("put");
+        }
+        let reopened = UnorderedRocksStore::open(dir.path(), None).expect("reopen db");
+        assert_eq!(reopened.current_sequence(), 2);
+        let s3 = reopened
+            .put_batch(vec![(Bytes::from_static(b"c"), Bytes::from_static(b"3"))])
+            .await
+            .expect("put");
+        assert_eq!(s3, 3);
+    }
+
+    #[tokio::test]
+    async fn open_adopts_orphaned_staged_batches() {
+        let dir = tempdir().expect("tempdir");
+        {
+            let store = UnorderedRocksStore::open(dir.path(), None).expect("open db");
+            store
+                .put_batch(vec![(Bytes::from_static(b"a"), Bytes::from_static(b"1"))])
+                .await
+                .expect("put");
+
+            // Model a crash between phase 1 and phase 2: data + staged row durable, but no
+            // pointer row or frontier update.
+            let staged_cf = store.staged_cf();
+            let orphan_ticket = [0xEEu8; TICKET_LEN];
+            let staged_value = encode_staged_value(&[(
+                Bytes::from_static(b"orphan"),
+                Bytes::from_static(b"o"),
+            )])
+            .expect("staged value");
+            let mut batch = rocksdb::WriteBatch::default();
+            batch.put(b"orphan", b"o");
+            batch.put_cf(staged_cf, orphan_ticket, staged_value);
+            store.db.write(batch).expect("seed orphan");
+        }
+
+        let reopened = UnorderedRocksStore::open(dir.path(), None).expect("reopen db");
+        assert_eq!(reopened.current_sequence(), 2);
+        assert_eq!(
+            batch_entries(
+                reopened
+                    .get_batch(2)
+                    .await
+                    .expect("get")
+                    .expect("adopted batch retained")
+            ),
+            vec![(Bytes::from_static(b"orphan"), Bytes::from_static(b"o"))]
+        );
+        // Re-opening again must not adopt the same batch twice.
+        drop(reopened);
+        let reopened = UnorderedRocksStore::open(dir.path(), None).expect("reopen db again");
+        assert_eq!(reopened.current_sequence(), 2);
+    }
+
+    #[tokio::test]
+    async fn sequence_prune_removes_pointer_and_staged_rows() {
+        let dir = tempdir().expect("tempdir");
+        let store = UnorderedRocksStore::open(dir.path(), None).expect("open db");
+        for i in 0u8..3 {
+            store
+                .put_batch(vec![(Bytes::from(vec![i]), Bytes::from(vec![i]))])
+                .await
+                .expect("put");
+        }
+
+        store.prune_log(3).expect("prune");
+
+        assert!(store.get_batch(1).await.expect("get").is_none());
+        assert!(store.get_batch(2).await.expect("get").is_none());
+        assert!(store.get_batch(3).await.expect("get").is_some());
+        assert_eq!(store.oldest_retained_batch().await.expect("oldest"), Some(3));
+        // Staged payloads for pruned batches must be gone too.
+        let staged_rows = store
+            .db
+            .iterator_cf(store.staged_cf(), IteratorMode::Start)
+            .count();
+        assert_eq!(staged_rows, 1);
+        // Current-state rows are untouched by sequence pruning.
+        assert_eq!(
+            store.get(Bytes::from(vec![0u8])).await.expect("get").0,
+            Some(Bytes::from(vec![0u8]))
+        );
+    }
+}

--- a/examples/simulator/src/unordered.rs
+++ b/examples/simulator/src/unordered.rs
@@ -438,7 +438,7 @@ impl UnorderedRocksStore {
 
 /// Encodes the staged replay payload: a `log.stream.v1.GetResponse` with the sequence number
 /// left unset (it is unknown until assignment). Returns `None` when there is nothing to log.
-fn encode_staged_value(kvs: &[(Bytes, Bytes)]) -> Option<Vec<u8>> {
+pub(crate) fn encode_staged_value(kvs: &[(Bytes, Bytes)]) -> Option<Vec<u8>> {
     if kvs.is_empty() {
         return None;
     }
@@ -462,7 +462,7 @@ fn encode_staged_value(kvs: &[(Bytes, Bytes)]) -> Option<Vec<u8>> {
 /// Builds the wire bytes of a `GetResponse` with `sequence_number` set by prefixing the staged
 /// (sequence-less) encoding with the field-1 varint. Field 1 is always encoded first by the
 /// generator, so this is equivalent to re-encoding the message with the sequence filled in.
-fn staged_value_with_sequence(sequence: u64, staged: &[u8]) -> Vec<u8> {
+pub(crate) fn staged_value_with_sequence(sequence: u64, staged: &[u8]) -> Vec<u8> {
     let mut bytes = Vec::with_capacity(staged.len() + 11);
     if sequence != 0 {
         bytes.push(0x08); // field 1, varint wire type

--- a/examples/simulator/src/unordered.rs
+++ b/examples/simulator/src/unordered.rs
@@ -28,12 +28,11 @@
 //!   log can disagree with the materialized state for racing same-key writers.
 //! - Data rows become visible to point/range reads as soon as the unsynced write lands (before
 //!   their sequence number is published). The ordered store has the same window, just narrower.
-//! - A crash can leave staged batches whose data write survived (via a later WAL sync) but whose
-//!   sequence assignment did not. [`UnorderedRocksStore::open`] adopts these orphans by assigning
-//!   them fresh sequence numbers, restoring the "no data without a sequence" invariant. A caller
-//!   that never received an ack may therefore observe its write published after a restart.
+//! - A crash (or a failed sequence assignment) can leave junk behind: data rows and staged
+//!   payloads whose write survived but whose sequence assignment never happened. These batches
+//!   were never acked and never published, so the sequence contract holds; the junk is simply
+//!   never referenced. No recovery/garbage-collection pass is attempted.
 
-use std::collections::HashSet;
 use std::num::NonZeroUsize;
 use std::path::Path;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -47,13 +46,15 @@ use exoware_sdk::common::kv::v1::Entry;
 use exoware_sdk::log::stream::v1::GetResponse as StreamGetResponse;
 use exoware_sdk::prune_policy::{PolicyScope, PrunePolicyDocument, RetainPolicy};
 use exoware_server::{Ingest, Log, LogBatch, Prune, Query, QueryExtra, Sequence};
-use rocksdb::{ColumnFamily, ColumnFamilyDescriptor, IteratorMode, Options, WriteOptions, DB};
+use rocksdb::{
+    ColumnFamily, ColumnFamilyDescriptor, FlushOptions, IteratorMode, Options, WriteOptions, DB,
+};
 use tokio::sync::oneshot;
 use tracing::debug;
 
 use crate::rocks::{
-    collect_key_prune_deletes, sequence_log_key, RocksRangeScanCursor, LOG_CF, META_CF,
-    SEQ_META_KEY,
+    collect_key_prune_deletes, sequence_log_key, CommitDurability, RocksRangeScanCursor, LOG_CF,
+    META_CF, SEQ_META_KEY,
 };
 
 const STAGED_CF: &str = "staged";
@@ -74,11 +75,18 @@ struct Sequencer {
 }
 
 impl Sequencer {
-    fn start(db: Arc<DB>, sequence: Arc<AtomicU64>, max_tickets_per_commit: usize) -> Self {
+    fn start(
+        db: Arc<DB>,
+        sequence: Arc<AtomicU64>,
+        max_tickets_per_commit: usize,
+        durability: CommitDurability,
+    ) -> Self {
         let (sender, receiver) = mpsc::channel();
         let handle = thread::Builder::new()
             .name("simulator-rocks-sequencer".to_string())
-            .spawn(move || run_sequencer(db, sequence, receiver, max_tickets_per_commit))
+            .spawn(move || {
+                run_sequencer(db, sequence, receiver, max_tickets_per_commit, durability)
+            })
             .expect("failed to spawn RocksDB sequencer");
         Self {
             sender: Mutex::new(Some(sender)),
@@ -111,12 +119,13 @@ impl Drop for Sequencer {
 }
 
 /// Drains waves of completed tickets, assigns contiguous sequence numbers in completion order,
-/// and publishes each wave with one small synced write.
+/// and publishes each wave with one small synced write (or a WAL-less write plus atomic flush).
 fn run_sequencer(
     db: Arc<DB>,
     sequence: Arc<AtomicU64>,
     receiver: mpsc::Receiver<Ticket>,
     max_tickets_per_commit: usize,
+    durability: CommitDurability,
 ) {
     while let Ok(first) = receiver.recv() {
         let mut tickets = vec![first];
@@ -126,16 +135,27 @@ fn run_sequencer(
                 Err(_) => break,
             }
         }
-        commit_tickets(&db, &sequence, tickets);
+        commit_tickets(&db, &sequence, tickets, durability);
     }
 }
 
-/// Assigns sequence numbers to one wave and commits the pointer rows + frontier with a synced
-/// write. On success the frontier is published and each caller receives its sequence number.
-fn commit_tickets(db: &DB, sequence: &AtomicU64, tickets: Vec<Ticket>) {
+/// Assigns sequence numbers to one wave and commits the pointer rows + frontier. On success the
+/// frontier is published and each caller receives its sequence number.
+///
+/// With [`CommitDurability::SyncWal`] the pointer batch is written with `sync=true`: syncing the
+/// shared WAL also persists the (already written, unsynced) phase-1 data of every ticket in the
+/// wave. With [`CommitDurability::NoWalFlush`] nothing has touched the WAL; the pointer batch is
+/// written WAL-less and one atomic flush of all column families makes the wave durable. Each
+/// ticket's phase-1 write happened before it was submitted, so the flush covers the whole wave.
+fn commit_tickets(
+    db: &DB,
+    sequence: &AtomicU64,
+    tickets: Vec<Ticket>,
+    durability: CommitDurability,
+) {
     let base = sequence.load(Ordering::Acquire);
     let Some(last) = base.checked_add(tickets.len() as u64) else {
-        fail_tickets(db, tickets, "rocks sequence number overflowed".to_string());
+        fail_tickets(tickets, "rocks sequence number overflowed".to_string());
         return;
     };
 
@@ -155,8 +175,19 @@ fn commit_tickets(db: &DB, sequence: &AtomicU64, tickets: Vec<Ticket>) {
     batch.put_cf(meta_cf, SEQ_META_KEY, last.to_le_bytes());
 
     let mut options = WriteOptions::default();
-    options.set_sync(true);
-    match db.write_opt(batch, &options) {
+    let result = match durability {
+        CommitDurability::SyncWal => {
+            options.set_sync(true);
+            db.write_opt(batch, &options).map_err(|e| e.to_string())
+        }
+        CommitDurability::NoWalFlush => {
+            options.disable_wal(true);
+            db.write_opt(batch, &options)
+                .map_err(|e| e.to_string())
+                .and_then(|()| flush_all_cfs(db))
+        }
+    };
+    match result {
         Ok(()) => {
             // Release so `current_sequence` readers only observe rows that are already durable.
             sequence.store(last, Ordering::Release);
@@ -169,23 +200,37 @@ fn commit_tickets(db: &DB, sequence: &AtomicU64, tickets: Vec<Ticket>) {
                 let _ = ticket.response.send(Ok(base + offset as u64 + 1));
             }
         }
-        Err(e) => fail_tickets(db, tickets, e.to_string()),
+        Err(e) => fail_tickets(tickets, e),
     }
 }
 
-/// Fails every ticket in a wave and best-effort deletes their staged rows so a later restart does
-/// not adopt batches whose callers were already told the write failed.
-fn fail_tickets(db: &DB, tickets: Vec<Ticket>, error: String) {
+/// Atomically flushes every column family so all rows beneath the new frontier are durable as
+/// SST files. Requires the DB to be opened with `set_atomic_flush(true)`.
+fn flush_all_cfs(db: &DB) -> Result<(), String> {
+    let default_cf = db
+        .cf_handle(rocksdb::DEFAULT_COLUMN_FAMILY_NAME)
+        .expect("default CF must exist");
+    let meta_cf = db
+        .cf_handle(META_CF)
+        .expect("meta CF must exist (created on open)");
+    let log_cf = db
+        .cf_handle(LOG_CF)
+        .expect("log CF must exist (created on open)");
     let staged_cf = db
         .cf_handle(STAGED_CF)
         .expect("staged CF must exist (created on open)");
-    let mut cleanup = rocksdb::WriteBatch::default();
-    for ticket in &tickets {
-        if ticket.staged {
-            cleanup.delete_cf(staged_cf, ticket.id);
-        }
-    }
-    let _ = db.write(cleanup);
+    let mut flush_options = FlushOptions::default();
+    flush_options.set_wait(true);
+    db.flush_cfs_opt(
+        &[&default_cf, &meta_cf, &log_cf, &staged_cf],
+        &flush_options,
+    )
+    .map_err(|e| e.to_string())
+}
+
+/// Fails every ticket in a wave. Their data and staged rows are left behind as unreferenced junk:
+/// no sequence number ever points at them, so they are invisible to the log and harmless.
+fn fail_tickets(tickets: Vec<Ticket>, error: String) {
     for ticket in tickets {
         let _ = ticket.response.send(Err(error.clone()));
     }
@@ -205,6 +250,8 @@ pub struct UnorderedRocksConfig {
     pub staged_cf_options: Options,
     /// Maximum tickets folded into one synced sequence-assignment write.
     pub max_tickets_per_commit: NonZeroUsize,
+    /// How each sequence-assignment wave is made durable before its callers are acked.
+    pub durability: CommitDurability,
 }
 
 impl Default for UnorderedRocksConfig {
@@ -217,6 +264,7 @@ impl Default for UnorderedRocksConfig {
             staged_cf_options: Options::default(),
             max_tickets_per_commit: NonZeroUsize::new(DEFAULT_MAX_TICKETS_PER_COMMIT)
                 .expect("default ticket commit limit must be nonzero"),
+            durability: CommitDurability::default(),
         }
     }
 }
@@ -232,6 +280,7 @@ pub struct UnorderedRocksStore {
     sequencer: Arc<Sequencer>,
     boot_nonce: u64,
     ticket_counter: Arc<AtomicU64>,
+    durability: CommitDurability,
 }
 
 impl UnorderedRocksStore {
@@ -245,10 +294,17 @@ impl UnorderedRocksStore {
             log_cf_options,
             staged_cf_options,
             max_tickets_per_commit,
+            durability,
         } = config.unwrap_or_default();
 
         db_options.create_if_missing(true);
         db_options.create_missing_column_families(true);
+        if durability == CommitDurability::NoWalFlush {
+            // WAL-less durability publishes a frontier only after flushing all CFs; the flush
+            // must be atomic across CFs or a crash could persist the meta frontier without the
+            // data, log, and staged rows beneath it.
+            db_options.set_atomic_flush(true);
+        }
 
         let db = Arc::new(DB::open_cf_descriptors(
             &db_options,
@@ -266,17 +322,19 @@ impl UnorderedRocksStore {
         let meta_cf = db
             .cf_handle(META_CF)
             .expect("meta CF must exist (created on open)");
-        let mut seq = match db.get_cf(meta_cf, SEQ_META_KEY)? {
+        // Staged batches that survived a crash without a sequence assignment are left in place:
+        // they were never acked or published, so ignoring them preserves the sequence contract.
+        let seq = match db.get_cf(meta_cf, SEQ_META_KEY)? {
             Some(bytes) if bytes.len() == 8 => u64::from_le_bytes(bytes.try_into().unwrap()),
             _ => 0,
         };
-        seq = adopt_orphaned_batches(&db, seq)?;
 
         let sequence = Arc::new(AtomicU64::new(seq));
         let sequencer = Arc::new(Sequencer::start(
             db.clone(),
             sequence.clone(),
             max_tickets_per_commit.get(),
+            durability,
         ));
         let boot_nonce = SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -288,6 +346,7 @@ impl UnorderedRocksStore {
             sequencer,
             boot_nonce,
             ticket_counter: Arc::new(AtomicU64::new(0)),
+            durability,
         })
     }
 
@@ -374,50 +433,6 @@ impl UnorderedRocksStore {
     }
 }
 
-/// Assigns sequence numbers (with one synced write) to staged batches that have no pointer row.
-/// Phase-1 writes are atomic, so a surviving staged row implies its data rows survived with it;
-/// adopting the batch restores the invariant that all queryable data sits beneath the frontier.
-fn adopt_orphaned_batches(db: &Arc<DB>, mut seq: u64) -> Result<u64, rocksdb::Error> {
-    let log_cf = db
-        .cf_handle(LOG_CF)
-        .expect("log CF must exist (created on open)");
-    let staged_cf = db
-        .cf_handle(STAGED_CF)
-        .expect("staged CF must exist (created on open)");
-    let meta_cf = db
-        .cf_handle(META_CF)
-        .expect("meta CF must exist (created on open)");
-
-    let mut assigned = HashSet::new();
-    for item in db.iterator_cf(log_cf, IteratorMode::Start) {
-        let (_, ticket) = item?;
-        assigned.insert(ticket.to_vec());
-    }
-
-    let mut batch = rocksdb::WriteBatch::default();
-    let mut adopted = 0usize;
-    for item in db.iterator_cf(staged_cf, IteratorMode::Start) {
-        let (ticket, _) = item?;
-        if assigned.contains(ticket.as_ref()) {
-            continue;
-        }
-        seq = seq
-            .checked_add(1)
-            .expect("rocks sequence number overflowed during recovery");
-        batch.put_cf(log_cf, sequence_log_key(seq), ticket.as_ref());
-        adopted += 1;
-    }
-    if adopted == 0 {
-        return Ok(seq);
-    }
-    batch.put_cf(meta_cf, SEQ_META_KEY, seq.to_le_bytes());
-    let mut options = WriteOptions::default();
-    options.set_sync(true);
-    db.write_opt(batch, &options)?;
-    debug!(adopted, sequence = seq, "adopted orphaned staged batches");
-    Ok(seq)
-}
-
 /// Encodes the staged replay payload: a `log.stream.v1.GetResponse` with the sequence number
 /// left unset (it is unknown until assignment). Returns `None` when there is nothing to log.
 fn encode_staged_value(kvs: &[(Bytes, Bytes)]) -> Option<Vec<u8>> {
@@ -471,9 +486,11 @@ impl Ingest for UnorderedRocksStore {
         let staged_value = encode_staged_value(&kvs);
         let staged = staged_value.is_some();
 
-        // Phase 1: unsynced, WAL-backed write of the data rows plus the staged payload. Runs on
-        // the blocking pool so concurrent callers reach RocksDB's write groups in parallel.
+        // Phase 1: unsynced write of the data rows plus the staged payload (WAL-backed under
+        // SyncWal, WAL-less under NoWalFlush). Runs on the blocking pool so concurrent callers
+        // reach RocksDB's write groups in parallel.
         let db = self.db.clone();
+        let durability = self.durability;
         tokio::task::spawn_blocking(move || {
             let mut batch = rocksdb::WriteBatch::default();
             for (k, v) in &kvs {
@@ -485,7 +502,9 @@ impl Ingest for UnorderedRocksStore {
                     .expect("staged CF must exist (created on open)");
                 batch.put_cf(staged_cf, ticket, staged_value);
             }
-            db.write(batch).map_err(|e| e.to_string())
+            let mut options = WriteOptions::default();
+            options.disable_wal(durability == CommitDurability::NoWalFlush);
+            db.write_opt(batch, &options).map_err(|e| e.to_string())
         })
         .await
         .map_err(|e| format!("rocks data write task failed: {e}"))??;
@@ -722,8 +741,56 @@ mod tests {
         assert_eq!(s3, 3);
     }
 
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn no_wal_flush_store_persists_across_reopen() {
+        let config = || UnorderedRocksConfig {
+            durability: CommitDurability::NoWalFlush,
+            ..Default::default()
+        };
+        let dir = tempdir().expect("tempdir");
+        {
+            let store = UnorderedRocksStore::open(dir.path(), Some(config())).expect("open db");
+            let mut puts = Vec::new();
+            for i in 0u8..16 {
+                let store = store.clone();
+                puts.push(tokio::spawn(async move {
+                    store
+                        .put_batch(vec![(Bytes::from(vec![i]), Bytes::from(vec![i + 1]))])
+                        .await
+                        .expect("put")
+                }));
+            }
+            let mut sequences = BTreeSet::new();
+            for put in puts {
+                sequences.insert(put.await.expect("put task"));
+            }
+            assert_eq!(sequences, (1..=16).collect::<BTreeSet<_>>());
+        }
+
+        // Durability came from the per-wave atomic flush, not the (disabled) WAL.
+        let reopened = UnorderedRocksStore::open(dir.path(), Some(config())).expect("reopen db");
+        assert_eq!(reopened.current_sequence(), 16);
+        let mut logged_keys = BTreeSet::new();
+        for sequence in 1..=16 {
+            let batch = reopened
+                .get_batch(sequence)
+                .await
+                .expect("get batch")
+                .expect("batch retained");
+            for (key, value) in batch_entries(batch) {
+                assert_eq!(value.as_ref(), &[key[0] + 1]);
+                assert_eq!(
+                    reopened.get(key.clone()).await.expect("get").0,
+                    Some(value.clone())
+                );
+                logged_keys.insert(key[0]);
+            }
+        }
+        assert_eq!(logged_keys, (0u8..16).collect::<BTreeSet<_>>());
+    }
+
     #[tokio::test]
-    async fn open_adopts_orphaned_staged_batches() {
+    async fn open_ignores_orphaned_staged_batches() {
         let dir = tempdir().expect("tempdir");
         {
             let store = UnorderedRocksStore::open(dir.path(), None).expect("open db");
@@ -745,22 +812,19 @@ mod tests {
             store.db.write(batch).expect("seed orphan");
         }
 
+        // The orphan is junk: the frontier stays where the last ack left it, no sequence number
+        // points at the staged row, and a new write simply takes the next number.
         let reopened = UnorderedRocksStore::open(dir.path(), None).expect("reopen db");
-        assert_eq!(reopened.current_sequence(), 2);
+        assert_eq!(reopened.current_sequence(), 1);
+        let s2 = reopened
+            .put_batch(vec![(Bytes::from_static(b"b"), Bytes::from_static(b"2"))])
+            .await
+            .expect("put");
+        assert_eq!(s2, 2);
         assert_eq!(
-            batch_entries(
-                reopened
-                    .get_batch(2)
-                    .await
-                    .expect("get")
-                    .expect("adopted batch retained")
-            ),
-            vec![(Bytes::from_static(b"orphan"), Bytes::from_static(b"o"))]
+            batch_entries(reopened.get_batch(2).await.expect("get").expect("retained")),
+            vec![(Bytes::from_static(b"b"), Bytes::from_static(b"2"))]
         );
-        // Re-opening again must not adopt the same batch twice.
-        drop(reopened);
-        let reopened = UnorderedRocksStore::open(dir.path(), None).expect("reopen db again");
-        assert_eq!(reopened.current_sequence(), 2);
     }
 
     #[tokio::test]

--- a/examples/simulator/tests/e2e_connect.rs
+++ b/examples/simulator/tests/e2e_connect.rs
@@ -19,11 +19,17 @@ use exoware_sdk::{
 };
 use tempfile::tempdir;
 
-async fn spawn_client() -> (tokio::task::JoinHandle<()>, PrefixedStoreClient, String) {
+/// The returned [`tempfile::TempDir`] guard must be held for the duration of the test: dropping
+/// it deletes the data directory out from under the running server, whose engine keeps creating
+/// files in it.
+async fn spawn_client() -> (
+    tokio::task::JoinHandle<()>,
+    PrefixedStoreClient,
+    String,
+    tempfile::TempDir,
+) {
     let dir = tempdir().expect("tempdir");
-    let dir_path = dir.path().to_owned();
-    let _dir = dir;
-    let (handle, url) = exoware_simulator::spawn_for_test(&dir_path)
+    let (handle, url) = exoware_simulator::spawn_for_test(dir.path())
         .await
         .expect("spawn_for_test");
     let client = StoreClient::builder()
@@ -31,7 +37,7 @@ async fn spawn_client() -> (tokio::task::JoinHandle<()>, PrefixedStoreClient, St
         .retry_config(RetryConfig::disabled())
         .build()
         .expect("build client");
-    (handle, PrefixedStoreClient::empty(client), url)
+    (handle, PrefixedStoreClient::empty(client), url, dir)
 }
 
 fn key(b: &[u8]) -> Key {
@@ -42,7 +48,7 @@ fn key(b: &[u8]) -> Key {
 
 #[tokio::test]
 async fn put_and_get_round_trip() {
-    let (_h, client, _url) = spawn_client().await;
+    let (_h, client, _url, _dir) = spawn_client().await;
     let k = key(b"hello");
     let v = b"world";
     let seq = client.ingest().put(&[(&k, v)]).await.expect("put");
@@ -54,14 +60,14 @@ async fn put_and_get_round_trip() {
 
 #[tokio::test]
 async fn get_missing_key_returns_none() {
-    let (_h, client, _url) = spawn_client().await;
+    let (_h, client, _url, _dir) = spawn_client().await;
     let got = client.query().get(&key(b"nope")).await.expect("get");
     assert!(got.is_none());
 }
 
 #[tokio::test]
 async fn put_overwrites_value() {
-    let (_h, client, _url) = spawn_client().await;
+    let (_h, client, _url, _dir) = spawn_client().await;
     let k = key(b"k");
     client.ingest().put(&[(&k, b"v1")]).await.expect("put1");
     let seq2 = client.ingest().put(&[(&k, b"v2")]).await.expect("put2");
@@ -77,7 +83,7 @@ async fn put_overwrites_value() {
 
 #[tokio::test]
 async fn get_many_returns_found_and_missing() {
-    let (_h, client, _url) = spawn_client().await;
+    let (_h, client, _url, _dir) = spawn_client().await;
     let ka = key(b"a");
     let kb = key(b"b");
     let kc = key(b"c");
@@ -102,7 +108,7 @@ async fn get_many_returns_found_and_missing() {
 
 #[tokio::test]
 async fn range_forward() {
-    let (_h, client, _url) = spawn_client().await;
+    let (_h, client, _url, _dir) = spawn_client().await;
     let ka = key(b"ra");
     let kb = key(b"rb");
     let kc = key(b"rc");
@@ -123,7 +129,7 @@ async fn range_forward() {
 
 #[tokio::test]
 async fn range_reverse() {
-    let (_h, client, _url) = spawn_client().await;
+    let (_h, client, _url, _dir) = spawn_client().await;
     let ka = key(b"sa");
     let kb = key(b"sb");
     let kc = key(b"sc");
@@ -144,7 +150,7 @@ async fn range_reverse() {
 
 #[tokio::test]
 async fn range_with_limit() {
-    let (_h, client, _url) = spawn_client().await;
+    let (_h, client, _url, _dir) = spawn_client().await;
     let ka = key(b"la");
     let kb = key(b"lb");
     let kc = key(b"lc");
@@ -166,7 +172,7 @@ async fn range_with_limit() {
 
 #[tokio::test]
 async fn range_empty_result() {
-    let (_h, client, _url) = spawn_client().await;
+    let (_h, client, _url, _dir) = spawn_client().await;
     let rows = client
         .query()
         .range(&key(b"zzz_no"), &key(b"zzz_nz"), 100)
@@ -179,7 +185,7 @@ async fn range_empty_result() {
 
 #[tokio::test]
 async fn reduce_count_all() {
-    let (_h, client, _url) = spawn_client().await;
+    let (_h, client, _url, _dir) = spawn_client().await;
     let ka = key(b"ca");
     let kb = key(b"cb");
     let kc = key(b"cc");
@@ -210,7 +216,7 @@ async fn reduce_count_all() {
 
 #[tokio::test]
 async fn reduce_sum_int64() {
-    let (_h, client, _url) = spawn_client().await;
+    let (_h, client, _url, _dir) = spawn_client().await;
     let ka = key(b"ua");
     let kb = key(b"ub");
     let kc = key(b"uc");
@@ -256,7 +262,7 @@ async fn reduce_sum_int64() {
 
 #[tokio::test]
 async fn prune_drop_all_removes_keys() {
-    let (_h, client, url) = spawn_client().await;
+    let (_h, client, url, _dir) = spawn_client().await;
 
     let codec = KeyCodec::new(4, 1);
     let ka = codec.encode(b"aaa").expect("encode key a");
@@ -316,7 +322,7 @@ async fn prune_drop_all_removes_keys() {
 
 #[tokio::test]
 async fn create_session_with_sequence_reads_at_or_above_floor() {
-    let (_h, client, _url) = spawn_client().await;
+    let (_h, client, _url, _dir) = spawn_client().await;
     let k1 = key(b"s1");
     let k2 = key(b"s2");
     let seq1 = client.ingest().put(&[(&k1, b"v1")]).await.expect("put1");
@@ -332,7 +338,7 @@ async fn create_session_with_sequence_reads_at_or_above_floor() {
 
 #[tokio::test]
 async fn health_endpoint() {
-    let (_h, client, _url) = spawn_client().await;
+    let (_h, client, _url, _dir) = spawn_client().await;
     assert!(client.client().health().await.expect("health"));
 }
 
@@ -340,7 +346,7 @@ async fn health_endpoint() {
 
 #[tokio::test]
 async fn put_batch_multiple_keys() {
-    let (_h, client, _url) = spawn_client().await;
+    let (_h, client, _url, _dir) = spawn_client().await;
     let ka = key(b"ba");
     let kb = key(b"bb");
     let kc = key(b"bc");
@@ -368,7 +374,7 @@ async fn put_batch_multiple_keys() {
 
 #[tokio::test]
 async fn range_stream_collects_all() {
-    let (_h, client, _url) = spawn_client().await;
+    let (_h, client, _url, _dir) = spawn_client().await;
     let ka = key(b"xa");
     let kb = key(b"xb");
     let kc = key(b"xc");
@@ -394,7 +400,7 @@ async fn range_stream_collects_all() {
 
 #[tokio::test]
 async fn get_with_min_sequence_number() {
-    let (_h, client, _url) = spawn_client().await;
+    let (_h, client, _url, _dir) = spawn_client().await;
     let k = key(b"msn");
     let seq = client.ingest().put(&[(&k, b"val")]).await.expect("put");
     let got = client
@@ -409,7 +415,7 @@ async fn get_with_min_sequence_number() {
 
 #[tokio::test]
 async fn prune_keep_latest_retains_newest() {
-    let (_h, client, url) = spawn_client().await;
+    let (_h, client, url, _dir) = spawn_client().await;
 
     let codec = KeyCodec::new(4, 2);
     // Keys: prefix(4bits,family=2) + logical(3 bytes) + \x00\x00 + version(8 bytes big-endian u64)
@@ -502,7 +508,7 @@ async fn prune_keep_latest_retains_newest() {
 
 #[tokio::test]
 async fn reduce_count_min_max_field() {
-    let (_h, client, _url) = spawn_client().await;
+    let (_h, client, _url, _dir) = spawn_client().await;
     let encode_row = |v: i64| -> Vec<u8> {
         StoredRow {
             values: vec![Some(StoredValue::Int64(v))],
@@ -558,7 +564,7 @@ async fn reduce_count_min_max_field() {
 
 #[tokio::test]
 async fn reduce_grouped_count() {
-    let (_h, client, _url) = spawn_client().await;
+    let (_h, client, _url, _dir) = spawn_client().await;
     let codec = KeyCodec::new(4, 1);
     let encode_row = |v: i64| -> Vec<u8> {
         StoredRow {
@@ -604,7 +610,7 @@ async fn reduce_grouped_count() {
 
 #[tokio::test]
 async fn store_client_prune_drop_all() {
-    let (_h, client, _url) = spawn_client().await;
+    let (_h, client, _url, _dir) = spawn_client().await;
 
     let codec = KeyCodec::new(4, 5);
     let ka = codec.encode(b"pa").expect("encode");
@@ -641,7 +647,7 @@ async fn store_client_prune_drop_all() {
 
 #[tokio::test]
 async fn prune_greater_than_retains_above_threshold() {
-    let (_h, client, url) = spawn_client().await;
+    let (_h, client, url, _dir) = spawn_client().await;
 
     let codec = KeyCodec::new(4, 3);
     let make_key = |logical: &[u8; 2], version: u64| -> Key {

--- a/examples/simulator/tests/e2e_stream.rs
+++ b/examples/simulator/tests/e2e_stream.rs
@@ -9,11 +9,16 @@ use exoware_sdk::stream_filter::StreamFilter;
 use exoware_sdk::{PrefixedStoreClient, RetryConfig, StoreClient};
 use tempfile::tempdir;
 
-async fn spawn_client() -> (tokio::task::JoinHandle<()>, PrefixedStoreClient) {
+/// The returned [`tempfile::TempDir`] guard must be held for the duration of the test: dropping
+/// it deletes the data directory out from under the running server, whose engine keeps creating
+/// files in it.
+async fn spawn_client() -> (
+    tokio::task::JoinHandle<()>,
+    PrefixedStoreClient,
+    tempfile::TempDir,
+) {
     let dir = tempdir().expect("tempdir");
-    let dir_path = dir.path().to_owned();
-    let _dir = dir;
-    let (handle, url) = exoware_simulator::spawn_for_test(&dir_path)
+    let (handle, url) = exoware_simulator::spawn_for_test(dir.path())
         .await
         .expect("spawn_for_test");
     let client = StoreClient::builder()
@@ -21,7 +26,7 @@ async fn spawn_client() -> (tokio::task::JoinHandle<()>, PrefixedStoreClient) {
         .retry_config(RetryConfig::disabled())
         .build()
         .expect("build client");
-    (handle, PrefixedStoreClient::empty(client))
+    (handle, PrefixedStoreClient::empty(client), dir)
 }
 
 fn key(family: u16, payload: &[u8]) -> Key {
@@ -67,7 +72,7 @@ async fn next_with_timeout(
 
 #[tokio::test]
 async fn live_subscribe_delivers_matching_entries() {
-    let (_h, client) = spawn_client().await;
+    let (_h, client, _dir) = spawn_client().await;
     let mut sub = client
         .stream()
         .subscribe(filter(1), None)
@@ -91,7 +96,7 @@ async fn live_subscribe_delivers_matching_entries() {
 
 #[tokio::test]
 async fn non_matching_put_yields_no_frame() {
-    let (_h, client) = spawn_client().await;
+    let (_h, client, _dir) = spawn_client().await;
     let mut sub = client
         .stream()
         .subscribe(filter(1), None)
@@ -113,7 +118,7 @@ async fn non_matching_put_yields_no_frame() {
 
 #[tokio::test]
 async fn multiple_selectors_delivered_once_per_put() {
-    let (_h, client) = spawn_client().await;
+    let (_h, client, _dir) = spawn_client().await;
     let f = StreamFilter {
         selectors: vec![
             Selector {
@@ -152,7 +157,7 @@ async fn multiple_selectors_delivered_once_per_put() {
 
 #[tokio::test]
 async fn two_puts_yield_two_distinct_frames() {
-    let (_h, client) = spawn_client().await;
+    let (_h, client, _dir) = spawn_client().await;
     let mut sub = client
         .stream()
         .subscribe(filter(1), None)
@@ -182,7 +187,7 @@ async fn two_puts_yield_two_distinct_frames() {
 
 #[tokio::test]
 async fn replay_since_delivers_retained_batches_then_live() {
-    let (_h, client) = spawn_client().await;
+    let (_h, client, _dir) = spawn_client().await;
     let mut seen_seqs = Vec::new();
     for i in 0..5u8 {
         let seq = client
@@ -226,7 +231,7 @@ async fn replay_since_delivers_retained_batches_then_live() {
 
 #[tokio::test]
 async fn replay_past_end_delivers_only_live() {
-    let (_h, client) = spawn_client().await;
+    let (_h, client, _dir) = spawn_client().await;
     let current = client
         .ingest()
         .put(&[(&key(1, b"seed"), b"v")])
@@ -257,7 +262,7 @@ async fn replay_past_end_delivers_only_live() {
 
 #[tokio::test]
 async fn replay_miss_after_prune_returns_batch_evicted() {
-    let (_h, client) = spawn_client().await;
+    let (_h, client, _dir) = spawn_client().await;
     for i in 0..20u8 {
         client
             .ingest()
@@ -293,7 +298,7 @@ async fn replay_miss_after_prune_returns_batch_evicted() {
 
 #[tokio::test]
 async fn get_batch_returns_whole_batch_unfiltered() {
-    let (_h, client) = spawn_client().await;
+    let (_h, client, _dir) = spawn_client().await;
     let ka = key(1, b"a");
     let kb = key(2, b"b");
     let seq = client
@@ -318,7 +323,7 @@ async fn get_batch_returns_whole_batch_unfiltered() {
 
 #[tokio::test]
 async fn get_batch_missing_seq_returns_none() {
-    let (_h, client) = spawn_client().await;
+    let (_h, client, _dir) = spawn_client().await;
     client
         .ingest()
         .put(&[(&key(1, b"a"), b"1")])
@@ -334,7 +339,7 @@ async fn get_batch_missing_seq_returns_none() {
 
 #[tokio::test]
 async fn get_batch_after_drop_all_returns_none() {
-    let (_h, client) = spawn_client().await;
+    let (_h, client, _dir) = spawn_client().await;
     let seq = client
         .ingest()
         .put(&[(&key(1, b"a"), b"1")])
@@ -352,7 +357,7 @@ async fn get_batch_after_drop_all_returns_none() {
 
 #[tokio::test]
 async fn get_batch_after_keep_latest_evicts_old_but_keeps_new() {
-    let (_h, client) = spawn_client().await;
+    let (_h, client, _dir) = spawn_client().await;
     let mut seqs = Vec::new();
     for i in 0..20u8 {
         let s = client
@@ -385,7 +390,7 @@ async fn get_batch_after_keep_latest_evicts_old_but_keeps_new() {
 
 #[tokio::test]
 async fn slow_subscriber_drops_without_blocking_ingest() {
-    let (_h, client) = spawn_client().await;
+    let (_h, client, _dir) = spawn_client().await;
     // Open subscription but never drain it. Internal cap = 256 frames.
     let _sub = client
         .stream()
@@ -423,7 +428,7 @@ async fn slow_subscriber_drops_without_blocking_ingest() {
 #[tokio::test]
 async fn value_filter_restricts_to_matching_values() {
     use exoware_sdk::stream_filter::Filter;
-    let (_h, client) = spawn_client().await;
+    let (_h, client, _dir) = spawn_client().await;
     let f = StreamFilter {
         selectors: vec![Selector {
             reserved_bits: 4,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Summary

Improves large-batch (250k+ keys/put) ingest throughput of the simulator by restructuring the write path. The final design (`FlatFileRocksStore`, now the server default) stages uploads as parallel checksummed flat files, assigns sequence numbers by renaming files (one directory fsync per wave), and populates a WAL-less RocksDB instance asynchronously to serve reads.

Measured at 250k keys x 128 B values (tuned RocksDB options, 4-core VM):

| mode | conc | MiB/s | p50 ms | p99 ms |
|---|---|---|---|---|
| `ordered` (current pipeline, synced WAL) | 1 | 106 | 297 | 356 |
| `ordered` | 4 | 176 | 756 | 873 |
| `unordered-nowal` (intermediate design) | 1 | 152 | 224 | 240 |
| `unordered-nowal` | 4 | 282 | 494 | 655 |
| **`flatfile` (this PR's engine)** | 1 | **353** | **87** | 138 |
| **`flatfile`** | 4 | **323** | **380** | 1112 |
| `flatfile-nodb` (ack-path ceiling, no DB apply) | 1 | 482 | 63 | 90 |
| `flatfile-nodb` | 4 | 780 | 167 | 273 |

With stock RocksDB options (what the server ships): `flatfile` 318 MiB/s vs `ordered` 99 MiB/s at conc=1 (3.2x); at conc=4 stock-option write stalls in the async apply backpressure ingest to 175 vs 136 MiB/s.

# Design

**Why the WAL is the bottleneck at this batch size.** Every payload byte previously went through RocksDB's single, serialized WAL and was then written again at memtable flush. For 250k-key uploads the commit path is bandwidth-bound, so the double write and the serialization both hurt.

**Write path.**
1. `put_batch` encodes the batch into one checksummed flat file under a temp name in `staging/` and fsyncs it. Concurrent uploads write independent files, so the payload-sized part of durability runs fully in parallel (unlike a shared WAL).
2. A sequencer thread drains a wave of completed uploads, assigns contiguous sequence numbers by renaming each file to `<seq>.seq`, makes the whole wave durable with **one directory fsync**, then acks every caller. The per-wave commit cost is one metadata fsync, independent of payload size (this is the original "fsync a tiny sequence blob" idea).
3. Applier threads populate RocksDB (WAL disabled on every write) from a bounded in-memory queue; batches are handed over in memory so flat files are never re-read outside crash recovery. Appliers write current-state rows plus the replay-log row and advance a contiguous applied frontier (persisted in the `meta` CF).

**Durability and recovery.** The flat files *are* the WAL. RocksDB is made durable by an atomic multi-CF flush every 256 MiB applied (plus best-effort on clean shutdown); only files at or beneath the flushed frontier are deleted. On open: `.tmp` files (never sequenced, never acked) are deleted; `.seq` files above the recovered frontier are checksum-verified and reapplied in order (idempotent); sequenced files past a gap were never acked (renames are fsynced before any ack in the wave) and are deleted so their numbers can be reassigned. A corrupt sequenced file fails `open` rather than silently dropping acked data.

**Read visibility.** Acks happen at sequencing time, before RocksDB has the data. To preserve "everything at or beneath a published sequence number is complete and queryable", every read gates on the applied frontier: it waits until the frontier reaches the durable (acked) sequence observed at call entry, then serves from RocksDB. `current_sequence` reports the applied frontier. The wait is bounded by the apply queue (512 MiB default), which backpressures ingest when appliers lag.

**Semantics vs. the ordered pipeline.**
- The unordered store's "keys that are never part of a sequence" caveat is gone: data enters RocksDB only after sequencing, so a crashed upload leaves at most a dead `.tmp` file (deleted on next open) and can never surface in query results.
- With `appliers = 1` batches apply in exact sequence order, so log replay always reproduces the state. With the default 4 parallel appliers, two racing same-key writers may apply out of order relative to their sequence numbers (same caveat as the unordered store).
- Prune mutations are ordinary unsynced RocksDB writes; a crash can undo a recent prune, which the next policy run re-applies.

# Also in this PR (earlier stages of the investigation)

- `CommitDurability::{SyncWal, NoWalFlush}` knob for both the ordered `RocksStore` pipeline and the new `UnorderedRocksStore` (concurrent unsynced data writes + post-hoc sequence assignment). These remain as library types; `NoWalFlush` replaces the WAL fsync with one atomic memtable flush per commit wave.
- `benches/ingest_load.rs`: load harness comparing `ordered`, `ordered-nowal`, `unordered`, `unordered-nowal`, `unordered-uw`, `raw-nosync`, `raw-sync`, `flatfile`, and `flatfile-nodb` across concurrency/value-size/batch-size grids, with a `--tuned` flag for bulk-ingest RocksDB options.
- e2e test harnesses now keep the server's tempdir alive for the whole test (the engine creates staging files continuously).

# Testing

- 84 tests pass (`cargo test -p exoware-simulator`), including new flatfile tests: monotonic sequences + log contents, 32-way concurrent puts, empty batches, reopen persistence, crash recovery from staged files (replays acked files, discards gap/tmp junk, reassigns unacked numbers), corrupt-file rejection, and sequence pruning.
- `cargo clippy -p exoware-simulator --all-targets` and `cargo fmt` clean.
- Benchmarks above run via `cargo bench -p exoware-simulator --bench ingest_load -- --modes ... --kvs-per-put 250000 --tuned`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f39a2-8045-7a77-80eb-a0a524d36e21"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f39a2-8045-7a77-80eb-a0a524d36e21"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

