### PR TITLE
Optimize simulator ingest throughput for large batches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2726,6 +2726,7 @@ dependencies = [
  "exoware-sdk",
  "exoware-server",
  "http",
+ "rayon",
  "regex",
  "reqwest",
  "rocksdb",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2726,6 +2726,7 @@ dependencies = [
  "exoware-sdk",
  "exoware-server",
  "http",
+ "parking_lot",
  "rayon",
  "regex",
  "reqwest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2727,7 +2727,6 @@ dependencies = [
  "exoware-server",
  "http",
  "parking_lot",
- "rayon",
  "regex",
  "reqwest",
  "rocksdb",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2726,6 +2726,7 @@ dependencies = [
  "exoware-sdk",
  "exoware-server",
  "http",
+ "mimalloc",
  "parking_lot",
  "regex",
  "reqwest",
@@ -3660,6 +3661,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a45a52f43e1c16f667ccfe4dd8c85b7f7c204fd5e3bf46c5b0db9a5c3c0b8e9"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "librocksdb-sys"
 version = "0.17.3+10.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3773,6 +3783,15 @@ name = "memchr"
 version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+
+[[package]]
+name = "mimalloc"
+version = "0.1.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d4139bb28d14ad1facf21d5eb8825051b326e172d216b39f6d31df53cc97862"
+dependencies = [
+ "libmimalloc-sys",
+]
 
 [[package]]
 name = "mime"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2564,7 +2564,6 @@ dependencies = [
  "exoware-sql",
  "futures",
  "reqwest",
- "tempfile",
  "tokio",
 ]
 
@@ -2689,7 +2688,6 @@ dependencies = [
  "futures",
  "hex",
  "rand 0.8.6",
- "tempfile",
  "thiserror",
  "tokio",
  "tracing",
@@ -2762,7 +2760,6 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "tempfile",
  "thiserror",
  "tokio",
  "tower-http 0.5.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,6 @@ commonware-storage = { git = "https://github.com/commonwarexyz/monorepo.git", re
 commonware-utils = { git = "https://github.com/commonwarexyz/monorepo.git", rev = "85f7103e3b625d44a466d120aac5a3a13f2bb177" }
 rocksdb = "0.24.0"
 rand = "0.8.5"
-rayon = "1.12.0"
 parking_lot = "0.12.5"
 bincode = "1.3.3"
 dashmap = "5.5.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ commonware-storage = { git = "https://github.com/commonwarexyz/monorepo.git", re
 commonware-utils = { git = "https://github.com/commonwarexyz/monorepo.git", rev = "85f7103e3b625d44a466d120aac5a3a13f2bb177" }
 rocksdb = "0.24.0"
 rand = "0.8.5"
+rayon = "1"
 bincode = "1.3.3"
 dashmap = "5.5.3"
 tokio-stream = "0.1.15"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,8 @@ commonware-storage = { git = "https://github.com/commonwarexyz/monorepo.git", re
 commonware-utils = { git = "https://github.com/commonwarexyz/monorepo.git", rev = "85f7103e3b625d44a466d120aac5a3a13f2bb177" }
 rocksdb = "0.24.0"
 rand = "0.8.5"
-rayon = "1"
+rayon = "1.12.0"
+parking_lot = "0.12.5"
 bincode = "1.3.3"
 dashmap = "5.5.3"
 tokio-stream = "0.1.15"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ commonware-runtime = { git = "https://github.com/commonwarexyz/monorepo.git", re
 commonware-storage = { git = "https://github.com/commonwarexyz/monorepo.git", rev = "85f7103e3b625d44a466d120aac5a3a13f2bb177" }
 commonware-utils = { git = "https://github.com/commonwarexyz/monorepo.git", rev = "85f7103e3b625d44a466d120aac5a3a13f2bb177" }
 rocksdb = "0.24.0"
+mimalloc = "0.1.52"
 rand = "0.8.5"
 parking_lot = "0.12.5"
 bincode = "1.3.3"

--- a/examples/simulator/Cargo.toml
+++ b/examples/simulator/Cargo.toml
@@ -17,7 +17,6 @@ bytes = { workspace = true }
 exoware-sdk = { workspace = true }
 exoware-server = { workspace = true }
 parking_lot = { workspace = true }
-rayon = { workspace = true }
 reqwest = { workspace = true }
 regex = { workspace = true }
 rocksdb = { workspace = true }

--- a/examples/simulator/Cargo.toml
+++ b/examples/simulator/Cargo.toml
@@ -38,5 +38,5 @@ name = "simulator"
 path = "src/main.rs"
 
 [[bench]]
-name = "ingest_throughput"
+name = "ingest"
 harness = false

--- a/examples/simulator/Cargo.toml
+++ b/examples/simulator/Cargo.toml
@@ -16,10 +16,12 @@ buffa = { workspace = true }
 bytes = { workspace = true }
 exoware-sdk = { workspace = true }
 exoware-server = { workspace = true }
+mimalloc = { workspace = true }
 parking_lot = { workspace = true }
 reqwest = { workspace = true }
 regex = { workspace = true }
 rocksdb = { workspace = true }
+tempfile = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
@@ -30,7 +32,6 @@ tower-http = { workspace = true }
 commonware-codec = { workspace = true }
 connectrpc = { workspace = true }
 http = { workspace = true }
-tempfile = { workspace = true }
 
 [[bin]]
 name = "simulator"

--- a/examples/simulator/Cargo.toml
+++ b/examples/simulator/Cargo.toml
@@ -16,6 +16,7 @@ buffa = { workspace = true }
 bytes = { workspace = true }
 exoware-sdk = { workspace = true }
 exoware-server = { workspace = true }
+rayon = { workspace = true }
 reqwest = { workspace = true }
 regex = { workspace = true }
 rocksdb = { workspace = true }

--- a/examples/simulator/Cargo.toml
+++ b/examples/simulator/Cargo.toml
@@ -34,3 +34,7 @@ tempfile = { workspace = true }
 [[bin]]
 name = "simulator"
 path = "src/main.rs"
+
+[[bench]]
+name = "ingest_throughput"
+harness = false

--- a/examples/simulator/Cargo.toml
+++ b/examples/simulator/Cargo.toml
@@ -16,6 +16,7 @@ buffa = { workspace = true }
 bytes = { workspace = true }
 exoware-sdk = { workspace = true }
 exoware-server = { workspace = true }
+parking_lot = { workspace = true }
 rayon = { workspace = true }
 reqwest = { workspace = true }
 regex = { workspace = true }

--- a/examples/simulator/benches/ingest.rs
+++ b/examples/simulator/benches/ingest.rs
@@ -21,6 +21,10 @@ use bytes::Bytes;
 use exoware_server::Ingest;
 use exoware_simulator::RocksStore;
 
+// Match the simulator binary's allocator so bench numbers reflect the deployed configuration.
+#[global_allocator]
+static ALLOC: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 fn env_usize(name: &str, default: usize) -> usize {
     std::env::var(name)
         .ok()
@@ -95,7 +99,7 @@ async fn run(store: Arc<RocksStore>, batches: Vec<Vec<(Bytes, Bytes)>>, writers:
 }
 
 fn main() {
-    let batches = env_usize("BENCH_BATCHES", 16);
+    let batches = env_usize("BENCH_BATCHES", 16).max(1);
     let keys_per_batch = env_usize("BENCH_KEYS_PER_BATCH", 250_000).max(1);
     let value_len = env_usize("BENCH_VALUE_LEN", 128);
     let writers = env_usize("BENCH_WRITERS", 4).max(1);

--- a/examples/simulator/benches/ingest.rs
+++ b/examples/simulator/benches/ingest.rs
@@ -8,7 +8,7 @@
 //! Run with:
 //!
 //! ```bash
-//! cargo bench -p exoware-simulator --bench ingest_throughput
+//! cargo bench -p exoware-simulator --bench ingest
 //! ```
 //!
 //! Environment overrides: `BENCH_BATCHES`, `BENCH_KEYS_PER_BATCH`,

--- a/examples/simulator/benches/ingest.rs
+++ b/examples/simulator/benches/ingest.rs
@@ -36,6 +36,7 @@ fn build_batch(batch_index: usize, keys_per_batch: usize, value_len: usize) -> V
         key.extend_from_slice(b"bench/");
         key.extend_from_slice(&(batch_index as u64).to_be_bytes());
         key.extend_from_slice(&(i as u64).to_be_bytes());
+
         // Mix the tail so keys are not fully sequential in memcmp order.
         let mixed = (i as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15);
         key.extend_from_slice(&mixed.to_be_bytes());

--- a/examples/simulator/benches/ingest.rs
+++ b/examples/simulator/benches/ingest.rs
@@ -70,19 +70,8 @@ fn report(label: &str, keys: usize, payload_bytes: usize, elapsed_secs: f64) {
     );
 }
 
-async fn run_serial(store: Arc<RocksStore>, batches: Vec<Vec<(Bytes, Bytes)>>) -> f64 {
-    let start = Instant::now();
-    for batch in batches {
-        store.put_batch(batch).await.expect("put batch");
-    }
-    start.elapsed().as_secs_f64()
-}
-
-async fn run_concurrent(
-    store: Arc<RocksStore>,
-    batches: Vec<Vec<(Bytes, Bytes)>>,
-    writers: usize,
-) -> f64 {
+/// Writes every batch through `writers` concurrent tasks; one writer is the serial mode.
+async fn run(store: Arc<RocksStore>, batches: Vec<Vec<(Bytes, Bytes)>>, writers: usize) -> f64 {
     let mut queues: Vec<Vec<Vec<(Bytes, Bytes)>>> = (0..writers).map(|_| Vec::new()).collect();
     for (index, batch) in batches.into_iter().enumerate() {
         queues[index % writers].push(batch);
@@ -128,11 +117,11 @@ fn main() {
         let payload = batch_payload_bytes(&data);
         let keys = batches * keys_per_batch;
 
-        let elapsed = if concurrent {
-            runtime.block_on(run_concurrent(store.clone(), data, writers))
-        } else {
-            runtime.block_on(run_serial(store.clone(), data))
-        };
+        let elapsed = runtime.block_on(run(
+            store.clone(),
+            data,
+            if concurrent { writers } else { 1 },
+        ));
         report(label, keys, payload, elapsed);
         drop(store);
     }

--- a/examples/simulator/benches/ingest.rs
+++ b/examples/simulator/benches/ingest.rs
@@ -106,9 +106,9 @@ async fn run_concurrent(
 
 fn main() {
     let batches = env_usize("BENCH_BATCHES", 16);
-    let keys_per_batch = env_usize("BENCH_KEYS_PER_BATCH", 250_000);
+    let keys_per_batch = env_usize("BENCH_KEYS_PER_BATCH", 250_000).max(1);
     let value_len = env_usize("BENCH_VALUE_LEN", 128);
-    let writers = env_usize("BENCH_WRITERS", 4);
+    let writers = env_usize("BENCH_WRITERS", 4).max(1);
 
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .enable_all()

--- a/examples/simulator/benches/ingest_throughput.rs
+++ b/examples/simulator/benches/ingest_throughput.rs
@@ -1,0 +1,139 @@
+//! Ingest throughput benchmark for the RocksDB-backed simulator store.
+//!
+//! Measures `put_batch` on the workload the simulator is expected to sustain:
+//! large batches (hundreds of thousands of keys each), both from a single
+//! serial writer and from several concurrent writers that keep the write
+//! pipeline full.
+//!
+//! Run with:
+//!
+//! ```bash
+//! cargo bench -p exoware-simulator --bench ingest_throughput
+//! ```
+//!
+//! Environment overrides: `BENCH_BATCHES`, `BENCH_KEYS_PER_BATCH`,
+//! `BENCH_VALUE_LEN`, `BENCH_WRITERS`.
+
+use std::sync::Arc;
+use std::time::Instant;
+
+use bytes::Bytes;
+use exoware_server::Ingest;
+use exoware_simulator::RocksStore;
+
+fn env_usize(name: &str, default: usize) -> usize {
+    std::env::var(name)
+        .ok()
+        .and_then(|raw| raw.parse().ok())
+        .unwrap_or(default)
+}
+
+/// Builds one batch of unique keys with pseudo-random, incompressible-ish values.
+fn build_batch(batch_index: usize, keys_per_batch: usize, value_len: usize) -> Vec<(Bytes, Bytes)> {
+    let mut kvs = Vec::with_capacity(keys_per_batch);
+    for i in 0..keys_per_batch {
+        let mut key = Vec::with_capacity(32);
+        key.extend_from_slice(b"bench/");
+        key.extend_from_slice(&(batch_index as u64).to_be_bytes());
+        key.extend_from_slice(&(i as u64).to_be_bytes());
+        // Mix the tail so keys are not fully sequential in memcmp order.
+        let mixed = (i as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15);
+        key.extend_from_slice(&mixed.to_be_bytes());
+
+        let mut value = vec![0u8; value_len];
+        let mut state = mixed ^ (batch_index as u64);
+        for chunk in value.chunks_mut(8) {
+            state = state
+                .wrapping_mul(6_364_136_223_846_793_005)
+                .wrapping_add(1_442_695_040_888_963_407);
+            let bytes = state.to_le_bytes();
+            chunk.copy_from_slice(&bytes[..chunk.len()]);
+        }
+        kvs.push((Bytes::from(key), Bytes::from(value)));
+    }
+    kvs
+}
+
+fn batch_payload_bytes(batches: &[Vec<(Bytes, Bytes)>]) -> usize {
+    batches
+        .iter()
+        .flatten()
+        .map(|(k, v)| k.len() + v.len())
+        .sum()
+}
+
+fn report(label: &str, keys: usize, payload_bytes: usize, elapsed_secs: f64) {
+    println!(
+        "{label}: {keys} keys in {elapsed_secs:.3}s -> {:.0} keys/s, {:.1} MiB/s",
+        keys as f64 / elapsed_secs,
+        payload_bytes as f64 / (1024.0 * 1024.0) / elapsed_secs,
+    );
+}
+
+async fn run_serial(store: Arc<RocksStore>, batches: Vec<Vec<(Bytes, Bytes)>>) -> f64 {
+    let start = Instant::now();
+    for batch in batches {
+        store.put_batch(batch).await.expect("put batch");
+    }
+    start.elapsed().as_secs_f64()
+}
+
+async fn run_concurrent(
+    store: Arc<RocksStore>,
+    batches: Vec<Vec<(Bytes, Bytes)>>,
+    writers: usize,
+) -> f64 {
+    let mut queues: Vec<Vec<Vec<(Bytes, Bytes)>>> = (0..writers).map(|_| Vec::new()).collect();
+    for (index, batch) in batches.into_iter().enumerate() {
+        queues[index % writers].push(batch);
+    }
+
+    let start = Instant::now();
+    let mut tasks = Vec::with_capacity(writers);
+    for queue in queues {
+        let store = store.clone();
+        tasks.push(tokio::spawn(async move {
+            for batch in queue {
+                store.put_batch(batch).await.expect("put batch");
+            }
+        }));
+    }
+    for task in tasks {
+        task.await.expect("writer task");
+    }
+    start.elapsed().as_secs_f64()
+}
+
+fn main() {
+    let batches = env_usize("BENCH_BATCHES", 16);
+    let keys_per_batch = env_usize("BENCH_KEYS_PER_BATCH", 250_000);
+    let value_len = env_usize("BENCH_VALUE_LEN", 128);
+    let writers = env_usize("BENCH_WRITERS", 4);
+
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .expect("build runtime");
+
+    println!(
+        "workload: {batches} batches x {keys_per_batch} keys, {value_len}B values, {writers} concurrent writers"
+    );
+
+    for (label, concurrent) in [("serial", false), ("concurrent", true)] {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = Arc::new(RocksStore::open(dir.path(), None).expect("open store"));
+        let data: Vec<_> = (0..batches)
+            .map(|batch| build_batch(batch, keys_per_batch, value_len))
+            .collect();
+        let payload = batch_payload_bytes(&data);
+        let keys = batches * keys_per_batch;
+
+        let elapsed = if concurrent {
+            runtime.block_on(run_concurrent(store.clone(), data, writers))
+        } else {
+            runtime.block_on(run_serial(store.clone(), data))
+        };
+        report(label, keys, payload, elapsed);
+        drop(store);
+    }
+}

--- a/examples/simulator/src/lib.rs
+++ b/examples/simulator/src/lib.rs
@@ -6,4 +6,4 @@ pub mod server;
 pub use exoware_server::{connect_stack, AppState, Ingest, Log, Prune, Query, Sequence};
 pub use rocks::{RocksConfig, RocksRangeScanCursor, RocksStore, RocksWritePipelineConfig};
 pub use rocksdb;
-pub use server::{run, test_spawn, CMD, RUN_CMD};
+pub use server::{open_temp, run, CMD, RUN_CMD};

--- a/examples/simulator/src/lib.rs
+++ b/examples/simulator/src/lib.rs
@@ -4,6 +4,6 @@ pub mod rocks;
 pub mod server;
 
 pub use exoware_server::{connect_stack, AppState, Ingest, Log, Prune, Query, Sequence};
-pub use rocks::{RocksConfig, RocksStore, RocksWritePipelineConfig};
+pub use rocks::{RocksConfig, RocksRangeScanCursor, RocksStore, RocksWritePipelineConfig};
 pub use rocksdb;
 pub use server::{run, spawn_for_test, CMD, RUN_CMD};

--- a/examples/simulator/src/lib.rs
+++ b/examples/simulator/src/lib.rs
@@ -6,4 +6,4 @@ pub mod server;
 pub use exoware_server::{connect_stack, AppState, Ingest, Log, Prune, Query, Sequence};
 pub use rocks::{RocksConfig, RocksRangeScanCursor, RocksStore, RocksWritePipelineConfig};
 pub use rocksdb;
-pub use server::{run, spawn_for_test, CMD, RUN_CMD};
+pub use server::{run, test_spawn, CMD, RUN_CMD};

--- a/examples/simulator/src/lib.rs
+++ b/examples/simulator/src/lib.rs
@@ -4,6 +4,6 @@ pub mod rocks;
 pub mod server;
 
 pub use exoware_server::{connect_stack, AppState, Ingest, Log, Prune, Query, Sequence};
-pub use rocks::{RocksConfig, RocksRangeScanCursor, RocksStore, RocksWritePipelineConfig};
+pub use rocks::{RocksConfig, RocksStore, RocksWritePipelineConfig};
 pub use rocksdb;
 pub use server::{open_temp, run, CMD, RUN_CMD};

--- a/examples/simulator/src/main.rs
+++ b/examples/simulator/src/main.rs
@@ -4,6 +4,7 @@ use clap::{Arg, ArgAction, Command};
 use std::path::PathBuf;
 use tracing::error;
 
+use exoware_simulator::rocks::WRITER_THREAD_PREFIX;
 use exoware_simulator::server;
 
 pub fn crate_version() -> &'static str {
@@ -67,13 +68,16 @@ async fn main() -> std::process::ExitCode {
 
     // Store write errors are fatal by design: a panicked writer thread can never accept writes
     // again, so exit instead of serving reads from a store that silently fails every put. A
-    // restart rolls the store forward from its log. Request-handler panics are unaffected.
+    // restart rolls the store forward from its log. The exit must stay scoped to the writer
+    // threads (not abort on every panic): the request path relies on contained panics —
+    // subscribe-filter validation catches a `KeyCodec` panic to reject bad client input — so an
+    // unconditional abort would let a malformed request kill the process.
     let default_hook = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |info| {
         default_hook(info);
         if std::thread::current()
             .name()
-            .is_some_and(|name| name.starts_with("simulator-rocks-"))
+            .is_some_and(|name| name.starts_with(WRITER_THREAD_PREFIX))
         {
             std::process::exit(1);
         }

--- a/examples/simulator/src/main.rs
+++ b/examples/simulator/src/main.rs
@@ -7,6 +7,9 @@ use tracing::error;
 use exoware_simulator::rocks::WRITER_THREAD_PREFIX;
 use exoware_simulator::server;
 
+#[global_allocator]
+static ALLOC: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 pub fn crate_version() -> &'static str {
     env!("CARGO_PKG_VERSION")
 }
@@ -67,11 +70,13 @@ async fn main() -> std::process::ExitCode {
     tracing_subscriber::fmt().with_max_level(level).init();
 
     // Store write errors are fatal by design: a panicked writer thread can never accept writes
-    // again, so exit instead of serving reads from a store that silently fails every put. A
-    // restart rolls the store forward from its log. The exit must stay scoped to the writer
-    // threads (not abort on every panic): the request path relies on contained panics —
-    // subscribe-filter validation catches a `KeyCodec` panic to reject bad client input — so an
-    // unconditional abort would let a malformed request kill the process.
+    // again, so kill the process instead of serving reads from a store that silently fails
+    // every put. A restart rolls the store forward from its log. `abort` rather than `exit`:
+    // exit-time teardown runs while tokio workers and RocksDB background threads are still
+    // live and can hang. The kill must stay scoped to the writer threads (not fire on every
+    // panic): the request path relies on contained panics (subscribe-filter validation
+    // catches a `KeyCodec` panic to reject bad client input), so an unconditional abort would
+    // let a malformed request kill the process.
     let default_hook = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |info| {
         default_hook(info);
@@ -79,7 +84,7 @@ async fn main() -> std::process::ExitCode {
             .name()
             .is_some_and(|name| name.starts_with(WRITER_THREAD_PREFIX))
         {
-            std::process::exit(1);
+            std::process::abort();
         }
     }));
 

--- a/examples/simulator/src/main.rs
+++ b/examples/simulator/src/main.rs
@@ -65,6 +65,20 @@ async fn main() -> std::process::ExitCode {
     };
     tracing_subscriber::fmt().with_max_level(level).init();
 
+    // Store write errors are fatal by design: a panicked writer thread can never accept writes
+    // again, so exit instead of serving reads from a store that silently fails every put. A
+    // restart rolls the store forward from its log. Request-handler panics are unaffected.
+    let default_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        default_hook(info);
+        if std::thread::current()
+            .name()
+            .is_some_and(|name| name.starts_with("simulator-rocks-"))
+        {
+            std::process::exit(1);
+        }
+    }));
+
     if let Some(server_matches) = matches.subcommand_matches(server::CMD) {
         match server_matches.subcommand() {
             Some((server::RUN_CMD, m)) => {

--- a/examples/simulator/src/rocks.rs
+++ b/examples/simulator/src/rocks.rs
@@ -1,23 +1,25 @@
 //! Naive reference storage for local development: user keys and values are written as-is to
-//! RocksDB. A `meta` column family holds the state-floor row (see below). A separate `log`
-//! column family keeps per-sequence-number batch payloads so the stream service can serve
-//! replay and point lookups. Batch-log pruning is driven exclusively by the compact service's
-//! `Sequence` scope.
+//! RocksDB. A `meta` column family holds the state-floor row, and a `log` column family keeps
+//! one row per commit group — the exact `log.stream.v1.GetResponse` bytes the stream service
+//! serves for that sequence, loaded on demand. Everything is addressed by key: recovery and
+//! pruning never assume which SST files rows live in, so RocksDB is free to place and compact
+//! them however it likes.
 //!
-//! Both structures are written as SST files and ingested, bypassing the WAL and the memtables
-//! entirely: `prepare` stages one sorted state file and one log file per commit group, and
-//! `commit` ingests the log file first (its rows alone define durability — `open` derives the
-//! frontier from the highest retained row and the state-floor meta row), then the state file,
-//! and only then publishes and acks. The two ingestions are not atomic, but the window is one
-//! group wide: a crash between them leaves the log durable and the state missing for at most the
-//! last group, which `open` repairs by replaying the retained log rows above the state floor
-//! within the last retained log file, before the store serves reads. The floor meta row is
-//! written only by pruning — atomically with the log range tombstone or the pruned state keys —
-//! so a store recovers by reading one meta row, one file listing, and replaying at most one
-//! group.
+//! Writes bypass the WAL and the memtables: `prepare` coalesces queued requests into a commit
+//! group that shares one sequence number and stages the group's log row and sorted state rows
+//! as two SST files (built in parallel), while `commit` ingests the previous group — the log
+//! file first (the durable row alone defines the group; `open` derives the frontier from the
+//! highest retained row and the state-floor meta row), then the state file, then publish and
+//! ack. Ingestion
+//! is atomic, so a crash never leaves a partial batch — at worst the newest groups' state
+//! ingestions are missing, and `open` repairs that by re-applying the retained log rows above
+//! the state floor. The floor advances whenever state is provably authoritative: an unsynced
+//! meta-row write after every commit, a synced one from prunes (atomic with their deletes),
+//! and a synced one parking it at the frontier on clean shutdown — so an unremarkable reopen
+//! replays nothing and a crash replays only the trailing groups above the last durable floor.
 //!
-//! Any write failure in the pipeline is fatal: once a group's log rows are durable it cannot be
-//! rolled back (its sequence numbers must never be re-issued), so the writer panics and the next
+//! Any write failure in the pipeline is fatal: once a group's log row is durable it cannot be
+//! rolled back (its sequence number must never be re-issued), so the writer panics and the next
 //! open rolls the store forward instead of any in-process recovery.
 
 use std::cmp::Ordering as CmpOrdering;
@@ -54,11 +56,11 @@ use tracing::debug;
 const STATE_CF: &str = rocksdb::DEFAULT_COLUMN_FAMILY_NAME;
 const META_CF: &str = "meta";
 const SEQ_META_KEY: &[u8] = b"sequence";
-const LOG_CF: &str = "log";
-const LOG_BATCH_KEY_LEN: usize = 8;
 const PRUNE_SCAN_BATCH_SIZE: usize = 4096;
 const DEFAULT_COMMIT_COALESCE_MAX_BATCH_BYTES: usize = 16 * 1024 * 1024;
 const LOG_INGEST_DIR: &str = "ingest";
+const LOG_CF: &str = "log";
+const LOG_BATCH_KEY_LEN: usize = 8;
 pub const WRITER_THREAD_PREFIX: &str = "simulator-rocks-";
 type RocksIterItem = Result<(Box<[u8]>, Box<[u8]>), rocksdb::Error>;
 
@@ -302,13 +304,13 @@ fn keys_to_delete(
 
 /// Sequence frontier shared by the store and its writer stages.
 struct Frontiers {
-    /// Highest sequence whose log rows and state rows are both ingested; gates every
+    /// Highest sequence whose log row and state rows are both committed; gates every
     /// sequence-addressed read (`current_sequence`, `get_batch`, `oldest_retained_batch`).
     /// Point reads of current state are deliberately ungated: state may lead this frontier by
     /// the one group being published, but never lags it. The durable frontier (highest sequence
-    /// whose log rows are durable) is not tracked in-process — it only runs ahead of `published`
-    /// while a group's state ingestion is in flight, and is re-derived at open from the retained
-    /// log rows and the state-floor meta row.
+    /// whose log row is durable) is not tracked in-process — it only runs ahead of `published`
+    /// while a group's state ingestion is in flight, and is re-derived at open from the
+    /// retained log rows and the state-floor meta row.
     published: AtomicU64,
     /// Serializes prunes (so the persisted state floor never moves backward) and orders state
     /// visibility against floor reads: `commit` ingests and publishes each group's state under
@@ -331,45 +333,40 @@ struct WriteRequest {
     response: oneshot::Sender<Result<u64, String>>,
 }
 
-struct AssignedWrite {
+/// One staged commit group: every coalesced request shares a single sequence number, whose log
+/// row carries all their rows in arrival order.
+struct PreparedWrite {
     sequence: u64,
-    request: WriteRequest,
-}
-
-/// SST files staged for one commit group, ready to be ingested.
-struct StagedFiles {
-    /// Replay-log rows (ascending sequence order), destined for the log column family.
+    requests: Vec<WriteRequest>,
+    /// Staged single-row log SST (the group's encoded batch), ready for ingestion.
     log: PathBuf,
-    /// Current-state rows (sorted by key, last write per key), destined for the default column
-    /// family.
+    /// Staged current-state SST (sorted by key, last write per key), ready for ingestion.
     state: PathBuf,
     /// Combined payload bytes staged, for debug logging.
     staged_bytes: usize,
-}
-
-/// One commit group covering a contiguous run of assigned sequence numbers.
-struct PreparedWrite {
-    writes: Vec<AssignedWrite>,
-    staged: StagedFiles,
 }
 
 struct Writer {
     /// `None` only during `Drop`, which closes the channel before joining the workers.
     sender: Option<mpsc::Sender<WriteRequest>>,
     handles: Vec<thread::JoinHandle<()>>,
+    /// For parking the floor at the published frontier on clean shutdown (see `Drop`).
+    db: Arc<DB>,
+    frontiers: Arc<Frontiers>,
 }
 
 impl Writer {
     /// Starts the two-stage write pipeline. `prepare` drains queued requests up to the
-    /// configured byte cap, assigns a contiguous sequence number to each (continuing from the
-    /// published frontier, which is exactly the frontier derived at open since nothing has
-    /// committed yet), and stages each wave's log and state SST files
-    /// (including their data syncs); `commit` ingests the log file, then the state file,
-    /// publishes the frontier, and resolves the requests. The stages overlap, so one group's
-    /// files are being staged while the previous group's are being ingested. Any write failure
-    /// in either stage is fatal (the worker panics): the log rows alone define durability, so
-    /// the next open re-derives the frontier and repairs at most the last group — sequence
-    /// numbers never need to be reclaimed in-process.
+    /// configured byte cap into a commit group that shares one sequence number (continuing
+    /// from the published frontier, which is exactly the frontier derived at open since
+    /// nothing has committed yet) and stages the group's log and state SSTs in parallel;
+    /// `commit` ingests the log file, then the state file, publishes the frontier, advances
+    /// the floor, and resolves the requests. The stages overlap, so one group is staged while
+    /// the previous commits — and `commit` ingests strictly in order, so a crash still leaves
+    /// at most the newest ingested group without its state. Any write failure in either stage
+    /// is fatal (the worker panics): the durable log row alone defines the group, so the next
+    /// open re-derives the frontier and replays the rows above the floor — sequence numbers
+    /// never need to be reclaimed in-process.
     fn start(
         db: Arc<DB>,
         ingest_dir: PathBuf,
@@ -378,14 +375,16 @@ impl Writer {
     ) -> Self {
         let next = frontiers.published.load(Ordering::Acquire);
         let (request_sender, request_receiver) = mpsc::channel();
-        // Rendezvous so `prepare` runs at most one wave ahead of `commit`: it hands off a staged
-        // group, then stages the next while `commit` ingests this one.
+        // Rendezvous so `prepare` runs at most one wave ahead of `commit`: it hands off a
+        // staged group, then stages the next while `commit` ingests this one.
         let (group_sender, group_receiver) = mpsc::sync_channel(0);
         let max_commit_batch_bytes = write_pipeline.max_commit_batch_bytes.get();
 
+        let commit_db = db.clone();
+        let commit_frontiers = frontiers.clone();
         let commit = thread::Builder::new()
             .name(format!("{WRITER_THREAD_PREFIX}commit"))
-            .spawn(move || run_commit(db, frontiers, group_receiver))
+            .spawn(move || run_commit(commit_db, commit_frontiers, group_receiver))
             .expect("failed to spawn RocksDB commit worker");
 
         let prepare = thread::Builder::new()
@@ -404,14 +403,16 @@ impl Writer {
         Self {
             sender: Some(request_sender),
             handles: vec![prepare, commit],
+            db,
+            frontiers,
         }
     }
 
     /// Enqueues one ingest request and resolves once `commit` has durably published it.
     async fn put_batch(&self, kvs: Vec<(Bytes, Bytes)>) -> Result<u64, String> {
-        // An empty batch has no log row, so its sequence number could not be re-derived from the
-        // log after a crash; rejecting it keeps every acked sequence recoverable. The RPC layer
-        // already requires at least one entry per put.
+        // An empty batch would still cut a log row, but rejecting it keeps every sequence
+        // backed by at least one entry. The RPC layer already requires at least one entry per
+        // put.
         if kvs.is_empty() {
             return Err("cannot ingest an empty batch".to_string());
         }
@@ -429,19 +430,36 @@ impl Writer {
 
 impl Drop for Writer {
     fn drop(&mut self) {
-        // Closing the request channel lets `prepare` drain and exit, which drops the group
-        // channel and stops `commit`; joining keeps background RocksDB writers from outliving
-        // the store.
+        // Closing the request channel lets the writer drain and exit; joining keeps the
+        // background thread from outliving the store.
         self.sender.take();
         for handle in self.handles.drain(..) {
             let _ = handle.join();
         }
+        // Park the floor at the published frontier, synced: every published group's state is
+        // durable and authoritative, so the next open has nothing to replay after a clean
+        // shutdown even if the per-commit (unsynced) floor advances were lost.
+        let _guard = self.frontiers.persist.lock();
+        let mut batch = rocksdb::WriteBatch::default();
+        let meta_cf = self
+            .db
+            .cf_handle(META_CF)
+            .expect("meta CF must exist (created on open)");
+        batch.put_cf(
+            meta_cf,
+            SEQ_META_KEY,
+            self.frontiers
+                .published
+                .load(Ordering::Acquire)
+                .to_le_bytes(),
+        );
+        let _ = write_synced_batch(&self.db, batch);
     }
 }
 
-/// Drains each byte-bounded wave of queued requests, assigns contiguous sequence numbers, stages
-/// the wave's SST files, and hands the group to `commit`. Exits when the request channel closes
-/// (store drop); panics if `commit` died, since that only happens on a fatal write error.
+/// Drains each byte-bounded wave of queued requests into a group with the next sequence number,
+/// stages it, and hands it to `commit`. Exits when the request channel closes (store drop);
+/// panics if `commit` died, since that only happens on a fatal write error.
 fn run_prepare(
     ingest_dir: PathBuf,
     mut next: u64,
@@ -451,12 +469,8 @@ fn run_prepare(
 ) {
     while let Ok(first) = receiver.recv() {
         let (group, disconnected) =
-            prepare_queued_write(&ingest_dir, &receiver, first, next, max_commit_batch_bytes);
-        next = group
-            .writes
-            .last()
-            .expect("groups are never empty")
-            .sequence;
+            stage_queued_write(&ingest_dir, &receiver, first, next, max_commit_batch_bytes);
+        next = group.sequence;
         if sender.send(group).is_err() {
             panic!("rocks commit worker died");
         }
@@ -467,37 +481,45 @@ fn run_prepare(
     }
 }
 
-/// Builds one prepared write from requests already queued behind `first` without waiting for new
+/// Commits staged groups one at a time — log ingestion, state ingestion, publish, floor
+/// advance, ack — until the group channel closes (store drop). Any write failure panics inside
+/// `commit_group`.
+fn run_commit(db: Arc<DB>, frontiers: Arc<Frontiers>, receiver: mpsc::Receiver<PreparedWrite>) {
+    while let Ok(group) = receiver.recv() {
+        commit_group(&db, &frontiers, group);
+    }
+}
+
+/// Builds one staged group from requests already queued behind `first` without waiting for new
 /// arrivals, stopping once the accumulated payload reaches the soft byte cap. The request that
-/// crosses the cap stays in the wave so a single large request can still make progress.
-fn prepare_queued_write(
+/// crosses the cap stays in the wave so a single large request can still make progress. The
+/// whole wave shares one sequence number: its rows, in arrival order, form one log batch.
+fn stage_queued_write(
     ingest_dir: &Path,
     receiver: &mpsc::Receiver<WriteRequest>,
     first: WriteRequest,
     from: u64,
     max_batch_bytes: usize,
 ) -> (PreparedWrite, bool) {
-    let mut writes = Vec::with_capacity(64);
+    let sequence = from
+        .checked_add(1)
+        .expect("rocks sequence number overflowed");
+    let mut requests = Vec::with_capacity(64);
+    let mut rows: Vec<(Bytes, Bytes)> = Vec::with_capacity(first.kvs.len());
     let mut staged_bytes = 0usize;
-    let mut next = from;
     let mut request = first;
     let mut disconnected = false;
 
     loop {
-        next = next
-            .checked_add(1)
-            .expect("rocks sequence number overflowed");
-        // Payload counted twice: once as state rows and once inside the encoded log row.
+        // Payload counted twice: once as state rows and once inside the encoded log batch.
         staged_bytes += 2 * request
             .kvs
             .iter()
             .map(|(k, v)| k.len() + v.len())
             .sum::<usize>();
-        writes.push(AssignedWrite {
-            sequence: next,
-            request,
-        });
-        if staged_bytes >= max_batch_bytes || next == u64::MAX {
+        rows.extend(request.kvs.iter().cloned());
+        requests.push(request);
+        if staged_bytes >= max_batch_bytes {
             break;
         }
 
@@ -511,83 +533,65 @@ fn prepare_queued_write(
         }
     }
 
-    let staged = stage_group_files(ingest_dir, &writes);
-    (PreparedWrite { writes, staged }, disconnected)
-}
-
-/// Writes and syncs one commit group's two SST files: the replay-log rows (already in ascending
-/// sequence order) and the current-state rows (sorted by key, keeping the last write per key).
-/// The two files are built concurrently — the state file on a scoped thread while this thread
-/// writes the log file. Ingestion later links them into their column families, so each payload
-/// byte reaches the disk exactly once, in its final resting place. A staging failure is fatal;
-/// leftover files are removed by the next open.
-fn stage_group_files(ingest_dir: &Path, writes: &[AssignedWrite]) -> StagedFiles {
-    let first = writes.first().expect("groups are never empty").sequence;
-    let last = writes.last().expect("groups are never empty").sequence;
-    let log_path = ingest_dir.join(format!("log-{first:020}-{last:020}.sst"));
-    let state_path = ingest_dir.join(format!("state-{first:020}-{last:020}.sst"));
-
+    // Stage the group's two SST files in parallel — the single-row log SST on this thread, the
+    // sorted state SST on a scoped thread. Ingestion later links them into their column
+    // families, so each payload byte reaches the disk exactly once, in its final resting place.
+    // A staging failure is fatal; leftover staged files are removed by the next open.
+    let log = ingest_dir.join(format!("log-{sequence:020}.sst"));
+    let state = ingest_dir.join(format!("state-{sequence:020}.sst"));
     let (log_result, state_result) = thread::scope(|scope| {
-        let state = thread::Builder::new()
+        let state_task = thread::Builder::new()
             .name(format!("{WRITER_THREAD_PREFIX}stage"))
-            .spawn_scoped(scope, || stage_state_file(&state_path, writes))
+            .spawn_scoped(scope, || stage_state_file(&state, &rows))
             .expect("failed to spawn SST staging thread");
-        let log_result = stage_log_file(&log_path, writes);
+        let log_result = stage_log_file(&log, sequence, &rows);
         (
             log_result,
-            state.join().expect("state staging thread panicked"),
+            state_task.join().expect("state staging thread panicked"),
         )
     });
     let log_bytes = log_result.unwrap_or_else(|error| panic!("failed to stage log SST: {error}"));
     let state_bytes =
         state_result.unwrap_or_else(|error| panic!("failed to stage state SST: {error}"));
-    StagedFiles {
-        log: log_path,
-        state: state_path,
-        staged_bytes: log_bytes + state_bytes,
-    }
+    (
+        PreparedWrite {
+            sequence,
+            requests,
+            log,
+            state,
+            staged_bytes: log_bytes + state_bytes,
+        },
+        disconnected,
+    )
 }
 
-/// Options for staged SST files. Uncompressed: compressing on the ingest path would trade ack
-/// latency for bytes, and lower levels re-compress state during compaction per the CF options.
-fn staging_options() -> Options {
+/// Stages the single-row log SST: the group's sequence mapped to the exact encoded batch the
+/// stream service serves. Uncompressed, like the state SST.
+fn stage_log_file(path: &Path, sequence: u64, rows: &[(Bytes, Bytes)]) -> Result<usize, String> {
+    let payload = encode_log_value(sequence, rows);
     let mut options = Options::default();
     options.set_compression_type(DBCompressionType::None);
-    options
-}
-
-/// Stages the replay-log SST: one row per sequence, keyed in ascending sequence order.
-fn stage_log_file(path: &Path, writes: &[AssignedWrite]) -> Result<usize, String> {
-    let options = staging_options();
     let mut writer = SstFileWriter::create(&options);
     writer.open(path).map_err(|e| e.to_string())?;
-    let mut bytes = 0;
-    for write in writes {
-        let value = encode_log_value(write.sequence, &write.request.kvs);
-        bytes += LOG_BATCH_KEY_LEN + value.len();
-        writer
-            .put(sequence_log_key(write.sequence), &value)
-            .map_err(|e| e.to_string())?;
-    }
+    writer
+        .put(sequence_log_key(sequence), &payload)
+        .map_err(|e| e.to_string())?;
     // `finish` syncs the file before it is linked into the DB.
     writer.finish().map_err(|e| e.to_string())?;
-    Ok(bytes)
+    Ok(LOG_BATCH_KEY_LEN + payload.len())
 }
 
 /// Stages the current-state SST: the group's rows sorted by key, with the last write per key
-/// winning (across coalesced requests, in sequence order).
-fn stage_state_file(path: &Path, writes: &[AssignedWrite]) -> Result<usize, String> {
-    let mut rows: Vec<(&Bytes, &Bytes)> =
-        Vec::with_capacity(writes.iter().map(|write| write.request.kvs.len()).sum());
-    for write in writes {
-        for (key, value) in &write.request.kvs {
-            rows.push((key, value));
-        }
-    }
+/// winning (in arrival order across coalesced requests). Uncompressed: compressing on the
+/// ingest path would trade ack latency for bytes, and lower levels re-compress state during
+/// compaction per the CF options.
+fn stage_state_file(path: &Path, rows: &[(Bytes, Bytes)]) -> Result<usize, String> {
+    let mut rows: Vec<(&Bytes, &Bytes)> = rows.iter().map(|(key, value)| (key, value)).collect();
     // Stable sort: equal keys keep arrival order, so the last occurrence is the newest.
     rows.sort_by(|a, b| a.0.cmp(b.0));
 
-    let options = staging_options();
+    let mut options = Options::default();
+    options.set_compression_type(DBCompressionType::None);
     let mut writer = SstFileWriter::create(&options);
     writer.open(path).map_err(|e| e.to_string())?;
     let mut bytes = 0;
@@ -605,55 +609,57 @@ fn stage_state_file(path: &Path, writes: &[AssignedWrite]) -> Result<usize, Stri
     Ok(bytes)
 }
 
-/// Commits prepared groups one at a time — log ingestion, state ingestion, publish, ack — until
-/// the group channel closes (store drop). Any write failure panics inside `commit_group`.
-fn run_commit(db: Arc<DB>, frontiers: Arc<Frontiers>, receiver: mpsc::Receiver<PreparedWrite>) {
-    while let Ok(group) = receiver.recv() {
-        commit_group(&db, &frontiers, group);
-    }
-}
-
-/// Commits one group: ingests its log file (durability), then its state file (visibility), then
-/// publishes the frontier and resolves the requests. Any write failure is fatal (panic): once
-/// the log rows are durable the group cannot be rolled back (its sequences must not be
-/// re-issued), and the next open rolls it forward by replaying the log file — so nothing is ever
-/// reclaimed or retried in-process. The panic drops the group's response channels, so waiting
-/// callers observe an error even though the group may resurface after the restart repair — an
-/// accepted at-least-once ambiguity of this severe error path.
+/// Commits one group: ingests its log row (durability), then its state file (visibility), then
+/// publishes the frontier, advances the floor, and resolves the requests. Any write failure is
+/// fatal (panic): once the log row is durable the group cannot be rolled back (its sequence
+/// must not be re-issued), and the next open rolls it forward by replaying the row — so
+/// nothing is ever reclaimed or retried in-process. The panic drops the group's response
+/// channels, so waiting callers observe an error even though the group may resurface after the
+/// restart repair — an accepted at-least-once ambiguity of this severe error path.
 fn commit_group(db: &DB, frontiers: &Frontiers, group: PreparedWrite) {
-    assert!(!group.writes.is_empty(), "groups are never empty");
-    let PreparedWrite { writes, staged } = group;
-    let requests = writes.len();
-    let last_sequence = writes
-        .last()
-        .expect("non-empty group has a last write")
-        .sequence;
+    assert!(!group.requests.is_empty(), "groups are never empty");
+    let PreparedWrite {
+        sequence,
+        requests,
+        log,
+        state,
+        staged_bytes,
+    } = group;
 
-    // Log first: its rows define durability, and an ingested state file without its log rows
-    // could leave keys in the store that were never part of a sequenced batch. This runs outside
-    // the floor lock, which is safe against a concurrent prune: every sequence in this file is
-    // above the published frontier (publish happens below, only after the state ingestion),
-    // while a prune's log deletes are capped at a published frontier it loaded earlier — so the
-    // prune's tombstone and file unlink are always disjoint from the file being ingested, and
-    // RocksDB serializes the metadata edits themselves.
-    ingest_staged_file(db, LOG_CF, &staged.log);
+    // Log first: the durable row alone defines the group (an ingested state file without its
+    // log row could leave keys in the store that were never part of a sequenced batch). Safe
+    // against a concurrent prune without a lock: a prune only deletes rows below a published
+    // frontier it loaded earlier, and this sequence sits above every published frontier until
+    // publish.
+    ingest_staged_file(db, LOG_CF, &log);
 
     // Ingest and publish under the floor lock: a prune loads the published frontier as its
     // state floor under the same lock, so no scan-visible state row can outrun the frontier
     // covering it (a key prune must never delete a row the floor does not cover).
     let publish_guard = frontiers.persist.lock();
-    ingest_staged_file(db, STATE_CF, &staged.state);
+    ingest_staged_file(db, STATE_CF, &state);
 
     // Release so `current_sequence` readers only observe frontiers whose rows are readable.
-    frontiers.published.store(last_sequence, Ordering::Release);
+    frontiers.published.store(sequence, Ordering::Release);
+
+    // Advance the floor while still under the lock — unsynced, a memtable write: the group's
+    // state is durably ingested, so a crash from here on replays at most the groups whose
+    // floor advance was lost. Prunes and clean shutdown persist the floor synced.
+    let mut floor = rocksdb::WriteBatch::default();
+    let meta_cf = db
+        .cf_handle(META_CF)
+        .expect("meta CF must exist (created on open)");
+    floor.put_cf(meta_cf, SEQ_META_KEY, sequence.to_le_bytes());
+    db.write(floor)
+        .unwrap_or_else(|error| panic!("failed to advance state floor: {error}"));
     drop(publish_guard);
     debug!(
-        requests,
-        staged_bytes = staged.staged_bytes,
-        sequence = last_sequence,
-        "committed write batch"
+        requests = requests.len(),
+        staged_bytes, sequence, "committed write batch"
     );
-    complete_assigned_writes(writes);
+    for request in requests {
+        let _ = request.response.send(Ok(sequence));
+    }
 }
 
 /// Ingests one staged SST file into `cf`. Ingestion links the file into the column family and
@@ -680,26 +686,41 @@ fn write_synced_batch(db: &DB, batch: rocksdb::WriteBatch) -> Result<(), String>
         .map_err(|e| e.to_string())
 }
 
-/// Creates the SST staging directory and deletes files a crashed ingestion left behind. Staged
-/// files are only ever moved into the DB by ingestion, so anything still here was never visible.
+/// Creates the SST staging directory and deletes files a crashed writer left behind. Staged
+/// files are only ever consumed by `commit`, so anything still here was never visible.
 fn prepare_ingest_dir(store_path: &Path) -> Result<PathBuf, String> {
     let ingest_dir = store_path.join(LOG_INGEST_DIR);
     std::fs::create_dir_all(&ingest_dir)
-        .map_err(|e| format!("failed to create log ingest directory: {e}"))?;
+        .map_err(|e| format!("failed to create staging directory: {e}"))?;
     for entry in std::fs::read_dir(&ingest_dir)
-        .map_err(|e| format!("failed to read log ingest directory: {e}"))?
+        .map_err(|e| format!("failed to read staging directory: {e}"))?
     {
-        let entry = entry.map_err(|e| format!("failed to read log ingest directory: {e}"))?;
+        let entry = entry.map_err(|e| format!("failed to read staging directory: {e}"))?;
         std::fs::remove_file(entry.path())
-            .map_err(|e| format!("failed to remove staged log file: {e}"))?;
+            .map_err(|e| format!("failed to remove staged file: {e}"))?;
     }
     Ok(ingest_dir)
 }
 
-/// Returns the sequence of the highest retained log row, or zero when the log is empty. Rows are
-/// only ever ingested by sequential, atomic commits, so the highest retained row is a lower bound
-/// on the durable frontier (pruning persists the state floor atomically with its deletes, so the
-/// floor covers whatever was pruned).
+/// Encodes a sequence number as a log-CF key that preserves numeric order in RocksDB.
+fn sequence_log_key(sequence: u64) -> [u8; LOG_BATCH_KEY_LEN] {
+    sequence.to_be_bytes()
+}
+
+/// Decodes a log-CF key back into the sequence number it indexes.
+fn sequence_from_log_key(key: &[u8]) -> Result<u64, String> {
+    if key.len() != LOG_BATCH_KEY_LEN {
+        return Err(format!("log CF key has unexpected length {}", key.len()));
+    }
+    let mut raw = [0u8; 8];
+    raw.copy_from_slice(&key[..8]);
+    Ok(u64::from_be_bytes(raw))
+}
+
+/// Returns the sequence of the highest retained log row, or zero when the log is empty. Rows
+/// are only ever ingested by sequential, atomic commits, so the highest retained row is a lower
+/// bound on the durable frontier (pruning persists the state floor atomically with its deletes,
+/// so the floor covers whatever was pruned).
 fn highest_log_row(db: &DB) -> Result<u64, String> {
     let log_cf = db
         .cf_handle(LOG_CF)
@@ -727,32 +748,19 @@ fn read_state_floor(db: &DB) -> Result<u64, String> {
     }
 }
 
-/// Repairs the current state after a crash that hit between a group's two ingestions: the log
-/// file is durable but the state file may be missing, and only for the last committed group
-/// (commit ingests strictly in order and publishes before starting the next group). Re-applies
-/// the rows of the last retained log file — the group whose state might be missing is always
-/// the one that ends at the durable frontier — which is idempotent because those rows are the
-/// newest writes for their keys. Rows at or below `floor` are skipped: their state is already
-/// authoritative, and key pruning may have deleted rows a replay would resurrect.
-fn replay_last_log_file(db: &DB, floor: u64) -> Result<(), String> {
-    let last_file_start = db
-        .live_files()
-        .map_err(|e| e.to_string())?
-        .into_iter()
-        .filter(|file| file.column_family_name == LOG_CF)
-        .filter_map(|file| file.start_key.zip(file.end_key))
-        .max_by(|a, b| a.1.cmp(&b.1))
-        .map(|(start, _)| sequence_from_log_key(&start))
-        .transpose()?;
-    let Some(start) = last_file_start else {
-        return Ok(());
-    };
-    let Some(above_floor) = floor.checked_add(1) else {
+/// Re-applies retained log rows above the state floor to the state column family. Only the
+/// trailing groups can be missing state (the writer commits strictly in order, and the floor
+/// advances with every commit), so this reads at most the few newest rows in practice; it is
+/// idempotent because a group's rows are the newest writes for their keys and are applied in
+/// ascending sequence order. Rows at or below `floor` are never replayed: their state is
+/// authoritative, and key pruning may have deleted rows a replay would resurrect. Ingestion is
+/// atomic, so no partial row can exist; a row that fails to decode is real corruption and
+/// fails the open.
+fn replay_log_above_floor(db: &DB, floor: u64) -> Result<(), String> {
+    let Some(start) = floor.checked_add(1) else {
         // The floor covers every representable sequence; nothing can need replay.
         return Ok(());
     };
-    let start = start.max(above_floor);
-
     let log_cf = db
         .cf_handle(LOG_CF)
         .expect("log CF must exist (created on open)");
@@ -767,19 +775,12 @@ fn replay_last_log_file(db: &DB, floor: u64) -> Result<(), String> {
             batch.put(entry.key, entry.value);
         }
     }
-    if !batch.is_empty() {
-        // Synced: once a later commit moves the last-file replay bound past this group, a
-        // repair lost to power loss would never be re-run.
-        write_synced_batch(db, batch)?;
+    if batch.is_empty() {
+        return Ok(());
     }
-    Ok(())
-}
-
-/// Resolves every assigned write with its own committed sequence number.
-fn complete_assigned_writes(writes: Vec<AssignedWrite>) {
-    for write in writes {
-        let _ = write.request.response.send(Ok(write.sequence));
-    }
+    // Synced: once a later floor advance moves the replay bound past these groups, a repair
+    // lost to power loss would never be re-run.
+    write_synced_batch(db, batch)
 }
 
 /// Application-level write pipeline options used by [`RocksStore::open`].
@@ -807,11 +808,10 @@ fn available_parallelism() -> NonZeroUsize {
 /// RocksDB engine and application-level write pipeline options used by [`RocksStore::open`].
 ///
 /// Column-family options are deliberately not configurable — the store's correctness leans on
-/// stock CF behavior: staged state SSTs and range-scan bounds assume bytewise key order, crash
-/// repair depends on log-CF file boundaries staying aligned with commit groups (see
-/// `replay_last_log_file`), and rows must never be dropped by a caller-supplied compaction
-/// filter or TTL (acked writes must stay readable, the meta CF's state-floor row must persist,
-/// and the repair replay would nondeterministically resurrect expired state rows).
+/// the CF options `open` chooses: staged state SSTs and range-scan bounds assume bytewise key
+/// order, and rows must never be dropped by a caller-supplied compaction filter or TTL (acked
+/// writes must stay readable, the meta CF's state-floor row must persist, and the repair
+/// replay would nondeterministically resurrect expired state rows).
 pub struct RocksConfig {
     /// Database-wide options. The default raises RocksDB's background-job budget (flushes and
     /// the compactions that must keep merging the overlapping ingested state SSTs) from the
@@ -829,6 +829,11 @@ impl Default for RocksConfig {
     fn default() -> Self {
         let mut db_options = Options::default();
         db_options.increase_parallelism(available_parallelism().get() as i32);
+        // Ingest links one log and one state SST per commit group into the DB, and stock
+        // RocksDB (max_open_files = -1) keeps every touched file's reader open forever. Bound
+        // the table-reader cache so cold reads pay a reopen instead of the process exhausting
+        // file descriptors.
+        db_options.set_max_open_files(4096);
         Self {
             db_options,
             write_pipeline: RocksWritePipelineConfig::default(),
@@ -848,10 +853,10 @@ pub struct RocksStore {
 impl RocksStore {
     /// Open the store with default options, unless `config` overrides the database or
     /// write-pipeline options (column families always run stock options — see [`RocksConfig`]).
-    /// Re-derives the durable frontier from the retained
-    /// log rows and the state-floor meta row, then replays the last retained log file's rows
-    /// above the floor into the default column family so the current state is complete below
-    /// the durable sequence even after a crash between a group's log and state ingestions.
+    /// Re-derives the durable frontier from the retained log rows and the state-floor meta row,
+    /// then re-applies the log rows above the floor to the state column family so the current
+    /// state is complete below the durable sequence even after a crash mid-commit (a no-op
+    /// after a clean shutdown, which parks the floor at the frontier).
     pub fn open(path: &Path, config: Option<RocksConfig>) -> Result<Self, String> {
         let RocksConfig {
             mut db_options,
@@ -868,12 +873,11 @@ impl RocksStore {
             DB::open_cf_descriptors(&db_options, path, vec![cf_state, cf_meta, cf_log])
                 .map_err(|e| e.to_string())?,
         );
-        // Commits do not write the state-floor meta row; the log rows are the durable record.
-        let floor = read_state_floor(&db)?;
-        let seq = floor.max(highest_log_row(&db)?);
 
         let ingest_dir = prepare_ingest_dir(path)?;
-        replay_last_log_file(&db, floor)?;
+        let floor = read_state_floor(&db)?;
+        let seq = floor.max(highest_log_row(&db)?);
+        replay_log_above_floor(&db, floor)?;
 
         let frontiers = Arc::new(Frontiers::new(seq));
         let writer = Arc::new(Writer::start(
@@ -933,39 +937,30 @@ impl RocksStore {
         write_synced_batch(&self.db, batch)
     }
 
-    /// Deletes replay-log batches with sequence numbers below `cutoff_exclusive`.
+    /// Deletes replay-log rows with sequence numbers below `cutoff_exclusive`.
     fn prune_log(&self, cutoff_exclusive: u64) -> Result<(), String> {
         if cutoff_exclusive == 0 {
             return Ok(());
         }
         let _guard = self.frontiers.persist.lock();
-        let cf = self.log_cf();
 
-        // One synced, atomic batch: the range tombstone that logically deletes the rows, and the
-        // state floor that keeps `open` from re-deriving a regressed frontier once those rows
-        // are gone. The published frontier covers every pruned row (the cutoff is capped at
-        // published + 1), and everything at or below it is durable and applied to the state.
-        // That cap is also what makes this safe against `commit`'s concurrent, lock-free log
-        // ingestion: an in-flight group's rows all sit above every published frontier this
-        // prune could have loaded, so neither the tombstone nor the file unlink below can touch
-        // them (and `delete_file_in_range_cf` only drops files entirely inside its range).
+        // One synced, atomic batch: the range tombstone that deletes the rows, and the state
+        // floor that keeps `open` from re-deriving a regressed frontier once they are gone.
+        // The published frontier covers every pruned row (the cutoff is capped at
+        // published + 1), and everything at or below it is durable and applied to the state —
+        // which also makes this safe against the writer's concurrent, lock-free log ingestion:
+        // an in-flight group's row sits above every published frontier this prune could have
+        // loaded. Space is reclaimed by ordinary compaction; nothing assumes which SST files
+        // hold the rows.
         let published = self.frontiers.published.load(Ordering::Acquire);
         let mut batch = rocksdb::WriteBatch::default();
         batch.put_cf(self.meta_cf(), SEQ_META_KEY, published.to_le_bytes());
-        batch.delete_range_cf(cf, sequence_log_key(0), sequence_log_key(cutoff_exclusive));
-        write_synced_batch(&self.db, batch)?;
-
-        // Unlink the ingested SST files that sit entirely below the cutoff (the common case,
-        // since each file covers one commit group's contiguous sequence range). This reclaims
-        // their space immediately, without compaction ever reading the massive log payloads;
-        // rows in a file straddling the cutoff stay covered by the tombstone above.
-        self.db
-            .delete_file_in_range_cf(
-                cf,
-                sequence_log_key(0),
-                sequence_log_key(cutoff_exclusive - 1),
-            )
-            .map_err(|e| e.to_string())
+        batch.delete_range_cf(
+            self.log_cf(),
+            sequence_log_key(0),
+            sequence_log_key(cutoff_exclusive),
+        );
+        write_synced_batch(&self.db, batch)
     }
 
     /// Applies each prune policy in document order to either current rows or replay-log rows.
@@ -1062,9 +1057,9 @@ impl Sequence for RocksStore {
     }
 }
 
-// Ingest uses dedicated writer threads so blocking RocksDB writes do not occupy Tokio workers.
-// The writer folds already-queued requests into one commit group while preserving a contiguous
-// sequence number and replay-log row for each request.
+// Ingest uses dedicated writer threads so blocking storage writes do not occupy Tokio workers.
+// The writer folds already-queued requests into one commit group that shares a single sequence
+// number and replay-log batch.
 impl Ingest for RocksStore {
     async fn put_batch(&self, kvs: Vec<(Bytes, Bytes)>) -> Result<u64, String> {
         self.writer.put_batch(kvs).await
@@ -1122,6 +1117,7 @@ impl Prune for RocksStore {
     }
 }
 
+// Log batches are loaded from the log column family on demand: no cache, one read per request.
 impl Log for RocksStore {
     async fn get_batch(&self, sequence_number: u64) -> Result<Option<LogBatch>, String> {
         // Serve only published batches: rows above the visible frontier are still being
@@ -1129,12 +1125,9 @@ impl Log for RocksStore {
         if sequence_number > self.frontiers.published.load(Ordering::Acquire) {
             return Ok(None);
         }
-        let store = self.clone();
-        let cf = store.log_cf();
-        let sequence_key = sequence_log_key(sequence_number);
-        let value = match store
+        let value = match self
             .db
-            .get_cf(cf, sequence_key)
+            .get_cf(self.log_cf(), sequence_log_key(sequence_number))
             .map_err(|e| e.to_string())?
         {
             Some(value) => value,
@@ -1144,17 +1137,15 @@ impl Log for RocksStore {
     }
 
     async fn oldest_retained_batch(&self) -> Result<Option<u64>, String> {
-        let store = self.clone();
-        let cf = store.log_cf();
-        let mut it = store.db.iterator_cf(cf, IteratorMode::Start);
+        let mut it = self.db.iterator_cf(self.log_cf(), IteratorMode::Start);
         match it.next() {
             None => Ok(None),
             Some(item) => {
                 let (key, _) = item.map_err(|e| e.to_string())?;
                 let sequence = sequence_from_log_key(key.as_ref())?;
                 // Gate on the published frontier like `get_batch`: never advertise an oldest
-                // batch that `get_batch` would then hide (log rows can outrun the published
-                // frontier while a group's state ingestion is in flight or has failed).
+                // batch that `get_batch` would then hide (a log row can outrun the published
+                // frontier while its group's state ingestion is in flight or has failed).
                 if sequence > self.frontiers.published.load(Ordering::Acquire) {
                     return Ok(None);
                 }
@@ -1164,22 +1155,7 @@ impl Log for RocksStore {
     }
 }
 
-/// Encodes a sequence number as a log-CF key that preserves numeric order in RocksDB.
-fn sequence_log_key(sequence: u64) -> [u8; LOG_BATCH_KEY_LEN] {
-    sequence.to_be_bytes()
-}
-
-/// Decodes a log-CF key back into the sequence number it indexes.
-fn sequence_from_log_key(key: &[u8]) -> Result<u64, String> {
-    if key.len() != LOG_BATCH_KEY_LEN {
-        return Err(format!("log CF key has unexpected length {}", key.len()));
-    }
-    let mut raw = [0u8; 8];
-    raw.copy_from_slice(&key[..8]);
-    Ok(u64::from_be_bytes(raw))
-}
-
-/// Encodes the replay payload for one sequence's key/value rows.
+/// Encodes the batch payload served for one sequence's key/value rows.
 fn encode_log_value(sequence: u64, kvs: &[(Bytes, Bytes)]) -> Vec<u8> {
     StreamGetResponse {
         sequence_number: sequence,
@@ -1243,32 +1219,27 @@ mod tests {
         store.frontiers.published.load(Ordering::Acquire)
     }
 
-    fn assigned_write(sequence: u64, key: &'static [u8], value: &'static [u8]) -> AssignedWrite {
-        assigned_write_with_response(sequence, key, value).0
+    /// Writes one log row directly, bypassing the write pipeline and the floor advance.
+    fn seed_log_row(store: &RocksStore, sequence: u64, payload: &[u8]) {
+        store
+            .db
+            .put_cf(store.log_cf(), sequence_log_key(sequence), payload)
+            .expect("seed log row");
     }
 
-    fn assigned_write_with_response(
-        sequence: u64,
-        key: &'static [u8],
-        value: &'static [u8],
-    ) -> (AssignedWrite, oneshot::Receiver<Result<u64, String>>) {
-        let (response, result) = oneshot::channel();
-        (
-            AssignedWrite {
-                sequence,
-                request: WriteRequest {
-                    kvs: vec![(Bytes::from_static(key), Bytes::from_static(value))],
-                    response,
-                },
-            },
-            result,
-        )
-    }
-
-    fn prepared_write(store: &RocksStore, writes: Vec<AssignedWrite>) -> PreparedWrite {
+    /// Stages one commit group carrying `kvs` under the sequence after `from`.
+    fn prepared_write(store: &RocksStore, from: u64, kvs: Vec<(Bytes, Bytes)>) -> PreparedWrite {
+        let (_sender, receiver) = mpsc::channel::<WriteRequest>();
+        let (response, _result) = oneshot::channel();
         let ingest_dir = store.db.path().join(LOG_INGEST_DIR);
-        let staged = stage_group_files(&ingest_dir, &writes);
-        PreparedWrite { writes, staged }
+        let (group, _) = stage_queued_write(
+            &ingest_dir,
+            &receiver,
+            WriteRequest { kvs, response },
+            from,
+            DEFAULT_COMMIT_COALESCE_MAX_BATCH_BYTES,
+        );
+        group
     }
 
     #[test]
@@ -1283,7 +1254,7 @@ mod tests {
     }
 
     #[test]
-    fn prepare_queued_write_collects_all_pending_below_byte_cap() {
+    fn stage_queued_write_collects_all_pending_below_byte_cap() {
         let dir = tempdir().expect("tempdir");
         let (sender, receiver) = mpsc::channel();
         sender.send(write_request(b"a")).expect("send");
@@ -1292,22 +1263,23 @@ mod tests {
         drop(sender);
 
         let first = receiver.recv().expect("first request");
-        let (group, disconnected) = prepare_queued_write(
+        let (group, disconnected) = stage_queued_write(
             dir.path(),
             &receiver,
             first,
             0,
             DEFAULT_COMMIT_COALESCE_MAX_BATCH_BYTES,
         );
-        assert_eq!(group.writes.len(), 3);
-        assert!(group.staged.log.exists());
-        assert!(group.staged.state.exists());
-        assert!(group.staged.staged_bytes > 0);
+        assert_eq!(group.sequence, 1);
+        assert_eq!(group.requests.len(), 3);
+        assert!(group.log.exists());
+        assert!(group.state.exists());
+        assert!(group.staged_bytes > 0);
         assert!(disconnected);
     }
 
     #[test]
-    fn prepare_queued_write_stops_after_soft_byte_cap() {
+    fn stage_queued_write_stops_after_soft_byte_cap() {
         let dir = tempdir().expect("tempdir");
         let (sender, receiver) = mpsc::channel();
         sender.send(write_request(b"a")).expect("send");
@@ -1316,10 +1288,10 @@ mod tests {
         drop(sender);
 
         let first = receiver.recv().expect("first request");
-        let (group, disconnected) = prepare_queued_write(dir.path(), &receiver, first, 0, 1);
+        let (group, disconnected) = stage_queued_write(dir.path(), &receiver, first, 0, 1);
 
-        assert_eq!(group.writes.len(), 1);
-        assert_eq!(group.writes[0].request.kvs[0].0.as_ref(), b"a");
+        assert_eq!(group.requests.len(), 1);
+        assert_eq!(group.requests[0].kvs[0].0.as_ref(), b"a");
         assert!(!disconnected);
         assert_eq!(
             receiver
@@ -1340,12 +1312,16 @@ mod tests {
         let dir = tempdir().expect("tempdir");
         let store = RocksStore::open(dir.path(), None).expect("open db");
 
-        let group = prepared_write(&store, vec![assigned_write(1, b"a", b"1")]);
-        std::fs::remove_file(&group.staged.state).expect("sabotage staged state file");
+        let group = prepared_write(
+            &store,
+            0,
+            vec![(Bytes::from_static(b"a"), Bytes::from_static(b"1"))],
+        );
+        std::fs::remove_file(&group.state).expect("sabotage staged state file");
         commit_and_apply(&store, group);
     }
 
-    /// One multi-megabyte batch, sized to exercise multi-block ingested log SSTs.
+    /// One multi-megabyte batch, sized to exercise multi-block ingested log rows.
     fn large_batch(tag: u8) -> Vec<(Bytes, Bytes)> {
         (0..1040)
             .map(|i| {
@@ -1389,9 +1365,7 @@ mod tests {
             Some(vec![1u8; 4096])
         );
 
-        // Sequence pruning drops the ingested rows like any other log rows, and unlinks the
-        // pruned batches' SST files outright instead of leaving them for compaction.
-        let log_files_before = live_log_files(&store);
+        // Sequence pruning deletes the rows by key; space reclamation is compaction's job.
         store
             .apply_prune_policies(PrunePolicyDocument {
                 version: exoware_sdk::prune_policy::PRUNE_POLICY_DOCUMENT_VERSION,
@@ -1407,24 +1381,18 @@ mod tests {
             store.oldest_retained_batch().await.expect("oldest"),
             Some(second)
         );
-        let log_files_after = live_log_files(&store);
-        assert_eq!(log_files_before, 2, "one ingested file per batch");
-        assert_eq!(log_files_after, 1, "pruned batch's file is unlinked");
     }
 
-    /// Number of live SST files backing the log column family.
-    fn live_log_files(store: &RocksStore) -> usize {
+    /// Number of retained rows in the log column family.
+    fn live_log_rows(store: &RocksStore) -> usize {
         store
             .db
-            .live_files()
-            .expect("live files")
-            .into_iter()
-            .filter(|file| file.column_family_name == LOG_CF)
+            .iterator_cf(store.log_cf(), IteratorMode::Start)
             .count()
     }
 
     #[tokio::test]
-    async fn reopen_replays_log_rows_missing_from_state() {
+    async fn reopen_replays_newest_log_batch_missing_from_state() {
         let dir = tempdir().expect("tempdir");
         {
             let store = RocksStore::open(dir.path(), None).expect("open db");
@@ -1433,44 +1401,39 @@ mod tests {
                 .await
                 .expect("put");
 
-            // Simulate a crash that lost the WAL-less state rows for sequences 2 and 3 but kept
-            // the durable log rows: append them directly, bypassing the state apply stage. No
-            // sequence meta row is written — the reopened store must re-derive the durable
-            // frontier from the retained rows alone, exactly as after a real crash (commits
-            // never write the meta row).
-            let mut log_batch = rocksdb::WriteBatch::default();
-            log_batch.put_cf(
-                store.log_cf(),
-                sequence_log_key(2),
-                encoded_log_entry(2, b"k2", b"v2-stale"),
-            );
-            log_batch.put_cf(
-                store.log_cf(),
-                sequence_log_key(3),
-                StreamGetResponse {
-                    sequence_number: 3,
-                    entries: vec![
-                        Entry {
-                            key: b"k2".to_vec(),
-                            value: Bytes::from_static(b"v2"),
-                            ..Default::default()
-                        },
-                        Entry {
-                            key: b"k3".to_vec(),
-                            value: Bytes::from_static(b"v3"),
-                            ..Default::default()
-                        },
-                    ],
-                    ..Default::default()
-                }
-                .encode_to_vec(),
-            );
-            write_synced_batch(&store.db, log_batch).expect("write log rows");
+            // Simulate a crash that lost the WAL-less state rows for sequence 2 (the group
+            // whose commit was interrupted) but kept its durable log row: write it directly,
+            // bypassing the state apply stage and the floor advance — the reopened store must
+            // re-derive the durable frontier from the retained rows alone, exactly as after a
+            // crash that also lost the unsynced floor advance.
+            let payload = StreamGetResponse {
+                sequence_number: 2,
+                entries: vec![
+                    Entry {
+                        key: b"k2".to_vec(),
+                        value: Bytes::from_static(b"v2-stale"),
+                        ..Default::default()
+                    },
+                    Entry {
+                        key: b"k2".to_vec(),
+                        value: Bytes::from_static(b"v2"),
+                        ..Default::default()
+                    },
+                    Entry {
+                        key: b"k3".to_vec(),
+                        value: Bytes::from_static(b"v3"),
+                        ..Default::default()
+                    },
+                ],
+                ..Default::default()
+            }
+            .encode_to_vec();
+            seed_log_row(&store, 2, &payload);
         }
 
         let store = RocksStore::open(dir.path(), None).expect("reopen db");
-        assert_eq!(store.current_sequence(), 3);
-        // Replay applied the missing rows in sequence order: last writer wins for k2.
+        assert_eq!(store.current_sequence(), 2);
+        // Replay applied the missing rows in arrival order: last writer wins for k2.
         for (key, value) in [
             (b"k1" as &[u8], b"v1" as &[u8]),
             (b"k2", b"v2"),
@@ -1482,10 +1445,10 @@ mod tests {
                 "key {key:?}"
             );
         }
-        // A second reopen replays again (the floor only advances on prune); idempotent.
+        // A second reopen has nothing to repair: the first clean close parked the floor.
         drop(store);
         let store = RocksStore::open(dir.path(), None).expect("reopen db again");
-        assert_eq!(store.current_sequence(), 3);
+        assert_eq!(store.current_sequence(), 2);
         assert_eq!(
             store.get_raw(b"k2").expect("get").as_deref(),
             Some(b"v2" as &[u8])
@@ -1524,35 +1487,50 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn prepared_write_preserves_contiguous_sequence_logs() {
+    async fn coalesced_group_shares_one_sequence() {
         let dir = tempdir().expect("tempdir");
         let store = RocksStore::open(dir.path(), None).expect("open db");
         let prepared = prepared_write(
             &store,
+            0,
             vec![
-                assigned_write(1, b"a", b"1"),
-                assigned_write(2, b"b", b"2"),
-                assigned_write(3, b"c", b"3"),
+                (Bytes::from_static(b"a"), Bytes::from_static(b"1")),
+                (Bytes::from_static(b"b"), Bytes::from_static(b"2")),
             ],
         );
+        assert_eq!(prepared.sequence, 1);
+        assert_eq!(commit_and_apply(&store, prepared), 1);
 
-        assert_eq!(prepared.writes.len(), 3);
-        let committed = commit_and_apply(&store, prepared);
-        assert_eq!(committed, 3);
+        let second = prepared_write(
+            &store,
+            1,
+            vec![(Bytes::from_static(b"c"), Bytes::from_static(b"3"))],
+        );
+        assert_eq!(second.sequence, 2);
+        assert_eq!(commit_and_apply(&store, second), 2);
 
-        assert_eq!(store.current_sequence(), 3);
-        for (sequence, key, value) in [
-            (1, Bytes::from_static(b"a"), Bytes::from_static(b"1")),
-            (2, Bytes::from_static(b"b"), Bytes::from_static(b"2")),
-            (3, Bytes::from_static(b"c"), Bytes::from_static(b"3")),
-        ] {
-            let batch = store
-                .get_batch(sequence)
-                .await
-                .expect("get batch")
-                .expect("batch retained");
-            assert_eq!(batch_entries(batch), vec![(key, value)]);
-        }
+        // Each group serves one batch carrying all its rows.
+        let batch = store
+            .get_batch(1)
+            .await
+            .expect("get batch")
+            .expect("batch retained");
+        assert_eq!(
+            batch_entries(batch),
+            vec![
+                (Bytes::from_static(b"a"), Bytes::from_static(b"1")),
+                (Bytes::from_static(b"b"), Bytes::from_static(b"2")),
+            ]
+        );
+        let batch = store
+            .get_batch(2)
+            .await
+            .expect("get batch")
+            .expect("batch retained");
+        assert_eq!(
+            batch_entries(batch),
+            vec![(Bytes::from_static(b"c"), Bytes::from_static(b"3"))]
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
@@ -1602,16 +1580,9 @@ mod tests {
     async fn sequence_prune_spares_log_rows_above_published_frontier() {
         let dir = tempdir().expect("tempdir");
         let store = RocksStore::open(dir.path(), None).expect("open db");
-        // A durable log row whose group never published (its state ingestion was in flight at a
-        // crash): pruning must spare it — it is the repair replay's input at the next open.
-        store
-            .db
-            .put_cf(
-                store.log_cf(),
-                sequence_log_key(1),
-                encoded_log_entry(1, b"k", b"v"),
-            )
-            .expect("seed log row");
+        // A durable log row whose group never published (its state ingestion was in flight at
+        // a crash): pruning must spare it — it is the repair replay's input at the next open.
+        seed_log_row(&store, 1, &encoded_log_entry(1, b"k", b"v"));
 
         store
             .apply_prune_policies(PrunePolicyDocument {
@@ -1623,25 +1594,18 @@ mod tests {
             })
             .expect("prune");
 
-        let survivors = store
-            .db
-            .iterator_cf(store.log_cf(), IteratorMode::Start)
-            .count();
-        assert_eq!(survivors, 1, "unpublished log row must survive the prune");
+        assert_eq!(
+            live_log_rows(&store),
+            1,
+            "unpublished log row must survive the prune"
+        );
     }
 
     #[tokio::test]
     async fn oldest_retained_batch_hides_rows_above_published_frontier() {
         let dir = tempdir().expect("tempdir");
         let store = RocksStore::open(dir.path(), None).expect("open db");
-        store
-            .db
-            .put_cf(
-                store.log_cf(),
-                sequence_log_key(1),
-                encoded_log_entry(1, b"k", b"v"),
-            )
-            .expect("seed log row");
+        seed_log_row(&store, 1, &encoded_log_entry(1, b"k", b"v"));
 
         // The row's group never published (e.g. its state ingestion is still in flight), so it
         // must stay invisible to both the point read and the oldest-retained probe.

--- a/examples/simulator/src/rocks.rs
+++ b/examples/simulator/src/rocks.rs
@@ -3,6 +3,13 @@
 //! A separate `log` column family keeps per-sequence-number batch payloads so the stream service
 //! can serve replay and point lookups. Batch-log pruning is driven exclusively by the compact
 //! service's `Sequence` scope.
+//!
+//! Durability is anchored on the replay log: each commit group writes its log rows plus the
+//! durable-sequence meta row in one synced batch, then the current-state rows are applied without
+//! a WAL and the visible sequence frontier advances. The state rows are recovered from the log,
+//! so `open` replays retained log rows above the persisted state-flushed watermark, and pruning
+//! flushes the default column family (advancing that watermark) before deleting log rows it may
+//! otherwise still need for recovery.
 
 use std::cmp::Ordering as CmpOrdering;
 use std::collections::BTreeMap;
@@ -12,8 +19,10 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{mpsc, Arc, Mutex};
 use std::thread;
 
+use buffa::MessageView;
 use bytes::Bytes;
 use exoware_sdk::keys::KeyCodec;
+use exoware_sdk::log::stream::v1::GetResponseView as StreamGetResponseView;
 use exoware_sdk::prune_policy::{
     KeysScope, OrderEncoding, PolicyScope, PrunePolicyDocument, RetainPolicy,
 };
@@ -31,6 +40,10 @@ use tracing::debug;
 
 const META_CF: &str = "meta";
 const SEQ_META_KEY: &[u8] = b"sequence";
+/// Highest sequence whose current-state rows are durable in the default column family (flushed to
+/// SSTs). Recovery replays retained log rows above this watermark to rebuild the state rows that
+/// were applied without a WAL.
+const STATE_FLUSHED_META_KEY: &[u8] = b"state_flushed_sequence";
 const LOG_CF: &str = "log";
 const LOG_BATCH_KEY_LEN: usize = 8;
 const PRUNE_SCAN_BATCH_SIZE: usize = 4096;
@@ -285,14 +298,25 @@ struct AssignedWrite {
     request: WriteRequest,
 }
 
-/// One RocksDB `WriteBatch` covering a contiguous run of assigned sequence numbers, committed
-/// atomically by a single synced write.
+/// One commit group covering a contiguous run of assigned sequence numbers.
 struct PreparedWrite {
     writes: Vec<AssignedWrite>,
-    batch: Result<rocksdb::WriteBatch, String>,
+    /// Replay-log rows plus the durable-sequence meta row, committed atomically by one synced
+    /// write. This batch alone defines durability; the state rows are recoverable from it.
+    log_batch: Result<rocksdb::WriteBatch, String>,
+    /// Current-state rows for the same sequences, applied without a WAL once the log batch is
+    /// durable.
+    state_batch: rocksdb::WriteBatch,
     batch_bytes: usize,
     /// Assignment epoch; `commit` rejects a group whose epoch an earlier failure has superseded.
     epoch: u64,
+}
+
+/// A group whose log batch is durable and whose state rows still have to be applied.
+struct CommittedWrite {
+    writes: Vec<AssignedWrite>,
+    state_batch: rocksdb::WriteBatch,
+    last_sequence: u64,
 }
 
 struct Writer {
@@ -301,19 +325,25 @@ struct Writer {
 }
 
 impl Writer {
-    /// Starts the two-stage write pipeline. `prepare` drains queued requests up to the configured
-    /// byte cap, assigns a contiguous sequence number to each, and builds a size-capped
-    /// `WriteBatch`; `commit` syncs each group and resolves its requests. Keeping `commit` on its
-    /// own thread lets `prepare` build the next wave while the current one is being fsync'd.
+    /// Starts the three-stage write pipeline. `prepare` drains queued requests up to the
+    /// configured byte cap, assigns a contiguous sequence number to each, and builds one log
+    /// batch plus one state batch per wave; `commit` syncs each log batch, publishing the durable
+    /// frontier; `apply` inserts the state rows without a WAL, advances the visible frontier, and
+    /// resolves the requests. The stages overlap, so while one group is being fsync'd the next is
+    /// being built and the previous group's state rows are being applied.
     fn start(
         db: Arc<DB>,
         sequence: Arc<AtomicU64>,
+        durable: Arc<AtomicU64>,
+        flushed: Arc<AtomicU64>,
         write_pipeline: RocksWritePipelineConfig,
     ) -> Self {
         let (request_sender, request_receiver) = mpsc::channel();
         // Rendezvous so `prepare` runs at most one wave ahead of `commit`: it hands off a built
         // group, then builds the next while `commit` syncs this one.
         let (group_sender, group_receiver) = mpsc::sync_channel(0);
+        // Allow `commit` to fsync the next group while `apply` inserts this group's state rows.
+        let (committed_sender, committed_receiver) = mpsc::sync_channel(1);
         let max_commit_batch_bytes = write_pipeline.max_commit_batch_bytes.get();
 
         // Bumped by `commit` whenever a group fails. That rejects the in-flight groups assigned
@@ -321,12 +351,27 @@ impl Writer {
         // sequence, re-allocating the abandoned numbers.
         let epoch = Arc::new(AtomicU64::new(0));
 
+        let apply_db = db.clone();
+        let apply_sequence = sequence.clone();
+        let apply = thread::Builder::new()
+            .name("simulator-rocks-apply".to_string())
+            .spawn(move || run_apply(apply_db, apply_sequence, flushed, committed_receiver))
+            .expect("failed to spawn RocksDB apply worker");
+
         let commit_db = db.clone();
-        let commit_sequence = sequence.clone();
+        let commit_durable = durable.clone();
         let commit_epoch = epoch.clone();
         let commit = thread::Builder::new()
             .name("simulator-rocks-commit".to_string())
-            .spawn(move || run_commit(commit_db, commit_sequence, commit_epoch, group_receiver))
+            .spawn(move || {
+                run_commit(
+                    commit_db,
+                    commit_durable,
+                    commit_epoch,
+                    group_receiver,
+                    committed_sender,
+                )
+            })
             .expect("failed to spawn RocksDB commit worker");
 
         let prepare = thread::Builder::new()
@@ -334,7 +379,7 @@ impl Writer {
             .spawn(move || {
                 run_prepare(
                     db,
-                    sequence,
+                    durable,
                     epoch,
                     request_receiver,
                     group_sender,
@@ -345,7 +390,7 @@ impl Writer {
 
         Self {
             sender: Mutex::new(Some(request_sender)),
-            handles: Mutex::new(vec![prepare, commit]),
+            handles: Mutex::new(vec![prepare, commit, apply]),
         }
     }
 
@@ -371,7 +416,8 @@ impl Writer {
 impl Drop for Writer {
     fn drop(&mut self) {
         // Closing the request channel lets `prepare` drain and exit, which drops the group channel
-        // and stops `commit`; joining keeps background RocksDB writers from outliving the store.
+        // and stops `commit`, which in turn stops `apply` after it drains the committed groups;
+        // joining keeps background RocksDB writers from outliving the store.
         if let Ok(mut sender) = self.sender.lock() {
             sender.take();
         }
@@ -389,22 +435,22 @@ impl Drop for Writer {
 /// re-allocated.
 fn run_prepare(
     db: Arc<DB>,
-    sequence: Arc<AtomicU64>,
+    durable: Arc<AtomicU64>,
     epoch: Arc<AtomicU64>,
     receiver: mpsc::Receiver<WriteRequest>,
     sender: mpsc::SyncSender<PreparedWrite>,
     max_commit_batch_bytes: usize,
 ) {
-    let mut next = sequence.load(Ordering::Acquire);
+    let mut next = durable.load(Ordering::Acquire);
     let mut seen_epoch = epoch.load(Ordering::Acquire);
 
     while let Ok(first) = receiver.recv() {
         let current_epoch = epoch.load(Ordering::Acquire);
         if current_epoch != seen_epoch {
-            // A commit failed: each group commits atomically so nothing past the durable frontier
-            // persisted, and the failed numbers can be reclaimed.
+            // A commit failed: each log batch commits atomically so nothing past the durable
+            // frontier persisted, and the failed numbers can be reclaimed.
             seen_epoch = current_epoch;
-            next = sequence.load(Ordering::Acquire);
+            next = durable.load(Ordering::Acquire);
         }
 
         let (group, disconnected) = match prepare_queued_write(
@@ -434,8 +480,15 @@ fn run_prepare(
     }
 }
 
+/// Estimated RocksDB `WriteBatch` size for one request's rows: payload plus per-record framing.
+/// Presizing the batch avoids repeated grow-and-copy cycles while appending large requests.
+fn write_batch_capacity(request: &WriteRequest) -> usize {
+    let payload: usize = request.kvs.iter().map(|(k, v)| k.len() + v.len()).sum();
+    payload + request.kvs.len() * 16 + 64
+}
+
 /// Builds one prepared write from requests already queued behind `first` without waiting for new
-/// arrivals, stopping once the accumulated RocksDB batch reaches the soft byte cap. The request
+/// arrivals, stopping once the accumulated RocksDB batches reach the soft byte cap. The request
 /// that crosses the cap stays in the wave so a single large request can still make progress.
 fn prepare_queued_write(
     db: &DB,
@@ -446,7 +499,9 @@ fn prepare_queued_write(
     epoch: u64,
 ) -> Result<(PreparedWrite, bool), (Vec<WriteRequest>, String)> {
     let mut writes = Vec::with_capacity(64);
-    let mut batch = rocksdb::WriteBatch::default();
+    let capacity = write_batch_capacity(&first);
+    let mut state_batch = rocksdb::WriteBatch::with_capacity_bytes(capacity);
+    let mut log_batch = rocksdb::WriteBatch::with_capacity_bytes(capacity);
     let mut next = from;
     let mut request = first;
     let mut disconnected = false;
@@ -465,18 +520,11 @@ fn prepare_queued_write(
             sequence: next,
             request,
         };
-        if let Err(error) = append_assigned_write_batch(db, &mut batch, &write) {
-            writes.push(write);
-            let group = PreparedWrite {
-                writes,
-                batch: Err(error),
-                batch_bytes: 0,
-                epoch,
-            };
-            return Ok((group, disconnected));
-        }
+        append_assigned_write(db, &mut state_batch, &mut log_batch, &write);
         writes.push(write);
-        if batch.size_in_bytes() >= max_batch_bytes || next == u64::MAX {
+        if state_batch.size_in_bytes() + log_batch.size_in_bytes() >= max_batch_bytes
+            || next == u64::MAX
+        {
             break;
         }
 
@@ -491,7 +539,7 @@ fn prepare_queued_write(
     }
 
     Ok((
-        finalize_prepared_write(db, writes, batch, epoch),
+        finalize_prepared_write(db, writes, state_batch, log_batch, epoch),
         disconnected,
     ))
 }
@@ -505,32 +553,40 @@ fn forward_group(sender: &mpsc::SyncSender<PreparedWrite>, group: PreparedWrite)
     true
 }
 
-/// Commits prepared groups one at a time with a synced write, publishing the durable frontier after
-/// each success. A group whose epoch was superseded by an earlier failure is rejected without being
-/// written; a failing group bumps the epoch so its frontier (and every later group assigned under
-/// it) is abandoned and re-allocated by `prepare`.
+/// Commits prepared groups one at a time with a synced log write, publishing the durable frontier
+/// after each success and handing the group to `apply`. A group whose epoch was superseded by an
+/// earlier failure is rejected without being written; a failing group bumps the epoch so its
+/// frontier (and every later group assigned under it) is abandoned and re-allocated by `prepare`.
 fn run_commit(
     db: Arc<DB>,
-    sequence: Arc<AtomicU64>,
+    durable: Arc<AtomicU64>,
     epoch: Arc<AtomicU64>,
     receiver: mpsc::Receiver<PreparedWrite>,
+    committed_sender: mpsc::SyncSender<CommittedWrite>,
 ) {
-    let mut committed = sequence.load(Ordering::Acquire);
     while let Ok(group) = receiver.recv() {
-        committed = commit_group(&db, &sequence, &epoch, committed, group);
+        let Some(committed) = commit_group(&db, &durable, &epoch, group) else {
+            continue;
+        };
+        if let Err(error) = committed_sender.send(committed) {
+            // The log batch is durable but the state rows can no longer be applied in this
+            // process; recovery replays them on the next open, so the callers only lose the ack.
+            fail_assigned_writes(error.0.writes, "rocks apply worker stopped".to_string());
+            break;
+        }
     }
 }
 
-/// Commits one group, returning the durable frontier afterwards (unchanged on rejection or failure).
+/// Commits one group's log batch, returning the group for state application on success. Returns
+/// `None` when the group is empty, rejected, or failed (with its requests already resolved).
 fn commit_group(
     db: &DB,
-    sequence: &AtomicU64,
+    durable: &AtomicU64,
     epoch: &AtomicU64,
-    committed: u64,
     group: PreparedWrite,
-) -> u64 {
+) -> Option<CommittedWrite> {
     if group.writes.is_empty() {
-        return committed;
+        return None;
     }
     if group.epoch != epoch.load(Ordering::Acquire) {
         // This group was assigned under a frontier an earlier commit failure has since abandoned
@@ -541,106 +597,161 @@ fn commit_group(
             group.writes,
             "rocks write batch superseded by an earlier failure, retry".to_string(),
         );
-        return committed;
+        return None;
     }
 
     let requests = group.writes.len();
-    let batch_bytes = group.batch_bytes;
-    match write_prepared_group(db, group) {
-        Ok((writes, last_sequence)) => {
-            // Release so `current_sequence` readers only observe rows that are already durable.
-            sequence.store(last_sequence, Ordering::Release);
+    let PreparedWrite {
+        writes,
+        log_batch,
+        state_batch,
+        batch_bytes,
+        ..
+    } = group;
+    let last_sequence = writes
+        .last()
+        .expect("non-empty group has a last write")
+        .sequence;
+    let log_batch = match log_batch {
+        Ok(log_batch) => log_batch,
+        Err(error) => {
+            epoch.fetch_add(1, Ordering::AcqRel);
+            fail_assigned_writes(writes, error);
+            return None;
+        }
+    };
+    match write_sequence_batch(db, log_batch) {
+        Ok(()) => {
+            // Release so `prepare` re-syncs against a frontier whose log rows are already synced.
+            durable.store(last_sequence, Ordering::Release);
             debug!(
                 requests,
                 batch_bytes,
                 sequence = last_sequence,
                 "committed write batch"
             );
-            complete_assigned_writes(writes);
-            last_sequence
+            Some(CommittedWrite {
+                writes,
+                state_batch,
+                last_sequence,
+            })
         }
-        Err((writes, error)) => {
+        Err(error) => {
             // Bump before failing: any in-flight group sharing the failed epoch is then rejected,
-            // and `prepare` re-syncs to `committed`, leaving the abandoned numbers for reuse.
+            // and `prepare` re-syncs to the durable frontier, leaving the abandoned numbers for
+            // reuse.
             epoch.fetch_add(1, Ordering::AcqRel);
             fail_assigned_writes(writes, error);
-            committed
+            None
         }
     }
 }
 
-/// Commits one prepared group with a single synced write. Returns the group's writes alongside its
-/// last sequence number on success, or the writes and the error on failure.
-fn write_prepared_group(
+/// Applies committed state batches in commit order, advancing the visible frontier and resolving
+/// requests after each group's rows are readable. On loop exit the applied rows are flushed so a
+/// clean reopen can skip the recovery replay.
+fn run_apply(
+    db: Arc<DB>,
+    sequence: Arc<AtomicU64>,
+    flushed: Arc<AtomicU64>,
+    receiver: mpsc::Receiver<CommittedWrite>,
+) {
+    let mut poisoned = None;
+    while let Ok(committed) = receiver.recv() {
+        apply_committed_write(&db, &sequence, &mut poisoned, committed);
+    }
+    if poisoned.is_none() {
+        if let Err(error) = advance_state_flushed(&db, &flushed, sequence.load(Ordering::Acquire))
+        {
+            debug!(error = %error, "failed to flush state rows on writer shutdown");
+        }
+    }
+}
+
+/// Applies one committed group's state rows and publishes its frontier. A failed state write
+/// poisons the stage: the frontier freezes below the missing rows (later groups are only failed,
+/// never published), so reads stay complete below the advertised sequence until a restart replays
+/// the durable log.
+fn apply_committed_write(
     db: &DB,
-    group: PreparedWrite,
-) -> Result<(Vec<AssignedWrite>, u64), (Vec<AssignedWrite>, String)> {
-    let PreparedWrite { writes, batch, .. } = group;
-    let last_sequence = match writes.last() {
-        Some(write) => write.sequence,
-        None => return Ok((writes, 0)),
-    };
-    let batch = match batch {
-        Ok(batch) => batch,
-        Err(error) => return Err((writes, error)),
-    };
-    match write_sequence_batch(db, batch) {
-        Ok(()) => Ok((writes, last_sequence)),
-        Err(error) => Err((writes, error)),
+    sequence: &AtomicU64,
+    poisoned: &mut Option<String>,
+    committed: CommittedWrite,
+) {
+    if let Some(error) = poisoned.as_ref() {
+        fail_assigned_writes(
+            committed.writes,
+            format!("rocks state apply previously failed: {error}"),
+        );
+        return;
+    }
+    match write_state_batch(db, committed.state_batch) {
+        Ok(()) => {
+            // Release so `current_sequence` readers only observe frontiers whose rows are already
+            // readable (and, via the log commit, durable).
+            sequence.store(committed.last_sequence, Ordering::Release);
+            complete_assigned_writes(committed.writes);
+        }
+        Err(error) => {
+            fail_assigned_writes(committed.writes, error.clone());
+            *poisoned = Some(error);
+        }
     }
 }
 
 fn finalize_prepared_write(
     db: &DB,
     writes: Vec<AssignedWrite>,
-    mut batch: rocksdb::WriteBatch,
+    state_batch: rocksdb::WriteBatch,
+    mut log_batch: rocksdb::WriteBatch,
     epoch: u64,
 ) -> PreparedWrite {
     if let Some(write) = writes.last() {
-        append_sequence_meta(db, &mut batch, write.sequence);
+        append_sequence_meta(db, &mut log_batch, write.sequence);
     }
-    let batch_bytes = batch.size_in_bytes();
+    let batch_bytes = state_batch.size_in_bytes() + log_batch.size_in_bytes();
     PreparedWrite {
         writes,
-        batch: Ok(batch),
+        log_batch: Ok(log_batch),
+        state_batch,
         batch_bytes,
         epoch,
     }
 }
 
-fn append_assigned_write_batch(
+fn append_assigned_write(
     db: &DB,
-    batch: &mut rocksdb::WriteBatch,
+    state_batch: &mut rocksdb::WriteBatch,
+    log_batch: &mut rocksdb::WriteBatch,
     write: &AssignedWrite,
-) -> Result<(), String> {
-    append_sequence_entries(
-        db,
-        batch,
-        write.sequence,
-        std::slice::from_ref(&write.request),
-    )
+) {
+    let requests = std::slice::from_ref(&write.request);
+    append_state_entries(state_batch, requests);
+    append_log_entry(db, log_batch, write.sequence, requests);
 }
 
-/// Appends one sequence's current-state rows plus its replay-log row to `batch`.
-fn append_sequence_entries(
+/// Appends the current-state rows for one sequence to the state batch.
+fn append_state_entries(state_batch: &mut rocksdb::WriteBatch, requests: &[WriteRequest]) {
+    for request in requests {
+        for (k, v) in &request.kvs {
+            state_batch.put(k.as_ref(), v.as_ref());
+        }
+    }
+}
+
+/// Appends one sequence's replay-log row to the log batch.
+fn append_log_entry(
     db: &DB,
-    batch: &mut rocksdb::WriteBatch,
+    log_batch: &mut rocksdb::WriteBatch,
     sequence: u64,
     requests: &[WriteRequest],
-) -> Result<(), String> {
+) {
     let log_cf = db
         .cf_handle(LOG_CF)
         .expect("log CF must exist (created on open)");
-
-    for request in requests {
-        for (k, v) in &request.kvs {
-            batch.put(k.as_ref(), v.as_ref());
-        }
-    }
     if let Some(log_value) = encode_log_value(sequence, requests) {
-        batch.put_cf(log_cf, sequence_log_key(sequence), log_value);
+        log_batch.put_cf(log_cf, sequence_log_key(sequence), log_value);
     }
-    Ok(())
 }
 
 fn append_sequence_meta(db: &DB, batch: &mut rocksdb::WriteBatch, sequence: u64) {
@@ -650,12 +761,86 @@ fn append_sequence_meta(db: &DB, batch: &mut rocksdb::WriteBatch, sequence: u64)
     batch.put_cf(meta_cf, SEQ_META_KEY, sequence.to_le_bytes());
 }
 
-/// Writes a sequence batch with sync enabled because it defines the stream log high-water mark.
+/// Writes a log batch with sync enabled because it defines the durable high-water mark.
 fn write_sequence_batch(db: &DB, batch: rocksdb::WriteBatch) -> Result<(), String> {
     let mut write_options = WriteOptions::default();
     write_options.set_sync(true);
     db.write_opt(batch, &write_options)
         .map_err(|e| e.to_string())
+}
+
+/// Writes current-state rows without a WAL: durability comes from the already-synced log batch,
+/// which `open` replays above the state-flushed watermark after a crash.
+fn write_state_batch(db: &DB, batch: rocksdb::WriteBatch) -> Result<(), String> {
+    let mut write_options = WriteOptions::default();
+    write_options.disable_wal(true);
+    db.write_opt(batch, &write_options)
+        .map_err(|e| e.to_string())
+}
+
+/// Makes every state row at or below `target` durable in the default column family, then persists
+/// and mirrors the watermark. Recovery replays retained log rows above this watermark, so it must
+/// only advance after the flush completes.
+fn advance_state_flushed(db: &DB, flushed: &AtomicU64, target: u64) -> Result<(), String> {
+    if flushed.load(Ordering::Acquire) >= target {
+        return Ok(());
+    }
+    let default_cf = db
+        .cf_handle(rocksdb::DEFAULT_COLUMN_FAMILY_NAME)
+        .expect("default CF must exist (created on open)");
+    db.flush_cf(default_cf).map_err(|e| e.to_string())?;
+
+    let meta_cf = db
+        .cf_handle(META_CF)
+        .expect("meta CF must exist (created on open)");
+    let mut batch = rocksdb::WriteBatch::default();
+    batch.put_cf(meta_cf, STATE_FLUSHED_META_KEY, target.to_le_bytes());
+    write_sequence_batch(db, batch)?;
+    flushed.fetch_max(target, Ordering::AcqRel);
+    Ok(())
+}
+
+/// Reads a little-endian u64 sequence value from the meta column family, defaulting to zero.
+fn read_meta_sequence(db: &DB, key: &[u8]) -> Result<u64, String> {
+    let meta_cf = db
+        .cf_handle(META_CF)
+        .expect("meta CF must exist (created on open)");
+    match db.get_cf(meta_cf, key).map_err(|e| e.to_string())? {
+        Some(bytes) if bytes.len() == 8 => Ok(u64::from_le_bytes(bytes.try_into().unwrap())),
+        _ => Ok(0),
+    }
+}
+
+/// Re-applies the retained log rows in `(from_exclusive, to_inclusive]` to the default column
+/// family. State rows are written without a WAL, so after a crash the rows above the flushed
+/// watermark only exist in the log; replaying them in sequence order (last writer wins) rebuilds
+/// the exact current state. Rows already covered by an earlier flush may have been pruned and are
+/// simply absent from the iteration.
+fn replay_state_from_log(db: &DB, from_exclusive: u64, to_inclusive: u64) -> Result<(), String> {
+    let log_cf = db
+        .cf_handle(LOG_CF)
+        .expect("log CF must exist (created on open)");
+    let start = sequence_log_key(from_exclusive.saturating_add(1));
+    let mut batch = rocksdb::WriteBatch::default();
+    for item in db.iterator_cf(log_cf, IteratorMode::From(&start, Direction::Forward)) {
+        let (key, value) = item.map_err(|e| e.to_string())?;
+        let sequence = sequence_from_log_key(key.as_ref())?;
+        if sequence > to_inclusive {
+            break;
+        }
+        let response = StreamGetResponseView::decode_view(value.as_ref())
+            .map_err(|e| format!("corrupt log row for sequence {sequence}: {e}"))?;
+        for entry in response.entries.iter() {
+            batch.put(entry.key, entry.value);
+        }
+        if batch.size_in_bytes() >= DEFAULT_COMMIT_COALESCE_MAX_BATCH_BYTES {
+            write_state_batch(db, std::mem::take(&mut batch))?;
+        }
+    }
+    if batch.len() > 0 {
+        write_state_batch(db, batch)?;
+    }
+    Ok(())
 }
 
 /// Sends the same assignment failure to every request in a wave.
@@ -716,13 +901,16 @@ pub struct RocksConfig {
 pub struct RocksStore {
     db: Arc<DB>,
     sequence: Arc<AtomicU64>,
+    flushed: Arc<AtomicU64>,
     writer: Arc<Writer>,
 }
 
 impl RocksStore {
     /// Open the store with stock RocksDB defaults, unless `config` overrides
-    /// the database and column-family options.
-    pub fn open(path: &Path, config: Option<RocksConfig>) -> Result<Self, rocksdb::Error> {
+    /// the database and column-family options. Replays retained log rows above the state-flushed
+    /// watermark into the default column family so the current state is complete below the
+    /// durable sequence even after a crash that lost un-flushed (WAL-less) state rows.
+    pub fn open(path: &Path, config: Option<RocksConfig>) -> Result<Self, String> {
         let RocksConfig {
             mut db_options,
             default_cf_options,
@@ -738,23 +926,32 @@ impl RocksStore {
             ColumnFamilyDescriptor::new(rocksdb::DEFAULT_COLUMN_FAMILY_NAME, default_cf_options);
         let cf_meta = ColumnFamilyDescriptor::new(META_CF, meta_cf_options);
         let cf_log = ColumnFamilyDescriptor::new(LOG_CF, log_cf_options);
-        let db = Arc::new(DB::open_cf_descriptors(
-            &db_options,
-            path,
-            vec![cf_default, cf_meta, cf_log],
-        )?);
-        let meta_cf = db
-            .cf_handle(META_CF)
-            .expect("meta CF must exist (created on open)");
-        let seq = match db.get_cf(meta_cf, SEQ_META_KEY)? {
-            Some(bytes) if bytes.len() == 8 => u64::from_le_bytes(bytes.try_into().unwrap()),
-            _ => 0,
-        };
+        let db = Arc::new(
+            DB::open_cf_descriptors(&db_options, path, vec![cf_default, cf_meta, cf_log])
+                .map_err(|e| e.to_string())?,
+        );
+        let seq = read_meta_sequence(&db, SEQ_META_KEY)?;
+        let flushed_seq = read_meta_sequence(&db, STATE_FLUSHED_META_KEY)?;
+
+        let flushed = Arc::new(AtomicU64::new(flushed_seq));
+        if flushed_seq < seq {
+            replay_state_from_log(&db, flushed_seq, seq)?;
+            advance_state_flushed(&db, &flushed, seq)?;
+        }
+
         let sequence = Arc::new(AtomicU64::new(seq));
-        let writer = Arc::new(Writer::start(db.clone(), sequence.clone(), write_pipeline));
+        let durable = Arc::new(AtomicU64::new(seq));
+        let writer = Arc::new(Writer::start(
+            db.clone(),
+            sequence.clone(),
+            durable,
+            flushed.clone(),
+            write_pipeline,
+        ));
         Ok(Self {
             db,
             sequence,
+            flushed,
             writer,
         })
     }
@@ -861,12 +1058,24 @@ impl RocksStore {
         for (_group_key, entries) in groups {
             all_deletes.extend(keys_to_delete(entries, scope, retain)?);
         }
-        self.delete_keys(&all_deletes).map_err(|e| e.to_string())
+        self.delete_keys(&all_deletes).map_err(|e| e.to_string())?;
+        // Flush so a crash-recovery replay (which starts above the watermark) cannot re-apply the
+        // puts of keys this policy just deleted.
+        advance_state_flushed(
+            &self.db,
+            &self.flushed,
+            self.sequence.load(Ordering::Acquire),
+        )
     }
 
     /// Computes the replay-log cutoff for a sequence policy and prunes only log rows.
     fn apply_sequence_prune_policy(&self, retain: &RetainPolicy) -> Result<(), String> {
         let current = self.sequence.load(Ordering::Acquire);
+        // Log rows below the cutoff may still be needed to rebuild WAL-less state rows after a
+        // crash. Flushing first makes those state rows durable, so deleting their log rows is
+        // safe; the watermark write precedes the range delete in the WAL, preserving that order
+        // across a crash.
+        advance_state_flushed(&self.db, &self.flushed, current)?;
         let cutoff_exclusive = match retain {
             RetainPolicy::KeepLatest { count } => {
                 let count = *count as u64;
@@ -876,6 +1085,10 @@ impl RocksStore {
             RetainPolicy::GreaterThanOrEqual { threshold } => *threshold,
             RetainPolicy::DropAll => current.saturating_add(1),
         };
+        // Never delete log rows above the flushed watermark: sequences committed but not yet
+        // visible may still need them to rebuild their WAL-less state rows after a crash.
+        let cutoff_exclusive =
+            cutoff_exclusive.min(self.flushed.load(Ordering::Acquire).saturating_add(1));
         self.prune_log(cutoff_exclusive)
     }
 }
@@ -1119,7 +1332,7 @@ mod tests {
         .encode_to_vec()
     }
 
-    /// Builds a group whose batch is already an error, modeling a build/commit failure for a
+    /// Builds a group whose log batch is already an error, modeling a build/commit failure for a
     /// contiguous run of assigned sequence numbers tagged with `epoch`.
     fn failing_group(
         epoch: u64,
@@ -1136,12 +1349,27 @@ mod tests {
         (
             PreparedWrite {
                 writes,
-                batch: Err(error.to_string()),
+                log_batch: Err(error.to_string()),
+                state_batch: rocksdb::WriteBatch::default(),
                 batch_bytes: 0,
                 epoch,
             },
             receivers,
         )
+    }
+
+    /// Commits one group and applies its state rows, mirroring the commit and apply stages.
+    /// Returns the durable frontier afterwards.
+    fn commit_and_apply(
+        store: &RocksStore,
+        durable: &AtomicU64,
+        epoch: &AtomicU64,
+        group: PreparedWrite,
+    ) -> u64 {
+        if let Some(committed) = commit_group(&store.db, durable, epoch, group) {
+            apply_committed_write(&store.db, &store.sequence, &mut None, committed);
+        }
+        durable.load(Ordering::Acquire)
     }
 
     fn commit_sequence_requests(
@@ -1153,10 +1381,13 @@ mod tests {
             .load(Ordering::Acquire)
             .checked_add(1)
             .ok_or_else(|| "rocks sequence number overflowed".to_string())?;
-        let mut batch = rocksdb::WriteBatch::default();
-        append_sequence_entries(db, &mut batch, next, requests)?;
-        append_sequence_meta(db, &mut batch, next);
-        write_sequence_batch(db, batch)?;
+        let mut state_batch = rocksdb::WriteBatch::default();
+        let mut log_batch = rocksdb::WriteBatch::default();
+        append_state_entries(&mut state_batch, requests);
+        append_log_entry(db, &mut log_batch, next, requests);
+        append_sequence_meta(db, &mut log_batch, next);
+        write_sequence_batch(db, log_batch)?;
+        write_state_batch(db, state_batch)?;
         sequence.store(next, Ordering::Release);
         Ok(next)
     }
@@ -1184,21 +1415,12 @@ mod tests {
     }
 
     fn prepared_write(db: &DB, epoch: u64, writes: Vec<AssignedWrite>) -> PreparedWrite {
-        let mut prepared = Vec::with_capacity(writes.len());
-        let mut batch = rocksdb::WriteBatch::default();
-        for write in writes {
-            if let Err(error) = append_assigned_write_batch(db, &mut batch, &write) {
-                prepared.push(write);
-                return PreparedWrite {
-                    writes: prepared,
-                    batch: Err(error),
-                    batch_bytes: 0,
-                    epoch,
-                };
-            }
-            prepared.push(write);
+        let mut state_batch = rocksdb::WriteBatch::default();
+        let mut log_batch = rocksdb::WriteBatch::default();
+        for write in &writes {
+            append_assigned_write(db, &mut state_batch, &mut log_batch, write);
         }
-        finalize_prepared_write(db, prepared, batch, epoch)
+        finalize_prepared_write(db, writes, state_batch, log_batch, epoch)
     }
 
     #[test]
@@ -1294,7 +1516,7 @@ mod tests {
             Err((_, error)) => panic!("{error}"),
         };
         assert_eq!(group.writes.len(), 3);
-        assert!(group.batch.is_ok());
+        assert!(group.log_batch.is_ok());
         assert!(group.batch_bytes > 0);
         assert_eq!(group.epoch, 7);
         assert!(disconnected);
@@ -1319,7 +1541,7 @@ mod tests {
 
         assert_eq!(group.writes.len(), 1);
         assert_eq!(group.writes[0].request.kvs[0].0.as_ref(), b"a");
-        assert!(group.batch.is_ok());
+        assert!(group.log_batch.is_ok());
         assert!(group.batch_bytes >= 1);
         assert_eq!(group.epoch, 7);
         assert!(!disconnected);
@@ -1357,11 +1579,12 @@ mod tests {
     async fn failed_group_supersedes_epoch_and_frees_sequence_numbers() {
         let dir = tempdir().expect("tempdir");
         let store = RocksStore::open(dir.path(), None).expect("open db");
+        let durable = AtomicU64::new(0);
         let epoch = AtomicU64::new(0);
 
         // A group that cannot commit (modeled with an already-failed batch) at sequences 1 and 2.
         let (group, receivers) = failing_group(0, &[(1, b"a", b"1"), (2, b"b", b"2")], "disk full");
-        let committed = commit_group(&store.db, &store.sequence, &epoch, 0, group);
+        let committed = commit_and_apply(&store, &durable, &epoch, group);
 
         // Nothing was published, and the epoch advanced so the abandoned numbers can be re-used.
         assert_eq!(committed, 0);
@@ -1378,7 +1601,7 @@ mod tests {
         let (write_x, result_x) = assigned_write_with_response(1, b"x", b"24");
         let (write_y, result_y) = assigned_write_with_response(2, b"y", b"25");
         let group = prepared_write(&store.db, 1, vec![write_x, write_y]);
-        let committed = commit_group(&store.db, &store.sequence, &epoch, committed, group);
+        let committed = commit_and_apply(&store, &durable, &epoch, group);
 
         assert_eq!(committed, 2);
         assert_eq!(store.current_sequence(), 2);
@@ -1398,12 +1621,13 @@ mod tests {
     async fn superseded_epoch_group_is_rejected_without_write() {
         let dir = tempdir().expect("tempdir");
         let store = RocksStore::open(dir.path(), None).expect("open db");
+        let durable = AtomicU64::new(0);
         // The current epoch is 1: an earlier failure already superseded epoch 0.
         let epoch = AtomicU64::new(1);
 
         let (write, result) = assigned_write_with_response(1, b"a", b"1");
         let group = prepared_write(&store.db, 0, vec![write]);
-        let committed = commit_group(&store.db, &store.sequence, &epoch, 0, group);
+        let committed = commit_and_apply(&store, &durable, &epoch, group);
 
         assert_eq!(committed, 0);
         assert_eq!(store.current_sequence(), 0);
@@ -1419,13 +1643,14 @@ mod tests {
     async fn writer_reallocates_sequence_numbers_after_failed_batch() {
         let dir = tempdir().expect("tempdir");
         let store = RocksStore::open(dir.path(), None).expect("open db");
+        let durable = AtomicU64::new(0);
         let epoch = AtomicU64::new(5);
 
         // Two successive failures both abandon sequence 1 without ever consuming it.
         for attempt in [b"first" as &[u8], b"second"] {
             let current = epoch.load(Ordering::Acquire);
             let (group, receivers) = failing_group(current, &[(1, b"k", b"v")], "boom");
-            let committed = commit_group(&store.db, &store.sequence, &epoch, 0, group);
+            let committed = commit_and_apply(&store, &durable, &epoch, group);
             assert_eq!(
                 committed, 0,
                 "attempt {attempt:?} must not advance the frontier"
@@ -1440,7 +1665,7 @@ mod tests {
         let current = epoch.load(Ordering::Acquire);
         let (write, result) = assigned_write_with_response(1, b"k", b"v");
         let group = prepared_write(&store.db, current, vec![write]);
-        let committed = commit_group(&store.db, &store.sequence, &epoch, 0, group);
+        let committed = commit_and_apply(&store, &durable, &epoch, group);
         assert_eq!(committed, 1);
         assert_eq!(result.await.expect("response"), Ok(1));
         assert_eq!(store.current_sequence(), 1);
@@ -1450,6 +1675,7 @@ mod tests {
     async fn reused_sequence_overwrites_abandoned_log_row() {
         let dir = tempdir().expect("tempdir");
         let store = RocksStore::open(dir.path(), None).expect("open db");
+        let durable = AtomicU64::new(0);
         let epoch = AtomicU64::new(0);
 
         // Model an abandoned sequence index: the durable frontier is still 0, but a row
@@ -1468,7 +1694,7 @@ mod tests {
         );
 
         let (failed, receivers) = failing_group(0, &[(1, b"k", b"failed")], "boom");
-        let committed = commit_group(&store.db, &store.sequence, &epoch, 0, failed);
+        let committed = commit_and_apply(&store, &durable, &epoch, failed);
         assert_eq!(committed, 0);
         assert_eq!(store.current_sequence(), 0);
         assert_eq!(epoch.load(Ordering::Acquire), 1);
@@ -1478,7 +1704,7 @@ mod tests {
 
         let (write, result) = assigned_write_with_response(1, b"k", b"new");
         let group = prepared_write(&store.db, 1, vec![write]);
-        let committed = commit_group(&store.db, &store.sequence, &epoch, committed, group);
+        let committed = commit_and_apply(&store, &durable, &epoch, group);
 
         assert_eq!(committed, 1);
         assert_eq!(result.await.expect("response"), Ok(1));
@@ -1486,6 +1712,74 @@ mod tests {
         assert_eq!(
             batch_entries(store.get_batch(1).await.expect("get").expect("retained")),
             vec![(Bytes::from_static(b"k"), Bytes::from_static(b"new"))]
+        );
+    }
+
+    #[tokio::test]
+    async fn reopen_replays_log_rows_missing_from_state() {
+        let dir = tempdir().expect("tempdir");
+        {
+            let store = RocksStore::open(dir.path(), None).expect("open db");
+            store
+                .put_batch(vec![(Bytes::from_static(b"k1"), Bytes::from_static(b"v1"))])
+                .await
+                .expect("put");
+
+            // Simulate a crash that lost the WAL-less state rows for sequences 2 and 3 but kept
+            // the synced log batches: append the log rows and durable-sequence meta directly,
+            // bypassing the state apply stage.
+            let mut log_batch = rocksdb::WriteBatch::default();
+            log_batch.put_cf(
+                store.log_cf(),
+                sequence_log_key(2),
+                encoded_log_entry(2, b"k2", b"v2-stale"),
+            );
+            log_batch.put_cf(
+                store.log_cf(),
+                sequence_log_key(3),
+                StreamGetResponse {
+                    sequence_number: 3,
+                    entries: vec![
+                        Entry {
+                            key: b"k2".to_vec(),
+                            value: Bytes::from_static(b"v2"),
+                            ..Default::default()
+                        },
+                        Entry {
+                            key: b"k3".to_vec(),
+                            value: Bytes::from_static(b"v3"),
+                            ..Default::default()
+                        },
+                    ],
+                    ..Default::default()
+                }
+                .encode_to_vec(),
+            );
+            append_sequence_meta(&store.db, &mut log_batch, 3);
+            write_sequence_batch(&store.db, log_batch).expect("write log rows");
+        }
+
+        let store = RocksStore::open(dir.path(), None).expect("reopen db");
+        assert_eq!(store.current_sequence(), 3);
+        // Replay applied the missing rows in sequence order: last writer wins for k2.
+        for (key, value) in [
+            (b"k1" as &[u8], b"v1" as &[u8]),
+            (b"k2", b"v2"),
+            (b"k3", b"v3"),
+        ] {
+            assert_eq!(
+                store.get_raw(key).expect("get").as_deref(),
+                Some(value),
+                "key {key:?}"
+            );
+        }
+        // A second reopen skips the replay because the watermark advanced with a flush.
+        drop(store);
+        let store = RocksStore::open(dir.path(), None).expect("reopen db again");
+        assert_eq!(store.current_sequence(), 3);
+        assert_eq!(
+            store.get_raw(b"k2").expect("get").as_deref(),
+            Some(b"v2" as &[u8])
         );
     }
 
@@ -1570,6 +1864,7 @@ mod tests {
     async fn prepared_write_preserves_contiguous_sequence_logs() {
         let dir = tempdir().expect("tempdir");
         let store = RocksStore::open(dir.path(), None).expect("open db");
+        let durable = AtomicU64::new(0);
         let epoch = AtomicU64::new(0);
         let prepared = prepared_write(
             &store.db,
@@ -1583,7 +1878,7 @@ mod tests {
 
         assert_eq!(prepared.writes.len(), 3);
         assert!(prepared.batch_bytes > 0);
-        let committed = commit_group(&store.db, &store.sequence, &epoch, 0, prepared);
+        let committed = commit_and_apply(&store, &durable, &epoch, prepared);
         assert_eq!(committed, 3);
 
         assert_eq!(store.current_sequence(), 3);

--- a/examples/simulator/src/rocks.rs
+++ b/examples/simulator/src/rocks.rs
@@ -4,17 +4,18 @@
 //! can serve replay and point lookups. Batch-log pruning is driven exclusively by the compact
 //! service's `Sequence` scope.
 //!
-//! Durability is anchored on the replay log: each commit group writes its log rows plus the
-//! durable-sequence meta row in one synced batch, then the current-state rows are applied without
-//! a WAL and the visible sequence frontier advances. The state rows are recovered from the log,
-//! so `open` replays retained log rows above the persisted state-flushed watermark, and pruning
-//! flushes the default column family (advancing that watermark) before deleting log rows it may
-//! otherwise still need for recovery.
+//! Durability is anchored on the replay log: each commit group makes its log rows plus the
+//! durable-sequence meta row durable first (one synced batch for small groups; an ingested SST
+//! file followed by a synced meta write for large ones), then the current-state rows are applied
+//! without a WAL and the visible sequence frontier advances. The state rows are recovered from
+//! the log, so `open` replays retained log rows above the persisted state-flushed watermark, and
+//! pruning flushes the default column family (advancing that watermark) before deleting log rows
+//! it may otherwise still need for recovery.
 
 use std::cmp::Ordering as CmpOrdering;
 use std::collections::BTreeMap;
 use std::num::NonZeroUsize;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{mpsc, Arc, Mutex};
 use std::thread;
@@ -32,8 +33,8 @@ use exoware_server::{
 };
 use regex::bytes::Regex;
 use rocksdb::{
-    ColumnFamily, ColumnFamilyDescriptor, DBIterator, Direction, IteratorMode, Options,
-    WriteOptions, DB,
+    ColumnFamily, ColumnFamilyDescriptor, DBCompressionType, DBIterator, Direction,
+    IngestExternalFileOptions, IteratorMode, Options, SstFileWriter, WriteOptions, DB,
 };
 use tokio::sync::oneshot;
 use tracing::debug;
@@ -48,6 +49,13 @@ const LOG_CF: &str = "log";
 const LOG_BATCH_KEY_LEN: usize = 8;
 const PRUNE_SCAN_BATCH_SIZE: usize = 4096;
 const DEFAULT_COMMIT_COALESCE_MAX_BATCH_BYTES: usize = 16 * 1024 * 1024;
+/// Directory under the store path where log SST files are staged before ingestion.
+const LOG_INGEST_DIR: &str = "ingest";
+/// Minimum accumulated log payload before a commit group's log rows are written as an ingested
+/// SST file instead of a WAL-backed batch. Ingested rows reach the disk once, while WAL-backed
+/// rows are written twice (WAL now, SST on flush), so large groups ingest and small groups keep
+/// the cheaper single-fsync WAL commit.
+const LOG_INGEST_MIN_BYTES: usize = 4 * 1024 * 1024;
 type RocksIterItem = Result<(Box<[u8]>, Box<[u8]>), rocksdb::Error>;
 
 /// Owns the DB handle for a RocksDB iterator that is moved through blocking tasks.
@@ -298,14 +306,24 @@ struct AssignedWrite {
     request: WriteRequest,
 }
 
+/// How one commit group's replay-log rows (and the durable-sequence meta row) reach the disk.
+/// Either way the log alone defines durability; the state rows are recoverable from it.
+enum PreparedLog {
+    /// Log rows plus the meta row in one WAL-backed batch, committed atomically by one synced
+    /// write. Used for small groups, where a single fsync beats the ingestion overhead.
+    Batch(rocksdb::WriteBatch),
+    /// Encoded log rows (ascending sequence order) written as one SST file and ingested directly
+    /// into the log column family, followed by a synced meta write. Large payloads reach the disk
+    /// once instead of twice (WAL now, SST again on flush), and being ingested at the bottom
+    /// level they are never rewritten by compaction.
+    Ingest(Vec<(u64, Vec<u8>)>),
+}
+
 /// One commit group covering a contiguous run of assigned sequence numbers.
 struct PreparedWrite {
     writes: Vec<AssignedWrite>,
-    /// Replay-log rows plus the durable-sequence meta row, committed atomically by one synced
-    /// write. This batch alone defines durability; the state rows are recoverable from it.
-    log_batch: Result<rocksdb::WriteBatch, String>,
-    /// Current-state rows for the same sequences, applied without a WAL once the log batch is
-    /// durable.
+    log: Result<PreparedLog, String>,
+    /// Current-state rows for the same sequences, applied without a WAL once the log is durable.
     state_batch: rocksdb::WriteBatch,
     batch_bytes: usize,
     /// Assignment epoch; `commit` rejects a group whose epoch an earlier failure has superseded.
@@ -333,6 +351,7 @@ impl Writer {
     /// being built and the previous group's state rows are being applied.
     fn start(
         db: Arc<DB>,
+        ingest_dir: PathBuf,
         sequence: Arc<AtomicU64>,
         durable: Arc<AtomicU64>,
         flushed: Arc<AtomicU64>,
@@ -366,6 +385,7 @@ impl Writer {
             .spawn(move || {
                 run_commit(
                     commit_db,
+                    ingest_dir,
                     commit_durable,
                     commit_epoch,
                     group_receiver,
@@ -499,9 +519,9 @@ fn prepare_queued_write(
     epoch: u64,
 ) -> Result<(PreparedWrite, bool), (Vec<WriteRequest>, String)> {
     let mut writes = Vec::with_capacity(64);
-    let capacity = write_batch_capacity(&first);
-    let mut state_batch = rocksdb::WriteBatch::with_capacity_bytes(capacity);
-    let mut log_batch = rocksdb::WriteBatch::with_capacity_bytes(capacity);
+    let mut state_batch = rocksdb::WriteBatch::with_capacity_bytes(write_batch_capacity(&first));
+    let mut log_rows: Vec<(u64, Vec<u8>)> = Vec::new();
+    let mut log_bytes = 0usize;
     let mut next = from;
     let mut request = first;
     let mut disconnected = false;
@@ -520,11 +540,13 @@ fn prepare_queued_write(
             sequence: next,
             request,
         };
-        append_assigned_write(db, &mut state_batch, &mut log_batch, &write);
+        append_state_entries(&mut state_batch, std::slice::from_ref(&write.request));
+        if let Some(value) = encode_log_value(next, std::slice::from_ref(&write.request)) {
+            log_bytes += LOG_BATCH_KEY_LEN + value.len();
+            log_rows.push((next, value));
+        }
         writes.push(write);
-        if state_batch.size_in_bytes() + log_batch.size_in_bytes() >= max_batch_bytes
-            || next == u64::MAX
-        {
+        if state_batch.size_in_bytes() + log_bytes >= max_batch_bytes || next == u64::MAX {
             break;
         }
 
@@ -539,7 +561,7 @@ fn prepare_queued_write(
     }
 
     Ok((
-        finalize_prepared_write(db, writes, state_batch, log_batch, epoch),
+        finalize_prepared_write(db, writes, state_batch, log_rows, log_bytes, epoch),
         disconnected,
     ))
 }
@@ -559,13 +581,14 @@ fn forward_group(sender: &mpsc::SyncSender<PreparedWrite>, group: PreparedWrite)
 /// frontier (and every later group assigned under it) is abandoned and re-allocated by `prepare`.
 fn run_commit(
     db: Arc<DB>,
+    ingest_dir: PathBuf,
     durable: Arc<AtomicU64>,
     epoch: Arc<AtomicU64>,
     receiver: mpsc::Receiver<PreparedWrite>,
     committed_sender: mpsc::SyncSender<CommittedWrite>,
 ) {
     while let Ok(group) = receiver.recv() {
-        let Some(committed) = commit_group(&db, &durable, &epoch, group) else {
+        let Some(committed) = commit_group(&db, &ingest_dir, &durable, &epoch, group) else {
             continue;
         };
         if let Err(error) = committed_sender.send(committed) {
@@ -577,10 +600,11 @@ fn run_commit(
     }
 }
 
-/// Commits one group's log batch, returning the group for state application on success. Returns
+/// Commits one group's log rows, returning the group for state application on success. Returns
 /// `None` when the group is empty, rejected, or failed (with its requests already resolved).
 fn commit_group(
     db: &DB,
+    ingest_dir: &Path,
     durable: &AtomicU64,
     epoch: &AtomicU64,
     group: PreparedWrite,
@@ -601,9 +625,10 @@ fn commit_group(
     }
 
     let requests = group.writes.len();
+    let group_epoch = group.epoch;
     let PreparedWrite {
         writes,
-        log_batch,
+        log,
         state_batch,
         batch_bytes,
         ..
@@ -612,15 +637,21 @@ fn commit_group(
         .last()
         .expect("non-empty group has a last write")
         .sequence;
-    let log_batch = match log_batch {
-        Ok(log_batch) => log_batch,
+    let log = match log {
+        Ok(log) => log,
         Err(error) => {
             epoch.fetch_add(1, Ordering::AcqRel);
             fail_assigned_writes(writes, error);
             return None;
         }
     };
-    match write_sequence_batch(db, log_batch) {
+    let committed = match log {
+        PreparedLog::Batch(log_batch) => write_sequence_batch(db, log_batch),
+        PreparedLog::Ingest(log_rows) => {
+            ingest_log_rows(db, ingest_dir, log_rows, last_sequence, group_epoch)
+        }
+    };
+    match committed {
         Ok(()) => {
             // Release so `prepare` re-syncs against a frontier whose log rows are already synced.
             durable.store(last_sequence, Ordering::Release);
@@ -703,31 +734,33 @@ fn finalize_prepared_write(
     db: &DB,
     writes: Vec<AssignedWrite>,
     state_batch: rocksdb::WriteBatch,
-    mut log_batch: rocksdb::WriteBatch,
+    log_rows: Vec<(u64, Vec<u8>)>,
+    log_bytes: usize,
     epoch: u64,
 ) -> PreparedWrite {
-    if let Some(write) = writes.last() {
-        append_sequence_meta(db, &mut log_batch, write.sequence);
-    }
-    let batch_bytes = state_batch.size_in_bytes() + log_batch.size_in_bytes();
+    let batch_bytes = state_batch.size_in_bytes() + log_bytes;
+    let log = if log_bytes >= LOG_INGEST_MIN_BYTES {
+        PreparedLog::Ingest(log_rows)
+    } else {
+        let log_cf = db
+            .cf_handle(LOG_CF)
+            .expect("log CF must exist (created on open)");
+        let mut log_batch = rocksdb::WriteBatch::with_capacity_bytes(log_bytes + 64);
+        for (sequence, value) in log_rows {
+            log_batch.put_cf(log_cf, sequence_log_key(sequence), value);
+        }
+        if let Some(write) = writes.last() {
+            append_sequence_meta(db, &mut log_batch, write.sequence);
+        }
+        PreparedLog::Batch(log_batch)
+    };
     PreparedWrite {
         writes,
-        log_batch: Ok(log_batch),
+        log: Ok(log),
         state_batch,
         batch_bytes,
         epoch,
     }
-}
-
-fn append_assigned_write(
-    db: &DB,
-    state_batch: &mut rocksdb::WriteBatch,
-    log_batch: &mut rocksdb::WriteBatch,
-    write: &AssignedWrite,
-) {
-    let requests = std::slice::from_ref(&write.request);
-    append_state_entries(state_batch, requests);
-    append_log_entry(db, log_batch, write.sequence, requests);
 }
 
 /// Appends the current-state rows for one sequence to the state batch.
@@ -736,21 +769,6 @@ fn append_state_entries(state_batch: &mut rocksdb::WriteBatch, requests: &[Write
         for (k, v) in &request.kvs {
             state_batch.put(k.as_ref(), v.as_ref());
         }
-    }
-}
-
-/// Appends one sequence's replay-log row to the log batch.
-fn append_log_entry(
-    db: &DB,
-    log_batch: &mut rocksdb::WriteBatch,
-    sequence: u64,
-    requests: &[WriteRequest],
-) {
-    let log_cf = db
-        .cf_handle(LOG_CF)
-        .expect("log CF must exist (created on open)");
-    if let Some(log_value) = encode_log_value(sequence, requests) {
-        log_batch.put_cf(log_cf, sequence_log_key(sequence), log_value);
     }
 }
 
@@ -767,6 +785,55 @@ fn write_sequence_batch(db: &DB, batch: rocksdb::WriteBatch) -> Result<(), Strin
     write_options.set_sync(true);
     db.write_opt(batch, &write_options)
         .map_err(|e| e.to_string())
+}
+
+/// Commits one group's log rows by writing them as an SST file, ingesting it into the log column
+/// family, and then durably advancing the sequence meta row. Ingestion syncs the file and the
+/// manifest, so the rows are durable before the meta write publishes them; if the meta write is
+/// lost, the orphaned rows sit above the durable frontier where `get_batch` cannot see them and
+/// `open` deletes them.
+fn ingest_log_rows(
+    db: &DB,
+    ingest_dir: &Path,
+    log_rows: Vec<(u64, Vec<u8>)>,
+    last_sequence: u64,
+    epoch: u64,
+) -> Result<(), String> {
+    let first = log_rows
+        .first()
+        .expect("ingested log groups are never empty")
+        .0;
+    // Leftover files from failed ingestions are deleted when the store reopens, and epochs make
+    // re-allocated sequence numbers unambiguous within one writer's lifetime.
+    let path = ingest_dir.join(format!("log-{first:020}-{last_sequence:020}-e{epoch}.sst"));
+
+    // Uncompressed for parity with the WAL-backed path (WAL payloads are not compressed either);
+    // compressing on the commit path would trade ack latency for bytes.
+    let mut options = Options::default();
+    options.set_compression_type(DBCompressionType::None);
+    let mut writer = SstFileWriter::create(&options);
+    writer.open(&path).map_err(|e| e.to_string())?;
+    for (sequence, value) in &log_rows {
+        writer
+            .put(sequence_log_key(*sequence), value)
+            .map_err(|e| e.to_string())?;
+    }
+    // `finish` syncs the file before it is linked into the DB.
+    writer.finish().map_err(|e| e.to_string())?;
+
+    let log_cf = db
+        .cf_handle(LOG_CF)
+        .expect("log CF must exist (created on open)");
+    let mut ingest_options = IngestExternalFileOptions::default();
+    ingest_options.set_move_files(true);
+    if let Err(error) = db.ingest_external_file_cf_opts(log_cf, &ingest_options, vec![&path]) {
+        let _ = std::fs::remove_file(&path);
+        return Err(error.to_string());
+    }
+
+    let mut meta_batch = rocksdb::WriteBatch::default();
+    append_sequence_meta(db, &mut meta_batch, last_sequence);
+    write_sequence_batch(db, meta_batch)
 }
 
 /// Writes current-state rows without a WAL: durability comes from the already-synced log batch,
@@ -798,6 +865,43 @@ fn advance_state_flushed(db: &DB, flushed: &AtomicU64, target: u64) -> Result<()
     write_sequence_batch(db, batch)?;
     flushed.fetch_max(target, Ordering::AcqRel);
     Ok(())
+}
+
+/// Creates the SST staging directory and deletes files a crashed ingestion left behind. Staged
+/// files are only ever moved into the DB by ingestion, so anything still here was never visible.
+fn prepare_ingest_dir(store_path: &Path) -> Result<PathBuf, String> {
+    let ingest_dir = store_path.join(LOG_INGEST_DIR);
+    std::fs::create_dir_all(&ingest_dir)
+        .map_err(|e| format!("failed to create log ingest directory: {e}"))?;
+    for entry in std::fs::read_dir(&ingest_dir)
+        .map_err(|e| format!("failed to read log ingest directory: {e}"))?
+    {
+        let entry = entry.map_err(|e| format!("failed to read log ingest directory: {e}"))?;
+        std::fs::remove_file(entry.path())
+            .map_err(|e| format!("failed to remove staged log file: {e}"))?;
+    }
+    Ok(ingest_dir)
+}
+
+/// Deletes log rows above the durable frontier. A crash between an SST ingestion and its meta
+/// write can leave rows whose sequences were never published; those numbers will be re-allocated,
+/// so the abandoned rows must not resurface.
+fn remove_log_rows_above(db: &DB, durable: u64) -> Result<(), String> {
+    let log_cf = db
+        .cf_handle(LOG_CF)
+        .expect("log CF must exist (created on open)");
+    if durable == u64::MAX {
+        return Ok(());
+    }
+    let start = sequence_log_key(durable + 1);
+    let mut stale = db.iterator_cf(log_cf, IteratorMode::From(&start, Direction::Forward));
+    if stale.next().is_none() {
+        return Ok(());
+    }
+    db.delete_range_cf(log_cf, start, sequence_log_key(u64::MAX))
+        .map_err(|e| e.to_string())?;
+    db.delete_cf(log_cf, sequence_log_key(u64::MAX))
+        .map_err(|e| e.to_string())
 }
 
 /// Reads a little-endian u64 sequence value from the meta column family, defaulting to zero.
@@ -881,7 +985,6 @@ impl Default for RocksWritePipelineConfig {
 }
 
 /// RocksDB engine and application-level write pipeline options used by [`RocksStore::open`].
-#[derive(Default)]
 pub struct RocksConfig {
     /// Database-wide options.
     pub db_options: Options,
@@ -893,6 +996,40 @@ pub struct RocksConfig {
     pub log_cf_options: Options,
     /// Options for the application-level ingest write pipeline.
     pub write_pipeline: RocksWritePipelineConfig,
+}
+
+impl Default for RocksConfig {
+    /// RocksDB options tuned for the simulator's ingest profile (hundreds of thousands of keys
+    /// per batch) instead of stock RocksDB defaults.
+    fn default() -> Self {
+        let cores = thread::available_parallelism()
+            .map(|n| n.get())
+            .unwrap_or(2) as i32;
+        let mut db_options = Options::default();
+        db_options.increase_parallelism(cores);
+
+        // Smaller, more numerous state memtables keep skiplist inserts shallow and shift work to
+        // background flushes.
+        let mut default_cf_options = Options::default();
+        default_cf_options.set_write_buffer_size(32 * 1024 * 1024);
+        default_cf_options.set_max_write_buffer_number(4);
+
+        // Replay-log values are large (one blob per ingest batch) and immutable until pruned.
+        // Storing them in blob files keeps log-CF compactions rewriting only the 8-byte keys and
+        // blob references instead of re-copying every batch payload.
+        let mut log_cf_options = Options::default();
+        log_cf_options.set_enable_blob_files(true);
+        log_cf_options.set_min_blob_size(4096);
+        log_cf_options.set_enable_blob_gc(true);
+
+        Self {
+            db_options,
+            default_cf_options,
+            meta_cf_options: Options::default(),
+            log_cf_options,
+            write_pipeline: RocksWritePipelineConfig::default(),
+        }
+    }
 }
 
 /// Minimal RocksDB-backed store for the simulator: batch writes plus a global sequence u64
@@ -933,6 +1070,9 @@ impl RocksStore {
         let seq = read_meta_sequence(&db, SEQ_META_KEY)?;
         let flushed_seq = read_meta_sequence(&db, STATE_FLUSHED_META_KEY)?;
 
+        let ingest_dir = prepare_ingest_dir(path)?;
+        remove_log_rows_above(&db, seq)?;
+
         let flushed = Arc::new(AtomicU64::new(flushed_seq));
         if flushed_seq < seq {
             replay_state_from_log(&db, flushed_seq, seq)?;
@@ -943,6 +1083,7 @@ impl RocksStore {
         let durable = Arc::new(AtomicU64::new(seq));
         let writer = Arc::new(Writer::start(
             db.clone(),
+            ingest_dir,
             sequence.clone(),
             durable,
             flushed.clone(),
@@ -1157,6 +1298,11 @@ impl Prune for RocksStore {
 
 impl Log for RocksStore {
     async fn get_batch(&self, sequence_number: u64) -> Result<Option<LogBatch>, String> {
+        // Serve only published batches: rows above the visible frontier are still being
+        // committed (or were abandoned by a crash) and must not be observable early.
+        if sequence_number > self.sequence.load(Ordering::Acquire) {
+            return Ok(None);
+        }
         let store = self.clone();
         let cf = store.log_cf();
         let sequence_key = sequence_log_key(sequence_number);
@@ -1349,7 +1495,7 @@ mod tests {
         (
             PreparedWrite {
                 writes,
-                log_batch: Err(error.to_string()),
+                log: Err(error.to_string()),
                 state_batch: rocksdb::WriteBatch::default(),
                 batch_bytes: 0,
                 epoch,
@@ -1366,7 +1512,8 @@ mod tests {
         epoch: &AtomicU64,
         group: PreparedWrite,
     ) -> u64 {
-        if let Some(committed) = commit_group(&store.db, durable, epoch, group) {
+        let ingest_dir = store.db.path().join(LOG_INGEST_DIR);
+        if let Some(committed) = commit_group(&store.db, &ingest_dir, durable, epoch, group) {
             apply_committed_write(&store.db, &store.sequence, &mut None, committed);
         }
         durable.load(Ordering::Acquire)
@@ -1384,7 +1531,12 @@ mod tests {
         let mut state_batch = rocksdb::WriteBatch::default();
         let mut log_batch = rocksdb::WriteBatch::default();
         append_state_entries(&mut state_batch, requests);
-        append_log_entry(db, &mut log_batch, next, requests);
+        if let Some(value) = encode_log_value(next, requests) {
+            let log_cf = db
+                .cf_handle(LOG_CF)
+                .expect("log CF must exist (created on open)");
+            log_batch.put_cf(log_cf, sequence_log_key(next), value);
+        }
         append_sequence_meta(db, &mut log_batch, next);
         write_sequence_batch(db, log_batch)?;
         write_state_batch(db, state_batch)?;
@@ -1416,11 +1568,17 @@ mod tests {
 
     fn prepared_write(db: &DB, epoch: u64, writes: Vec<AssignedWrite>) -> PreparedWrite {
         let mut state_batch = rocksdb::WriteBatch::default();
-        let mut log_batch = rocksdb::WriteBatch::default();
+        let mut log_rows = Vec::new();
+        let mut log_bytes = 0;
         for write in &writes {
-            append_assigned_write(db, &mut state_batch, &mut log_batch, write);
+            let requests = std::slice::from_ref(&write.request);
+            append_state_entries(&mut state_batch, requests);
+            if let Some(value) = encode_log_value(write.sequence, requests) {
+                log_bytes += LOG_BATCH_KEY_LEN + value.len();
+                log_rows.push((write.sequence, value));
+            }
         }
-        finalize_prepared_write(db, writes, state_batch, log_batch, epoch)
+        finalize_prepared_write(db, writes, state_batch, log_rows, log_bytes, epoch)
     }
 
     #[test]
@@ -1516,7 +1674,7 @@ mod tests {
             Err((_, error)) => panic!("{error}"),
         };
         assert_eq!(group.writes.len(), 3);
-        assert!(group.log_batch.is_ok());
+        assert!(group.log.is_ok());
         assert!(group.batch_bytes > 0);
         assert_eq!(group.epoch, 7);
         assert!(disconnected);
@@ -1541,7 +1699,7 @@ mod tests {
 
         assert_eq!(group.writes.len(), 1);
         assert_eq!(group.writes[0].request.kvs[0].0.as_ref(), b"a");
-        assert!(group.log_batch.is_ok());
+        assert!(group.log.is_ok());
         assert!(group.batch_bytes >= 1);
         assert_eq!(group.epoch, 7);
         assert!(!disconnected);
@@ -1688,10 +1846,8 @@ mod tests {
                 encoded_log_entry(1, b"k", b"stale"),
             )
             .expect("seed abandoned log row");
-        assert_eq!(
-            batch_entries(store.get_batch(1).await.expect("get").expect("retained")),
-            vec![(Bytes::from_static(b"k"), Bytes::from_static(b"stale"))]
-        );
+        // Rows above the visible frontier are unreadable, so the abandoned row cannot leak.
+        assert!(store.get_batch(1).await.expect("get").is_none());
 
         let (failed, receivers) = failing_group(0, &[(1, b"k", b"failed")], "boom");
         let committed = commit_and_apply(&store, &durable, &epoch, failed);
@@ -1712,6 +1868,68 @@ mod tests {
         assert_eq!(
             batch_entries(store.get_batch(1).await.expect("get").expect("retained")),
             vec![(Bytes::from_static(b"k"), Bytes::from_static(b"new"))]
+        );
+    }
+
+    /// One batch large enough to commit through the SST-ingestion path instead of a WAL batch.
+    fn large_batch(tag: u8) -> Vec<(Bytes, Bytes)> {
+        (0..(LOG_INGEST_MIN_BYTES / 4096 + 16))
+            .map(|i| {
+                let mut key = vec![tag];
+                key.extend_from_slice(&(i as u64).to_be_bytes());
+                (Bytes::from(key), Bytes::from(vec![tag; 4096]))
+            })
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn large_batches_commit_through_ingestion_and_survive_reopen() {
+        let dir = tempdir().expect("tempdir");
+        let (first, second) = {
+            let store = RocksStore::open(dir.path(), None).expect("open db");
+            let first = store.put_batch(large_batch(1)).await.expect("put");
+            let second = store.put_batch(large_batch(2)).await.expect("put");
+            assert_eq!(store.current_sequence(), second);
+
+            let batch = store
+                .get_batch(first)
+                .await
+                .expect("get batch")
+                .expect("batch retained");
+            assert_eq!(batch_entries(batch), large_batch(1));
+            (first, second)
+        };
+
+        let store = RocksStore::open(dir.path(), None).expect("reopen db");
+        assert_eq!(store.current_sequence(), second);
+        for (sequence, tag) in [(first, 1u8), (second, 2u8)] {
+            let batch = store
+                .get_batch(sequence)
+                .await
+                .expect("get batch")
+                .expect("batch retained");
+            assert_eq!(batch_entries(batch), large_batch(tag));
+        }
+        assert_eq!(
+            store.get_raw(&[1u8, 0, 0, 0, 0, 0, 0, 0, 0]).expect("get"),
+            Some(vec![1u8; 4096])
+        );
+
+        // Sequence pruning drops the ingested rows like any other log rows.
+        store
+            .apply_prune_policies(PrunePolicyDocument {
+                version: exoware_sdk::prune_policy::PRUNE_POLICY_DOCUMENT_VERSION,
+                policies: vec![exoware_sdk::prune_policy::PrunePolicy {
+                    scope: PolicyScope::Sequence,
+                    retain: RetainPolicy::KeepLatest { count: 1 },
+                }],
+            })
+            .expect("prune");
+        assert!(store.get_batch(first).await.expect("get").is_none());
+        assert!(store.get_batch(second).await.expect("get").is_some());
+        assert_eq!(
+            store.oldest_retained_batch().await.expect("oldest"),
+            Some(second)
         );
     }
 

--- a/examples/simulator/src/rocks.rs
+++ b/examples/simulator/src/rocks.rs
@@ -361,8 +361,9 @@ struct Writer {
 
 impl Writer {
     /// Starts the two-stage write pipeline. `prepare` drains queued requests up to the
-    /// configured byte cap, assigns a contiguous sequence number to each (continuing from
-    /// `next`, the frontier derived at open), and stages each wave's log and state SST files
+    /// configured byte cap, assigns a contiguous sequence number to each (continuing from the
+    /// published frontier, which is exactly the frontier derived at open since nothing has
+    /// committed yet), and stages each wave's log and state SST files
     /// (including their data syncs); `commit` ingests the log file, then the state file,
     /// publishes the frontier, and resolves the requests. The stages overlap, so one group's
     /// files are being staged while the previous group's are being ingested. Any write failure
@@ -373,9 +374,9 @@ impl Writer {
         db: Arc<DB>,
         ingest_dir: PathBuf,
         frontiers: Arc<Frontiers>,
-        next: u64,
         write_pipeline: RocksWritePipelineConfig,
     ) -> Self {
+        let next = frontiers.published.load(Ordering::Acquire);
         let (request_sender, request_receiver) = mpsc::channel();
         // Rendezvous so `prepare` runs at most one wave ahead of `commit`: it hands off a staged
         // group, then stages the next while `commit` ingests this one.
@@ -879,7 +880,6 @@ impl RocksStore {
             db.clone(),
             ingest_dir,
             frontiers.clone(),
-            seq,
             write_pipeline,
         ));
         Ok(Self {

--- a/examples/simulator/src/rocks.rs
+++ b/examples/simulator/src/rocks.rs
@@ -10,13 +10,12 @@
 //! as two SST files (built in parallel), while `commit` ingests the previous group — the log
 //! file first (the durable row alone defines the group; `open` derives the frontier from the
 //! highest retained row and the state-floor meta row), then the state file, then publish and
-//! ack. Ingestion
-//! is atomic, so a crash never leaves a partial batch — at worst the newest groups' state
-//! ingestions are missing, and `open` repairs that by re-applying the retained log rows above
-//! the state floor. The floor advances whenever state is provably authoritative: an unsynced
-//! meta-row write after every commit, a synced one from prunes (atomic with their deletes),
-//! and a synced one parking it at the frontier on clean shutdown — so an unremarkable reopen
-//! replays nothing and a crash replays only the trailing groups above the last durable floor.
+//! ack. Ingestion is atomic and strictly ordered, so a crash never leaves a partial batch and
+//! at most the newest group can be missing its state ingestion; `open` repairs that by
+//! re-applying the newest retained log row (idempotent — its rows are the newest writes for
+//! their keys). The floor meta row is written only by pruning, synced, atomically with its
+//! deletes: it marks state the replay must never touch (re-applying key-pruned rows would
+//! resurrect them) and keeps a fully-pruned log from regressing the frontier.
 //!
 //! Any write failure in the pipeline is fatal: once a group's log row is durable it cannot be
 //! rolled back (its sequence number must never be re-issued), so the writer panics and the next
@@ -350,9 +349,6 @@ struct Writer {
     /// `None` only during `Drop`, which closes the channel before joining the workers.
     sender: Option<mpsc::Sender<WriteRequest>>,
     handles: Vec<thread::JoinHandle<()>>,
-    /// For parking the floor at the published frontier on clean shutdown (see `Drop`).
-    db: Arc<DB>,
-    frontiers: Arc<Frontiers>,
 }
 
 impl Writer {
@@ -360,8 +356,8 @@ impl Writer {
     /// configured byte cap into a commit group that shares one sequence number (continuing
     /// from the published frontier, which is exactly the frontier derived at open since
     /// nothing has committed yet) and stages the group's log and state SSTs in parallel;
-    /// `commit` ingests the log file, then the state file, publishes the frontier, advances
-    /// the floor, and resolves the requests. The stages overlap, so one group is staged while
+    /// `commit` ingests the log file, then the state file, publishes the frontier, and
+    /// resolves the requests. The stages overlap, so one group is staged while
     /// the previous commits — and `commit` ingests strictly in order, so a crash still leaves
     /// at most the newest ingested group without its state. Any write failure in either stage
     /// is fatal (the worker panics): the durable log row alone defines the group, so the next
@@ -380,11 +376,9 @@ impl Writer {
         let (group_sender, group_receiver) = mpsc::sync_channel(0);
         let max_commit_batch_bytes = write_pipeline.max_commit_batch_bytes.get();
 
-        let commit_db = db.clone();
-        let commit_frontiers = frontiers.clone();
         let commit = thread::Builder::new()
             .name(format!("{WRITER_THREAD_PREFIX}commit"))
-            .spawn(move || run_commit(commit_db, commit_frontiers, group_receiver))
+            .spawn(move || run_commit(db, frontiers, group_receiver))
             .expect("failed to spawn RocksDB commit worker");
 
         let prepare = thread::Builder::new()
@@ -403,8 +397,6 @@ impl Writer {
         Self {
             sender: Some(request_sender),
             handles: vec![prepare, commit],
-            db,
-            frontiers,
         }
     }
 
@@ -436,24 +428,6 @@ impl Drop for Writer {
         for handle in self.handles.drain(..) {
             let _ = handle.join();
         }
-        // Park the floor at the published frontier, synced: every published group's state is
-        // durable and authoritative, so the next open has nothing to replay after a clean
-        // shutdown even if the per-commit (unsynced) floor advances were lost.
-        let _guard = self.frontiers.persist.lock();
-        let mut batch = rocksdb::WriteBatch::default();
-        let meta_cf = self
-            .db
-            .cf_handle(META_CF)
-            .expect("meta CF must exist (created on open)");
-        batch.put_cf(
-            meta_cf,
-            SEQ_META_KEY,
-            self.frontiers
-                .published
-                .load(Ordering::Acquire)
-                .to_le_bytes(),
-        );
-        let _ = write_synced_batch(&self.db, batch);
     }
 }
 
@@ -481,9 +455,8 @@ fn run_prepare(
     }
 }
 
-/// Commits staged groups one at a time — log ingestion, state ingestion, publish, floor
-/// advance, ack — until the group channel closes (store drop). Any write failure panics inside
-/// `commit_group`.
+/// Commits staged groups one at a time — log ingestion, state ingestion, publish, ack — until
+/// the group channel closes (store drop). Any write failure panics inside `commit_group`.
 fn run_commit(db: Arc<DB>, frontiers: Arc<Frontiers>, receiver: mpsc::Receiver<PreparedWrite>) {
     while let Ok(group) = receiver.recv() {
         commit_group(&db, &frontiers, group);
@@ -610,12 +583,12 @@ fn stage_state_file(path: &Path, rows: &[(Bytes, Bytes)]) -> Result<usize, Strin
 }
 
 /// Commits one group: ingests its log row (durability), then its state file (visibility), then
-/// publishes the frontier, advances the floor, and resolves the requests. Any write failure is
-/// fatal (panic): once the log row is durable the group cannot be rolled back (its sequence
-/// must not be re-issued), and the next open rolls it forward by replaying the row — so
-/// nothing is ever reclaimed or retried in-process. The panic drops the group's response
-/// channels, so waiting callers observe an error even though the group may resurface after the
-/// restart repair — an accepted at-least-once ambiguity of this severe error path.
+/// publishes the frontier and resolves the requests. Any write failure is fatal (panic): once
+/// the log row is durable the group cannot be rolled back (its sequence must not be
+/// re-issued), and the next open rolls it forward by replaying the row — so nothing is ever
+/// reclaimed or retried in-process. The panic drops the group's response channels, so waiting
+/// callers observe an error even though the group may resurface after the restart repair — an
+/// accepted at-least-once ambiguity of this severe error path.
 fn commit_group(db: &DB, frontiers: &Frontiers, group: PreparedWrite) {
     assert!(!group.requests.is_empty(), "groups are never empty");
     let PreparedWrite {
@@ -641,17 +614,6 @@ fn commit_group(db: &DB, frontiers: &Frontiers, group: PreparedWrite) {
 
     // Release so `current_sequence` readers only observe frontiers whose rows are readable.
     frontiers.published.store(sequence, Ordering::Release);
-
-    // Advance the floor while still under the lock — unsynced, a memtable write: the group's
-    // state is durably ingested, so a crash from here on replays at most the groups whose
-    // floor advance was lost. Prunes and clean shutdown persist the floor synced.
-    let mut floor = rocksdb::WriteBatch::default();
-    let meta_cf = db
-        .cf_handle(META_CF)
-        .expect("meta CF must exist (created on open)");
-    floor.put_cf(meta_cf, SEQ_META_KEY, sequence.to_le_bytes());
-    db.write(floor)
-        .unwrap_or_else(|error| panic!("failed to advance state floor: {error}"));
     drop(publish_guard);
     debug!(
         requests = requests.len(),
@@ -734,7 +696,9 @@ fn highest_log_row(db: &DB) -> Result<u64, String> {
     }
 }
 
-/// Reads the state-floor meta row, defaulting to zero when no prune has written it yet.
+/// Reads the state-floor meta row, defaulting to zero when no prune has written it yet. A
+/// malformed row is corruption and fails the open: silently treating it as zero would let the
+/// replay resurrect key-pruned rows.
 fn read_state_floor(db: &DB) -> Result<u64, String> {
     let meta_cf = db
         .cf_handle(META_CF)
@@ -743,43 +707,44 @@ fn read_state_floor(db: &DB) -> Result<u64, String> {
         .get_cf(meta_cf, SEQ_META_KEY)
         .map_err(|e| e.to_string())?
     {
-        Some(bytes) if bytes.len() == 8 => Ok(u64::from_le_bytes(bytes.try_into().unwrap())),
-        _ => Ok(0),
+        Some(bytes) => {
+            let bytes: [u8; 8] = bytes
+                .try_into()
+                .map_err(|_| "corrupt state-floor meta row".to_string())?;
+            Ok(u64::from_le_bytes(bytes))
+        }
+        None => Ok(0),
     }
 }
 
-/// Re-applies retained log rows above the state floor to the state column family. Only the
-/// trailing groups can be missing state (the writer commits strictly in order, and the floor
-/// advances with every commit), so this reads at most the few newest rows in practice; it is
-/// idempotent because a group's rows are the newest writes for their keys and are applied in
-/// ascending sequence order. Rows at or below `floor` are never replayed: their state is
+/// Re-applies the newest retained log row to the state column family. `commit` ingests
+/// strictly in order — a group's log row lands before its state, and the next group's row only
+/// after that state — so every older group's state is already durably ingested and at most the
+/// newest group can be missing it; re-applying is idempotent because the row's entries are the
+/// newest writes for their keys. A row at or below `floor` is never replayed: its state is
 /// authoritative, and key pruning may have deleted rows a replay would resurrect. Ingestion is
 /// atomic, so no partial row can exist; a row that fails to decode is real corruption and
 /// fails the open.
-fn replay_log_above_floor(db: &DB, floor: u64) -> Result<(), String> {
-    let Some(start) = floor.checked_add(1) else {
-        // The floor covers every representable sequence; nothing can need replay.
-        return Ok(());
-    };
+fn replay_newest_log_row(db: &DB, floor: u64) -> Result<(), String> {
     let log_cf = db
         .cf_handle(LOG_CF)
         .expect("log CF must exist (created on open)");
-    let mut batch = rocksdb::WriteBatch::default();
-    let from = sequence_log_key(start);
-    for item in db.iterator_cf(log_cf, IteratorMode::From(&from, Direction::Forward)) {
-        let (key, value) = item.map_err(|e| e.to_string())?;
-        let sequence = sequence_from_log_key(key.as_ref())?;
-        let response = StreamGetResponseView::decode_view(value.as_ref())
-            .map_err(|e| format!("corrupt log row for sequence {sequence}: {e}"))?;
-        for entry in response.entries.iter() {
-            batch.put(entry.key, entry.value);
-        }
-    }
-    if batch.is_empty() {
+    let Some(item) = db.iterator_cf(log_cf, IteratorMode::End).next() else {
+        return Ok(());
+    };
+    let (key, value) = item.map_err(|e| e.to_string())?;
+    let sequence = sequence_from_log_key(key.as_ref())?;
+    if sequence <= floor {
         return Ok(());
     }
-    // Synced: once a later floor advance moves the replay bound past these groups, a repair
-    // lost to power loss would never be re-run.
+    let response = StreamGetResponseView::decode_view(value.as_ref())
+        .map_err(|e| format!("corrupt log row for sequence {sequence}: {e}"))?;
+    let mut batch = rocksdb::WriteBatch::default();
+    for entry in response.entries.iter() {
+        batch.put(entry.key, entry.value);
+    }
+    // Synced: once a later commit moves the newest row past this group, a repair lost to power
+    // loss would never be re-run.
     write_synced_batch(db, batch)
 }
 
@@ -854,9 +819,8 @@ impl RocksStore {
     /// Open the store with default options, unless `config` overrides the database or
     /// write-pipeline options (column families always run stock options — see [`RocksConfig`]).
     /// Re-derives the durable frontier from the retained log rows and the state-floor meta row,
-    /// then re-applies the log rows above the floor to the state column family so the current
-    /// state is complete below the durable sequence even after a crash mid-commit (a no-op
-    /// after a clean shutdown, which parks the floor at the frontier).
+    /// then re-applies the newest log row to the state column family so the current state is
+    /// complete below the durable sequence even after a crash mid-commit.
     pub fn open(path: &Path, config: Option<RocksConfig>) -> Result<Self, String> {
         let RocksConfig {
             mut db_options,
@@ -875,9 +839,10 @@ impl RocksStore {
         );
 
         let ingest_dir = prepare_ingest_dir(path)?;
+        // Commits do not write the state-floor meta row; the log rows are the durable record.
         let floor = read_state_floor(&db)?;
         let seq = floor.max(highest_log_row(&db)?);
-        replay_log_above_floor(&db, floor)?;
+        replay_newest_log_row(&db, floor)?;
 
         let frontiers = Arc::new(Frontiers::new(seq));
         let writer = Arc::new(Writer::start(
@@ -1445,7 +1410,7 @@ mod tests {
                 "key {key:?}"
             );
         }
-        // A second reopen has nothing to repair: the first clean close parked the floor.
+        // A second reopen replays again (the floor only advances on prune); idempotent.
         drop(store);
         let store = RocksStore::open(dir.path(), None).expect("reopen db again");
         assert_eq!(store.current_sequence(), 2);

--- a/examples/simulator/src/rocks.rs
+++ b/examples/simulator/src/rocks.rs
@@ -797,12 +797,6 @@ impl Default for RocksWritePipelineConfig {
 }
 
 /// RocksDB engine and application-level write pipeline options used by [`RocksStore::open`].
-///
-/// Column-family options are deliberately not configurable because the store's correctness
-/// leans on the CF options `open` chooses: staged state SSTs and range-scan bounds assume bytewise key
-/// order, and rows must never be dropped by a caller-supplied compaction filter or TTL (acked
-/// writes must stay readable, the meta CF's state-floor row must persist, and the repair
-/// replay would nondeterministically resurrect expired state rows).
 #[derive(Default)]
 pub struct RocksConfig {
     /// Database-wide options, applied as-is (stock defaults). Two knobs matter under sustained

--- a/examples/simulator/src/rocks.rs
+++ b/examples/simulator/src/rocks.rs
@@ -53,20 +53,12 @@ use tracing::debug;
 
 const STATE_CF: &str = rocksdb::DEFAULT_COLUMN_FAMILY_NAME;
 const META_CF: &str = "meta";
-/// State floor: the published frontier at the time of the last prune. The state below it is
-/// authoritative — log rows at or below it are never replayed at open (replaying them could
-/// resurrect key-pruned rows), and the frontier at open is the maximum of this row and the
-/// highest retained log row (deleting log rows must not regress the derived frontier). Only
-/// pruning writes it, atomically with its deletes — commits never do.
 const SEQ_META_KEY: &[u8] = b"sequence";
 const LOG_CF: &str = "log";
 const LOG_BATCH_KEY_LEN: usize = 8;
 const PRUNE_SCAN_BATCH_SIZE: usize = 4096;
 const DEFAULT_COMMIT_COALESCE_MAX_BATCH_BYTES: usize = 16 * 1024 * 1024;
-/// Directory under the store path where SST files are staged before ingestion.
 const LOG_INGEST_DIR: &str = "ingest";
-/// Name prefix for the store's writer threads, whose panics are fatal by design. The binary's
-/// panic hook matches on it to turn a writer panic into a process exit.
 pub const WRITER_THREAD_PREFIX: &str = "simulator-rocks-";
 type RocksIterItem = Result<(Box<[u8]>, Box<[u8]>), rocksdb::Error>;
 

--- a/examples/simulator/src/rocks.rs
+++ b/examples/simulator/src/rocks.rs
@@ -436,9 +436,14 @@ impl Writer {
             return Err("cannot ingest an empty batch".to_string());
         }
         let (response, result) = oneshot::channel();
+
+        // The sender is `None` only inside `Writer::drop`, which cannot overlap a live call:
+        // dropping the writer requires exclusive access, and every in-flight `put_batch`
+        // holds a borrow through the store's `Arc<Writer>`. A writer whose workers are gone
+        // is the closed-channel case, surfaced as an error by `send` below.
         self.sender
             .as_ref()
-            .expect("sender lives until drop")
+            .expect("sender is None only during drop, which cannot overlap a call")
             .send(WriteRequest { kvs, response })
             .map_err(|_| "rocks writer stopped".to_string())?;
         result
@@ -1299,6 +1304,36 @@ mod tests {
             !path.exists(),
             "directory must be deleted once the last database holder drops"
         );
+    }
+
+    /// A drop-order canary: reopening the path only succeeds once the previous database
+    /// instance has released its `LOCK` file.
+    struct ReopenOnDrop {
+        path: PathBuf,
+    }
+
+    impl Drop for ReopenOnDrop {
+        fn drop(&mut self) {
+            DB::open(&Options::default(), &self.path)
+                .expect("closer must drop only after the database has closed");
+        }
+    }
+
+    #[test]
+    fn closer_drops_only_after_database_closes() {
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("db");
+        let mut options = Options::default();
+        options.create_if_missing(true);
+        let db = DB::open(&options, &path).expect("open db");
+
+        // Struct fields drop in declaration order, so `db` drops (and releases its `LOCK`
+        // file) before the canary closer runs. If the order ever flipped, the reopen inside
+        // the closer would fail against the still-held lock.
+        drop(Database {
+            db,
+            _closer: Some(Box::new(ReopenOnDrop { path: path.clone() })),
+        });
     }
 
     #[test]

--- a/examples/simulator/src/rocks.rs
+++ b/examples/simulator/src/rocks.rs
@@ -1103,6 +1103,18 @@ impl RocksStore {
             return Ok(());
         }
         let cf = self.log_cf();
+        // Unlink the ingested SST files that sit entirely below the cutoff (the common case,
+        // since each file covers one commit group's contiguous sequence range). This reclaims
+        // their space immediately, without compaction ever reading the massive log payloads.
+        self.db
+            .delete_file_in_range_cf(
+                cf,
+                sequence_log_key(0),
+                sequence_log_key(cutoff_exclusive - 1),
+            )
+            .map_err(|e| e.to_string())?;
+        // Cover the leftovers — rows in a file straddling the cutoff and any L0 stragglers —
+        // with a range tombstone so they are logically gone right away.
         self.db
             .delete_range_cf(cf, sequence_log_key(0), sequence_log_key(cutoff_exclusive))
             .map_err(|e| e.to_string())
@@ -1184,8 +1196,8 @@ impl RocksStore {
         let current = self.frontiers.published.load(Ordering::Acquire);
         // Log rows below the cutoff may still be needed to rebuild WAL-less state rows after a
         // crash, and `open` re-derives the durable frontier from the retained rows, so both
-        // frontiers must be persisted (with a state flush) before rows are deleted; the meta
-        // write precedes the range delete in the WAL, preserving that order across a crash.
+        // frontiers must be durable (synced meta write, after a state flush) before any row or
+        // file is deleted.
         persist_frontiers(&self.db, &self.frontiers)?;
         let cutoff_exclusive = match retain {
             RetainPolicy::KeepLatest { count } => {
@@ -1895,7 +1907,9 @@ mod tests {
             Some(vec![1u8; 4096])
         );
 
-        // Sequence pruning drops the ingested rows like any other log rows.
+        // Sequence pruning drops the ingested rows like any other log rows, and unlinks the
+        // pruned batches' SST files outright instead of leaving them for compaction.
+        let log_files_before = live_log_files(&store);
         store
             .apply_prune_policies(PrunePolicyDocument {
                 version: exoware_sdk::prune_policy::PRUNE_POLICY_DOCUMENT_VERSION,
@@ -1911,6 +1925,20 @@ mod tests {
             store.oldest_retained_batch().await.expect("oldest"),
             Some(second)
         );
+        let log_files_after = live_log_files(&store);
+        assert_eq!(log_files_before, 2, "one ingested file per batch");
+        assert_eq!(log_files_after, 1, "pruned batch's file is unlinked");
+    }
+
+    /// Number of live SST files backing the log column family.
+    fn live_log_files(store: &RocksStore) -> usize {
+        store
+            .db
+            .live_files()
+            .expect("live files")
+            .into_iter()
+            .filter(|file| file.column_family_name == LOG_CF)
+            .count()
     }
 
     #[tokio::test]

--- a/examples/simulator/src/rocks.rs
+++ b/examples/simulator/src/rocks.rs
@@ -1,18 +1,18 @@
 //! Naive reference storage for local development: user keys and values are written as-is to
 //! RocksDB. A `meta` column family holds the state-floor row, and a `log` column family keeps
-//! one row per commit group — the exact `log.stream.v1.GetResponse` bytes the stream service
+//! one row per commit group: the exact `log.stream.v1.GetResponse` bytes the stream service
 //! serves for that sequence, loaded on demand. Everything is addressed by key: recovery and
 //! pruning never assume which SST files rows live in, so RocksDB is free to place and compact
 //! them however it likes.
 //!
 //! Writes bypass the WAL and the memtables: `prepare` coalesces queued requests into a commit
 //! group that shares one sequence number and stages the group's log row and sorted state rows
-//! as two SST files (built in parallel), while `commit` ingests the previous group — the log
+//! as two SST files (built in parallel), while `commit` ingests the previous group: the log
 //! file first (the durable row alone defines the group; `open` derives the frontier from the
 //! highest retained row and the state-floor meta row), then the state file, then publish and
 //! ack. Ingestion is atomic and strictly ordered, so a crash never leaves a partial batch and
 //! at most the newest group can be missing its state ingestion; `open` repairs that by
-//! re-applying the newest retained log row (idempotent — its rows are the newest writes for
+//! re-applying the newest retained log row (idempotent: its rows are the newest writes for
 //! their keys). The floor meta row is written only by pruning, synced, atomically with its
 //! deletes: it marks state the replay must never touch (re-applying key-pruned rows would
 //! resurrect them) and keeps a fully-pruned log from regressing the frontier.
@@ -56,6 +56,7 @@ const STATE_CF: &str = rocksdb::DEFAULT_COLUMN_FAMILY_NAME;
 const META_CF: &str = "meta";
 const SEQ_META_KEY: &[u8] = b"sequence";
 const PRUNE_SCAN_BATCH_SIZE: usize = 4096;
+const PRUNE_DELETE_CHUNK_KEYS: usize = 4096;
 const DEFAULT_COMMIT_COALESCE_MAX_BATCH_BYTES: usize = 16 * 1024 * 1024;
 const LOG_INGEST_DIR: &str = "ingest";
 const LOG_CF: &str = "log";
@@ -63,19 +64,44 @@ const LOG_BATCH_KEY_LEN: usize = 8;
 pub const WRITER_THREAD_PREFIX: &str = "simulator-rocks-";
 type RocksIterItem = Result<(Box<[u8]>, Box<[u8]>), rocksdb::Error>;
 
+/// A resource dropped strictly after the database has closed (see [`Database`]).
+type Closer = Box<dyn std::any::Any + Send + Sync>;
+
+/// The open RocksDB handle plus everything that must outlive it.
+///
+/// Every holder of the database (store clones, the writer threads, open range-scan cursors,
+/// in-flight blocking reads) shares one `Arc<Database>`, so the database closes exactly when
+/// the last holder drops, wherever that happens. A closer attached at open drops strictly
+/// after the database (fields drop in declaration order).
+struct Database {
+    db: DB,
+    /// Dropped only after `db`: any resource that must outlive the open database. For a
+    /// store opened with [`RocksStore::open_owned`], this is the owner whose drop deletes
+    /// the data directory (for example a `tempfile::TempDir`).
+    _closer: Option<Closer>,
+}
+
+impl std::ops::Deref for Database {
+    type Target = DB;
+
+    fn deref(&self) -> &DB {
+        &self.db
+    }
+}
+
 /// Owns the DB handle for a RocksDB iterator that is moved through blocking tasks.
 struct OwnedRocksIterator {
     iter: DBIterator<'static>,
-    _db: Arc<DB>,
+    _db: Arc<Database>,
 }
 
 impl OwnedRocksIterator {
     /// Creates a RocksDB iterator whose borrowed DB handle is kept alive by the wrapper.
-    fn new(db: Arc<DB>, mode: IteratorMode<'_>) -> Self {
+    fn new(db: Arc<Database>, mode: IteratorMode<'_>) -> Self {
         // SAFETY: `iter` is dropped before `db` because fields are dropped in
         // declaration order. The RocksDB iterator therefore cannot outlive the
         // Arc-owned DB it borrows.
-        let db_ref: &'static DB = unsafe { &*Arc::as_ptr(&db) };
+        let db_ref: &'static DB = unsafe { &(*Arc::as_ptr(&db)).db };
         let iter = db_ref.iterator(mode);
         Self { iter, _db: db }
     }
@@ -98,7 +124,7 @@ struct RocksRangeScanState {
 
 impl RocksRangeScanState {
     /// Creates an iterator positioned at the first row that may belong to the requested range.
-    fn new(db: Arc<DB>, start: Bytes, end: Bytes, limit: usize, forward: bool) -> Self {
+    fn new(db: Arc<Database>, start: Bytes, end: Bytes, limit: usize, forward: bool) -> Self {
         let mode = if forward {
             IteratorMode::From(start.as_ref(), Direction::Forward)
         } else if end.is_empty() {
@@ -166,7 +192,7 @@ pub struct RocksRangeScanCursor {
 
 impl RocksRangeScanCursor {
     /// Stores scan state in an `Option` so it can be moved into `spawn_blocking` per page.
-    fn new(db: Arc<DB>, start: Bytes, end: Bytes, limit: usize, forward: bool) -> Self {
+    fn new(db: Arc<Database>, start: Bytes, end: Bytes, limit: usize, forward: bool) -> Self {
         Self {
             state: Some(RocksRangeScanState::new(db, start, end, limit, forward)),
         }
@@ -307,7 +333,7 @@ struct Frontiers {
     /// sequence-addressed read (`current_sequence`, `get_batch`, `oldest_retained_batch`).
     /// Point reads of current state are deliberately ungated: state may lead this frontier by
     /// the one group being published, but never lags it. The durable frontier (highest sequence
-    /// whose log row is durable) is not tracked in-process — it only runs ahead of `published`
+    /// whose log row is durable) is not tracked in-process: it only runs ahead of `published`
     /// while a group's state ingestion is in flight, and is re-derived at open from the
     /// retained log rows and the state-floor meta row.
     published: AtomicU64,
@@ -358,13 +384,13 @@ impl Writer {
     /// nothing has committed yet) and stages the group's log and state SSTs in parallel;
     /// `commit` ingests the log file, then the state file, publishes the frontier, and
     /// resolves the requests. The stages overlap, so one group is staged while
-    /// the previous commits — and `commit` ingests strictly in order, so a crash still leaves
+    /// the previous commits. `commit` still ingests strictly in order, so a crash leaves
     /// at most the newest ingested group without its state. Any write failure in either stage
     /// is fatal (the worker panics): the durable log row alone defines the group, so the next
-    /// open re-derives the frontier and replays the rows above the floor — sequence numbers
+    /// open re-derives the frontier and replays the rows above the floor. Sequence numbers
     /// never need to be reclaimed in-process.
     fn start(
-        db: Arc<DB>,
+        db: Arc<Database>,
         ingest_dir: PathBuf,
         frontiers: Arc<Frontiers>,
         write_pipeline: RocksWritePipelineConfig,
@@ -455,9 +481,13 @@ fn run_prepare(
     }
 }
 
-/// Commits staged groups one at a time — log ingestion, state ingestion, publish, ack — until
+/// Commits staged groups one at a time (log ingestion, state ingestion, publish, ack) until
 /// the group channel closes (store drop). Any write failure panics inside `commit_group`.
-fn run_commit(db: Arc<DB>, frontiers: Arc<Frontiers>, receiver: mpsc::Receiver<PreparedWrite>) {
+fn run_commit(
+    db: Arc<Database>,
+    frontiers: Arc<Frontiers>,
+    receiver: mpsc::Receiver<PreparedWrite>,
+) {
     while let Ok(group) = receiver.recv() {
         commit_group(&db, &frontiers, group);
     }
@@ -506,7 +536,7 @@ fn stage_queued_write(
         }
     }
 
-    // Stage the group's two SST files in parallel — the single-row log SST on this thread, the
+    // Stage the group's two SST files in parallel: the single-row log SST on this thread, the
     // sorted state SST on a scoped thread. Ingestion later links them into their column
     // families, so each payload byte reaches the disk exactly once, in its final resting place.
     // A staging failure is fatal; leftover staged files are removed by the next open.
@@ -585,9 +615,9 @@ fn stage_state_file(path: &Path, rows: &[(Bytes, Bytes)]) -> Result<usize, Strin
 /// Commits one group: ingests its log row (durability), then its state file (visibility), then
 /// publishes the frontier and resolves the requests. Any write failure is fatal (panic): once
 /// the log row is durable the group cannot be rolled back (its sequence must not be
-/// re-issued), and the next open rolls it forward by replaying the row — so nothing is ever
+/// re-issued), and the next open rolls it forward by replaying the row, so nothing is ever
 /// reclaimed or retried in-process. The panic drops the group's response channels, so waiting
-/// callers observe an error even though the group may resurface after the restart repair — an
+/// callers observe an error even though the group may resurface after the restart repair, an
 /// accepted at-least-once ambiguity of this severe error path.
 fn commit_group(db: &DB, frontiers: &Frontiers, group: PreparedWrite) {
     assert!(!group.requests.is_empty(), "groups are never empty");
@@ -718,8 +748,8 @@ fn read_state_floor(db: &DB) -> Result<u64, String> {
 }
 
 /// Re-applies the newest retained log row to the state column family. `commit` ingests
-/// strictly in order — a group's log row lands before its state, and the next group's row only
-/// after that state — so every older group's state is already durably ingested and at most the
+/// strictly in order (a group's log row lands before its state, and the next group's row only
+/// after that state), so every older group's state is already durably ingested and at most the
 /// newest group can be missing it; re-applying is idempotent because the row's entries are the
 /// newest writes for their keys. A row at or below `floor` is never replayed: its state is
 /// authoritative, and key pruning may have deleted rows a replay would resurrect. Ingestion is
@@ -765,63 +795,68 @@ impl Default for RocksWritePipelineConfig {
     }
 }
 
-/// The machine's available parallelism, defaulting to two when it cannot be queried.
-fn available_parallelism() -> NonZeroUsize {
-    thread::available_parallelism().unwrap_or_else(|_| NonZeroUsize::new(2).expect("nonzero"))
-}
-
 /// RocksDB engine and application-level write pipeline options used by [`RocksStore::open`].
 ///
-/// Column-family options are deliberately not configurable — the store's correctness leans on
-/// the CF options `open` chooses: staged state SSTs and range-scan bounds assume bytewise key
+/// Column-family options are deliberately not configurable because the store's correctness
+/// leans on the CF options `open` chooses: staged state SSTs and range-scan bounds assume bytewise key
 /// order, and rows must never be dropped by a caller-supplied compaction filter or TTL (acked
 /// writes must stay readable, the meta CF's state-floor row must persist, and the repair
 /// replay would nondeterministically resurrect expired state rows).
+#[derive(Default)]
 pub struct RocksConfig {
-    /// Database-wide options. The default raises RocksDB's background-job budget (flushes and
-    /// the compactions that must keep merging the overlapping ingested state SSTs) from the
-    /// stock 2 to the machine's available parallelism; a caller replacing `db_options`
-    /// replaces that choice too — open applies these options as-is.
+    /// Database-wide options, applied as-is (stock defaults). Two knobs matter under sustained
+    /// ingest: `max_background_jobs` (stock RocksDB fixes it at 2, and compactions must keep
+    /// merging the overlapping ingested state SSTs) and `max_open_files` (stock RocksDB keeps
+    /// every touched table file open forever, and ingest creates one log and one state SST per
+    /// commit group).
     pub db_options: Options,
     /// Options for the application-level ingest write pipeline.
     pub write_pipeline: RocksWritePipelineConfig,
-}
-
-impl Default for RocksConfig {
-    /// Stock RocksDB options, with the background-job budget raised to the machine's available
-    /// cores. Memtables are off the hot path (only the open-time replay and prune deletes write
-    /// them), so they stay at stock defaults.
-    fn default() -> Self {
-        let mut db_options = Options::default();
-        db_options.increase_parallelism(available_parallelism().get() as i32);
-        // Ingest links one log and one state SST per commit group into the DB, and stock
-        // RocksDB (max_open_files = -1) keeps every touched file's reader open forever. Bound
-        // the table-reader cache so cold reads pay a reopen instead of the process exhausting
-        // file descriptors.
-        db_options.set_max_open_files(4096);
-        Self {
-            db_options,
-            write_pipeline: RocksWritePipelineConfig::default(),
-        }
-    }
 }
 
 /// Minimal RocksDB-backed store for the simulator: batch writes plus a global sequence u64
 /// plus a per-sequence log.
 #[derive(Clone)]
 pub struct RocksStore {
-    db: Arc<DB>,
+    db: Arc<Database>,
     frontiers: Arc<Frontiers>,
     writer: Arc<Writer>,
 }
 
 impl RocksStore {
     /// Open the store with default options, unless `config` overrides the database or
-    /// write-pipeline options (column families always run stock options — see [`RocksConfig`]).
+    /// write-pipeline options. Column families always run stock options (see [`RocksConfig`]).
     /// Re-derives the durable frontier from the retained log rows and the state-floor meta row,
     /// then re-applies the newest log row to the state column family so the current state is
     /// complete below the durable sequence even after a crash mid-commit.
+    ///
+    /// The caller keeps the directory at `path` alive until every handle to the store (clones,
+    /// open cursors, in-flight operations) has dropped. [`RocksStore::open_owned`] hands that
+    /// ordering to the store instead.
     pub fn open(path: &Path, config: Option<RocksConfig>) -> Result<Self, String> {
+        Self::open_database(path, config, None)
+    }
+
+    /// Open a store that owns its data directory: `directory` is dropped strictly after the
+    /// database has fully closed. Every store clone, open cursor, and in-flight operation
+    /// keeps the database open, and the last of them releases the directory wherever it
+    /// drops, so a directory whose drop has effects (for example `tempfile::TempDir`,
+    /// which deletes it) can never be torn down under a live database.
+    pub fn open_owned<D>(directory: D, config: Option<RocksConfig>) -> Result<Self, String>
+    where
+        D: AsRef<Path> + Send + Sync + 'static,
+    {
+        let path = directory.as_ref().to_path_buf();
+        Self::open_database(&path, config, Some(Box::new(directory)))
+    }
+
+    /// Shared open path: see [`RocksStore::open`] for the recovery contract and
+    /// [`RocksStore::open_owned`] for the directory-ownership contract.
+    fn open_database(
+        path: &Path,
+        config: Option<RocksConfig>,
+        closer: Option<Closer>,
+    ) -> Result<Self, String> {
         let RocksConfig {
             mut db_options,
             write_pipeline,
@@ -833,10 +868,12 @@ impl RocksStore {
         let cf_state = ColumnFamilyDescriptor::new(STATE_CF, Options::default());
         let cf_meta = ColumnFamilyDescriptor::new(META_CF, Options::default());
         let cf_log = ColumnFamilyDescriptor::new(LOG_CF, Options::default());
-        let db = Arc::new(
-            DB::open_cf_descriptors(&db_options, path, vec![cf_state, cf_meta, cf_log])
-                .map_err(|e| e.to_string())?,
-        );
+        let db = DB::open_cf_descriptors(&db_options, path, vec![cf_state, cf_meta, cf_log])
+            .map_err(|e| e.to_string())?;
+        let db = Arc::new(Database {
+            db,
+            _closer: closer,
+        });
 
         let ingest_dir = prepare_ingest_dir(path)?;
         // Commits do not write the state-floor meta row; the log rows are the durable record.
@@ -877,29 +914,45 @@ impl RocksStore {
         self.db.get(key)
     }
 
-    /// Deletes key-pruned current rows, atomically raising the state floor to the published
-    /// frontier in the same synced batch. Every deleted row's log entry sits at or below that
-    /// floor, so the replay at the next open cannot resurrect it — and the sync makes an acked
-    /// prune durable.
+    /// Deletes key-pruned current rows. The state floor is raised to the published frontier
+    /// first (synced, under the publish lock), so every deleted row's log entry sits at or
+    /// below a durable floor and the replay at the next open cannot resurrect it. The deletes
+    /// themselves are applied in bounded chunks outside the lock (all covered by the
+    /// just-persisted floor), so a large prune never stalls commit acks; the final chunk is
+    /// synced, which flushes the whole run and makes an acked prune durable. A crash between
+    /// chunks leaves rows the next prune pass re-deletes.
     fn delete_keys(&self, keys: &[Bytes]) -> Result<(), String> {
         if keys.is_empty() {
             return Ok(());
         }
 
-        let _guard = self.frontiers.persist.lock();
-        let mut batch = rocksdb::WriteBatch::default();
-        batch.put_cf(
-            self.meta_cf(),
-            SEQ_META_KEY,
-            self.frontiers
-                .published
-                .load(Ordering::Acquire)
-                .to_le_bytes(),
-        );
-        for k in keys {
-            batch.delete(k.as_ref());
+        {
+            let _guard = self.frontiers.persist.lock();
+            let mut batch = rocksdb::WriteBatch::default();
+            batch.put_cf(
+                self.meta_cf(),
+                SEQ_META_KEY,
+                self.frontiers
+                    .published
+                    .load(Ordering::Acquire)
+                    .to_le_bytes(),
+            );
+            write_synced_batch(&self.db, batch)?;
         }
-        write_synced_batch(&self.db, batch)
+
+        let mut chunks = keys.chunks(PRUNE_DELETE_CHUNK_KEYS).peekable();
+        while let Some(chunk) = chunks.next() {
+            let mut batch = rocksdb::WriteBatch::default();
+            for k in chunk {
+                batch.delete(k.as_ref());
+            }
+            if chunks.peek().is_none() {
+                write_synced_batch(&self.db, batch)?;
+            } else {
+                self.db.write(batch).map_err(|e| e.to_string())?;
+            }
+        }
+        Ok(())
     }
 
     /// Deletes replay-log rows with sequence numbers below `cutoff_exclusive`.
@@ -1049,8 +1102,13 @@ impl Query for RocksStore {
         limit: usize,
         forward: bool,
     ) -> Result<Self::RangeScan, String> {
-        let db = self.db.clone();
-        Ok(RocksRangeScanCursor::new(db, start, end, limit, forward))
+        Ok(RocksRangeScanCursor::new(
+            self.db.clone(),
+            start,
+            end,
+            limit,
+            forward,
+        ))
     }
 
     async fn get_many(
@@ -1205,6 +1263,34 @@ mod tests {
             DEFAULT_COMMIT_COALESCE_MAX_BATCH_BYTES,
         );
         group
+    }
+
+    #[test]
+    fn owned_directory_outlives_every_database_holder() {
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().to_path_buf();
+        let store = RocksStore::open_owned(dir, None).expect("open owned store");
+
+        // A cursor keeps the database, and therefore the owned directory, alive after every
+        // store handle is gone.
+        let cursor = RocksRangeScanCursor::new(
+            store.db.clone(),
+            Bytes::new(),
+            Bytes::new(),
+            usize::MAX,
+            true,
+        );
+        drop(store);
+        assert!(
+            path.exists(),
+            "directory must survive while a cursor still holds the database"
+        );
+
+        drop(cursor);
+        assert!(
+            !path.exists(),
+            "directory must be deleted once the last database holder drops"
+        );
     }
 
     #[test]
@@ -1368,7 +1454,7 @@ mod tests {
 
             // Simulate a crash that lost the WAL-less state rows for sequence 2 (the group
             // whose commit was interrupted) but kept its durable log row: write it directly,
-            // bypassing the state apply stage and the floor advance — the reopened store must
+            // bypassing the state apply stage and the floor advance. The reopened store must
             // re-derive the durable frontier from the retained rows alone, exactly as after a
             // crash that also lost the unsynced floor advance.
             let payload = StreamGetResponse {
@@ -1546,7 +1632,7 @@ mod tests {
         let dir = tempdir().expect("tempdir");
         let store = RocksStore::open(dir.path(), None).expect("open db");
         // A durable log row whose group never published (its state ingestion was in flight at
-        // a crash): pruning must spare it — it is the repair replay's input at the next open.
+        // a crash): pruning must spare it. It is the repair replay's input at the next open.
         seed_log_row(&store, 1, &encoded_log_entry(1, b"k", b"v"));
 
         store

--- a/examples/simulator/src/rocks.rs
+++ b/examples/simulator/src/rocks.rs
@@ -692,8 +692,7 @@ fn run_apply(
         apply_committed_write(&db, &sequence, &mut poisoned, committed);
     }
     if poisoned.is_none() {
-        if let Err(error) = advance_state_flushed(&db, &flushed, sequence.load(Ordering::Acquire))
-        {
+        if let Err(error) = advance_state_flushed(&db, &flushed, sequence.load(Ordering::Acquire)) {
             debug!(error = %error, "failed to flush state rows on writer shutdown");
         }
     }
@@ -941,7 +940,7 @@ fn replay_state_from_log(db: &DB, from_exclusive: u64, to_inclusive: u64) -> Res
             write_state_batch(db, std::mem::take(&mut batch))?;
         }
     }
-    if batch.len() > 0 {
+    if !batch.is_empty() {
         write_state_batch(db, batch)?;
     }
     Ok(())
@@ -1583,8 +1582,12 @@ mod tests {
 
     #[test]
     fn log_value_matches_generated_encoder() {
-        let cases: Vec<(u64, Vec<Vec<(Bytes, Bytes)>>)> = vec![
-            (1, vec![vec![(Bytes::from_static(b"a"), Bytes::from_static(b"1"))]]),
+        type RequestKvs = Vec<Vec<(Bytes, Bytes)>>;
+        let cases: Vec<(u64, RequestKvs)> = vec![
+            (
+                1,
+                vec![vec![(Bytes::from_static(b"a"), Bytes::from_static(b"1"))]],
+            ),
             // Coalesced requests, empty keys/values, and multi-byte varint lengths.
             (
                 u64::MAX,
@@ -1594,10 +1597,7 @@ mod tests {
                         (Bytes::from_static(b"empty-value"), Bytes::new()),
                         (Bytes::new(), Bytes::new()),
                     ],
-                    vec![(
-                        Bytes::from(vec![7u8; 200]),
-                        Bytes::from(vec![9u8; 20_000]),
-                    )],
+                    vec![(Bytes::from(vec![7u8; 200]), Bytes::from(vec![9u8; 20_000]))],
                 ],
             ),
         ];

--- a/examples/simulator/src/rocks.rs
+++ b/examples/simulator/src/rocks.rs
@@ -4,14 +4,16 @@
 //! can serve replay and point lookups. Batch-log pruning is driven exclusively by the compact
 //! service's `Sequence` scope.
 //!
-//! Durability is anchored on the replay log: each commit group makes its log rows durable first
-//! (one SST file ingested into the log column family), then the current-state rows are applied
-//! without a WAL and the visible sequence frontier advances. The log rows themselves define the
-//! durable frontier — `open` derives it from the highest retained row and the sequence meta row,
-//! which is only persisted when rows may go away (pruning) or applied state may be lost (writer
-//! shutdown). State rows are recovered from the log, so `open` replays retained log rows above
-//! the persisted state-flushed watermark, and pruning flushes the default column family
-//! (advancing that watermark) before deleting log rows it may otherwise still need for recovery.
+//! Both structures are written as SST files and ingested, bypassing the WAL and the memtables
+//! entirely: `prepare` stages one sorted state file and one log file per commit group, and
+//! `commit` ingests the log file first (its rows alone define durability — `open` derives the
+//! frontier from the highest retained row and the sequence meta row), then the state file, and
+//! only then publishes and acks. The two ingestions are not atomic, but the window is one group
+//! wide: a crash between them leaves the log durable and the state missing for at most the last
+//! group, which `open` repairs by replaying the rows of the last retained log file before the
+//! store serves reads. The sequence meta row is persisted only before pruning deletes log rows,
+//! so an unpruned store recovers by reading one meta row, one file listing, and replaying at
+//! most one group.
 
 use std::cmp::Ordering as CmpOrdering;
 use std::collections::BTreeMap;
@@ -32,6 +34,7 @@ use exoware_sdk::selector::compile_payload_regex;
 use exoware_server::{
     Ingest, Log, LogBatch, Prune, Query, QueryExtra, RangeScan, RangeScanBatch, Sequence,
 };
+use rayon::slice::ParallelSliceMut;
 use regex::bytes::Regex;
 use rocksdb::{
     ColumnFamily, ColumnFamilyDescriptor, DBCompressionType, DBIterator, Direction,
@@ -42,18 +45,14 @@ use tracing::debug;
 
 const META_CF: &str = "meta";
 /// Durable-sequence floor. The frontier at open is the maximum of this row and the highest
-/// retained log row, so it is only persisted when log rows may be deleted (pruning) or the
-/// process winds down; commits never write it.
+/// retained log row; it is only persisted before pruning deletes log rows — commits never write
+/// it.
 const SEQ_META_KEY: &[u8] = b"sequence";
-/// Highest sequence whose current-state rows are durable in the default column family (flushed to
-/// SSTs). Recovery replays retained log rows above this watermark to rebuild the state rows that
-/// were applied without a WAL.
-const STATE_FLUSHED_META_KEY: &[u8] = b"state_flushed_sequence";
 const LOG_CF: &str = "log";
 const LOG_BATCH_KEY_LEN: usize = 8;
 const PRUNE_SCAN_BATCH_SIZE: usize = 4096;
 const DEFAULT_COMMIT_COALESCE_MAX_BATCH_BYTES: usize = 16 * 1024 * 1024;
-/// Directory under the store path where log SST files are staged before ingestion.
+/// Directory under the store path where SST files are staged before ingestion.
 const LOG_INGEST_DIR: &str = "ingest";
 type RocksIterItem = Result<(Box<[u8]>, Box<[u8]>), rocksdb::Error>;
 
@@ -297,27 +296,23 @@ fn keys_to_delete(
 
 /// Sequence frontiers shared by the store and its writer stages.
 struct Frontiers {
-    /// Highest sequence readers may observe: log rows durable and state rows applied.
+    /// Highest sequence readers may observe: log rows and state rows both ingested.
     published: AtomicU64,
-    /// Highest sequence whose log rows are durable. Runs ahead of `published` while state
-    /// application is in flight; re-derived at open from the retained log rows and the sequence
-    /// meta row.
+    /// Highest sequence whose log rows are durable. Runs ahead of `published` only while a
+    /// group's state ingestion is in flight; re-derived at open from the retained log rows and
+    /// the sequence meta row.
     durable: AtomicU64,
-    /// Highest sequence whose state rows are flushed to SSTs (the recovery-replay lower bound).
-    flushed: AtomicU64,
-    /// Highest durable-sequence value written to the meta row, so an unchanged store can skip
-    /// the flush and synced write entirely.
+    /// Highest durable-sequence value written to the meta row, so redundant persists are free.
     persisted_durable: AtomicU64,
-    /// Serializes frontier persistence so the meta rows never move backward.
+    /// Serializes floor persistence so the meta row never moves backward.
     persist: Mutex<()>,
 }
 
 impl Frontiers {
-    fn new(durable: u64, flushed: u64, persisted_durable: u64) -> Self {
+    fn new(durable: u64, persisted_durable: u64) -> Self {
         Self {
             published: AtomicU64::new(durable),
             durable: AtomicU64::new(durable),
-            flushed: AtomicU64::new(flushed),
             persisted_durable: AtomicU64::new(persisted_durable),
             persist: Mutex::new(()),
         }
@@ -334,27 +329,24 @@ struct AssignedWrite {
     request: WriteRequest,
 }
 
+/// SST files staged for one commit group, ready to be ingested.
+struct StagedFiles {
+    /// Replay-log rows (ascending sequence order), destined for the log column family.
+    log: PathBuf,
+    /// Current-state rows (sorted by key, last write per key), destined for the default column
+    /// family.
+    state: PathBuf,
+    /// Combined payload bytes staged, for debug logging.
+    staged_bytes: usize,
+}
+
 /// One commit group covering a contiguous run of assigned sequence numbers.
 struct PreparedWrite {
     writes: Vec<AssignedWrite>,
-    /// Encoded replay-log rows in ascending sequence order. They alone define durability (the
-    /// state rows are recoverable from them): `commit` writes them as one SST file ingested
-    /// directly into the log column family, followed by a synced meta write, so the payload
-    /// reaches the disk once instead of twice (WAL now, SST again on flush) and, sitting at the
-    /// bottom level, is never rewritten by compaction.
-    log_rows: Result<Vec<(u64, Vec<u8>)>, String>,
-    /// Current-state rows for the same sequences, applied without a WAL once the log is durable.
-    state_batch: rocksdb::WriteBatch,
-    batch_bytes: usize,
+    /// The group's staged SST files, or the error that aborted staging them.
+    staged: Result<StagedFiles, String>,
     /// Assignment epoch; `commit` rejects a group whose epoch an earlier failure has superseded.
     epoch: u64,
-}
-
-/// A group whose log batch is durable and whose state rows still have to be applied.
-struct CommittedWrite {
-    writes: Vec<AssignedWrite>,
-    state_batch: rocksdb::WriteBatch,
-    last_sequence: u64,
 }
 
 struct Writer {
@@ -363,13 +355,11 @@ struct Writer {
 }
 
 impl Writer {
-    /// Starts the three-stage write pipeline. `prepare` drains queued requests up to the
-    /// configured byte cap, assigns a contiguous sequence number to each, and builds each wave's
-    /// state batch and encoded log rows; `commit` makes each group's log rows durable (one
-    /// ingested SST), publishing the durable frontier; `apply` inserts the state rows without a
-    /// WAL, advances the visible frontier, and resolves the requests. The stages overlap, so
-    /// while one group is being synced the next is being built and the previous group's state
-    /// rows are being applied.
+    /// Starts the two-stage write pipeline. `prepare` drains queued requests up to the
+    /// configured byte cap, assigns a contiguous sequence number to each, and stages each wave's
+    /// log and state SST files (including their data syncs); `commit` ingests the log file, then
+    /// the state file, publishes the frontier, and resolves the requests. The stages overlap, so
+    /// one group's files are being staged while the previous group's are being ingested.
     fn start(
         db: Arc<DB>,
         ingest_dir: PathBuf,
@@ -377,11 +367,9 @@ impl Writer {
         write_pipeline: RocksWritePipelineConfig,
     ) -> Self {
         let (request_sender, request_receiver) = mpsc::channel();
-        // Rendezvous so `prepare` runs at most one wave ahead of `commit`: it hands off a built
-        // group, then builds the next while `commit` syncs this one.
+        // Rendezvous so `prepare` runs at most one wave ahead of `commit`: it hands off a staged
+        // group, then stages the next while `commit` ingests this one.
         let (group_sender, group_receiver) = mpsc::sync_channel(0);
-        // Allow `commit` to sync the next group while `apply` inserts this group's state rows.
-        let (committed_sender, committed_receiver) = mpsc::sync_channel(1);
         let max_commit_batch_bytes = write_pipeline.max_commit_batch_bytes.get();
 
         // Bumped by `commit` whenever a group fails. That rejects the in-flight groups assigned
@@ -389,33 +377,18 @@ impl Writer {
         // sequence, re-allocating the abandoned numbers.
         let epoch = Arc::new(AtomicU64::new(0));
 
-        let apply_db = db.clone();
-        let apply_frontiers = frontiers.clone();
-        let apply = thread::Builder::new()
-            .name("simulator-rocks-apply".to_string())
-            .spawn(move || run_apply(apply_db, apply_frontiers, committed_receiver))
-            .expect("failed to spawn RocksDB apply worker");
-
         let commit_frontiers = frontiers.clone();
         let commit_epoch = epoch.clone();
         let commit = thread::Builder::new()
             .name("simulator-rocks-commit".to_string())
-            .spawn(move || {
-                run_commit(
-                    db,
-                    ingest_dir,
-                    commit_frontiers,
-                    commit_epoch,
-                    group_receiver,
-                    committed_sender,
-                )
-            })
+            .spawn(move || run_commit(db, commit_frontiers, commit_epoch, group_receiver))
             .expect("failed to spawn RocksDB commit worker");
 
         let prepare = thread::Builder::new()
             .name("simulator-rocks-prepare".to_string())
             .spawn(move || {
                 run_prepare(
+                    ingest_dir,
                     frontiers,
                     epoch,
                     request_receiver,
@@ -427,7 +400,7 @@ impl Writer {
 
         Self {
             sender: Mutex::new(Some(request_sender)),
-            handles: Mutex::new(vec![prepare, commit, apply]),
+            handles: Mutex::new(vec![prepare, commit]),
         }
     }
 
@@ -458,9 +431,9 @@ impl Writer {
 
 impl Drop for Writer {
     fn drop(&mut self) {
-        // Closing the request channel lets `prepare` drain and exit, which drops the group channel
-        // and stops `commit`, which in turn stops `apply` after it drains the committed groups;
-        // joining keeps background RocksDB writers from outliving the store.
+        // Closing the request channel lets `prepare` drain and exit, which drops the group
+        // channel and stops `commit`; joining keeps background RocksDB writers from outliving
+        // the store.
         if let Ok(mut sender) = self.sender.lock() {
             sender.take();
         }
@@ -472,11 +445,12 @@ impl Drop for Writer {
     }
 }
 
-/// Drains each byte-bounded wave of queued requests, assigns contiguous sequence numbers, builds a
-/// size-capped commit group, and hands it to `commit`. After a commit failure bumps the epoch, the
-/// next wave re-syncs `next` to the durable frontier so the abandoned sequence numbers are
+/// Drains each byte-bounded wave of queued requests, assigns contiguous sequence numbers, stages
+/// the wave's SST files, and hands the group to `commit`. After a commit failure bumps the epoch,
+/// the next wave re-syncs `next` to the durable frontier so the abandoned sequence numbers are
 /// re-allocated.
 fn run_prepare(
+    ingest_dir: PathBuf,
     frontiers: Arc<Frontiers>,
     epoch: Arc<AtomicU64>,
     receiver: mpsc::Receiver<WriteRequest>,
@@ -489,14 +463,14 @@ fn run_prepare(
     while let Ok(first) = receiver.recv() {
         let current_epoch = epoch.load(Ordering::Acquire);
         if current_epoch != seen_epoch {
-            // A commit failed: each group commits its log rows atomically (one ingested file),
-            // so nothing past the durable frontier persisted, and the failed numbers can be
-            // reclaimed.
+            // A commit failed: nothing past the durable frontier persisted, so the failed
+            // numbers can be reclaimed.
             seen_epoch = current_epoch;
             next = frontiers.durable.load(Ordering::Acquire);
         }
 
         let (group, disconnected) = match prepare_queued_write(
+            &ingest_dir,
             &receiver,
             first,
             next,
@@ -522,17 +496,11 @@ fn run_prepare(
     }
 }
 
-/// Estimated RocksDB `WriteBatch` size for one request's rows: payload plus per-record framing.
-/// Presizing the batch avoids repeated grow-and-copy cycles while appending large requests.
-fn write_batch_capacity(request: &WriteRequest) -> usize {
-    let payload: usize = request.kvs.iter().map(|(k, v)| k.len() + v.len()).sum();
-    payload + request.kvs.len() * 16 + 64
-}
-
 /// Builds one prepared write from requests already queued behind `first` without waiting for new
-/// arrivals, stopping once the accumulated RocksDB batches reach the soft byte cap. The request
-/// that crosses the cap stays in the wave so a single large request can still make progress.
+/// arrivals, stopping once the accumulated payload reaches the soft byte cap. The request that
+/// crosses the cap stays in the wave so a single large request can still make progress.
 fn prepare_queued_write(
+    ingest_dir: &Path,
     receiver: &mpsc::Receiver<WriteRequest>,
     first: WriteRequest,
     from: u64,
@@ -540,9 +508,7 @@ fn prepare_queued_write(
     epoch: u64,
 ) -> Result<(PreparedWrite, bool), (Vec<WriteRequest>, String)> {
     let mut writes = Vec::with_capacity(64);
-    let mut state_batch = rocksdb::WriteBatch::with_capacity_bytes(write_batch_capacity(&first));
-    let mut log_rows: Vec<(u64, Vec<u8>)> = Vec::new();
-    let mut log_bytes = 0usize;
+    let mut staged_bytes = 0usize;
     let mut next = from;
     let mut request = first;
     let mut disconnected = false;
@@ -557,17 +523,17 @@ fn prepare_queued_write(
                 ));
             }
         };
-        let write = AssignedWrite {
+        // Payload counted twice: once as state rows and once inside the encoded log row.
+        staged_bytes += 2 * request
+            .kvs
+            .iter()
+            .map(|(k, v)| k.len() + v.len())
+            .sum::<usize>();
+        writes.push(AssignedWrite {
             sequence: next,
             request,
-        };
-        append_state_entries(&mut state_batch, std::slice::from_ref(&write.request));
-        if let Some(value) = encode_log_value(next, std::slice::from_ref(&write.request)) {
-            log_bytes += LOG_BATCH_KEY_LEN + value.len();
-            log_rows.push((next, value));
-        }
-        writes.push(write);
-        if state_batch.size_in_bytes() + log_bytes >= max_batch_bytes || next == u64::MAX {
+        });
+        if staged_bytes >= max_batch_bytes || next == u64::MAX {
             break;
         }
 
@@ -581,14 +547,103 @@ fn prepare_queued_write(
         }
     }
 
+    let staged = stage_group_files(ingest_dir, &writes, epoch);
     let group = PreparedWrite {
         writes,
-        log_rows: Ok(log_rows),
-        batch_bytes: state_batch.size_in_bytes() + log_bytes,
-        state_batch,
+        staged,
         epoch,
     };
     Ok((group, disconnected))
+}
+
+/// Writes and syncs one commit group's two SST files: the replay-log rows (already in ascending
+/// sequence order) and the current-state rows (sorted by key in parallel, keeping the last write
+/// per key). The two files are built concurrently; ingestion later links them into their column
+/// families, so each payload byte reaches the disk exactly once, in its final resting place.
+fn stage_group_files(
+    ingest_dir: &Path,
+    writes: &[AssignedWrite],
+    epoch: u64,
+) -> Result<StagedFiles, String> {
+    let first = writes.first().expect("groups are never empty").sequence;
+    let last = writes.last().expect("groups are never empty").sequence;
+    let log_path = ingest_dir.join(format!("log-{first:020}-{last:020}-e{epoch}.sst"));
+    let state_path = ingest_dir.join(format!("state-{first:020}-{last:020}-e{epoch}.sst"));
+
+    let (log_result, state_result) = rayon::join(
+        || stage_log_file(&log_path, writes),
+        || stage_state_file(&state_path, writes),
+    );
+    let staged = match (log_result, state_result) {
+        (Ok(log_bytes), Ok(state_bytes)) => Ok(StagedFiles {
+            log: log_path.clone(),
+            state: state_path.clone(),
+            staged_bytes: log_bytes + state_bytes,
+        }),
+        (log, state) => Err(log.err().or(state.err()).expect("one side failed")),
+    };
+    if staged.is_err() {
+        let _ = std::fs::remove_file(&log_path);
+        let _ = std::fs::remove_file(&state_path);
+    }
+    staged
+}
+
+/// Options for staged SST files. Uncompressed: compressing on the ingest path would trade ack
+/// latency for bytes, and lower levels re-compress state during compaction per the CF options.
+fn staging_options() -> Options {
+    let mut options = Options::default();
+    options.set_compression_type(DBCompressionType::None);
+    options
+}
+
+/// Stages the replay-log SST: one row per sequence, keyed in ascending sequence order.
+fn stage_log_file(path: &Path, writes: &[AssignedWrite]) -> Result<usize, String> {
+    let options = staging_options();
+    let mut writer = SstFileWriter::create(&options);
+    writer.open(path).map_err(|e| e.to_string())?;
+    let mut bytes = 0;
+    for write in writes {
+        let value = encode_log_value(write.sequence, std::slice::from_ref(&write.request))
+            .expect("requests always carry rows (empty batches are rejected on entry)");
+        bytes += LOG_BATCH_KEY_LEN + value.len();
+        writer
+            .put(sequence_log_key(write.sequence), &value)
+            .map_err(|e| e.to_string())?;
+    }
+    // `finish` syncs the file before it is linked into the DB.
+    writer.finish().map_err(|e| e.to_string())?;
+    Ok(bytes)
+}
+
+/// Stages the current-state SST: the group's rows sorted by key, with the last write per key
+/// winning (across coalesced requests, in sequence order).
+fn stage_state_file(path: &Path, writes: &[AssignedWrite]) -> Result<usize, String> {
+    let mut rows: Vec<(&Bytes, &Bytes)> = Vec::new();
+    for write in writes {
+        for (key, value) in &write.request.kvs {
+            rows.push((key, value));
+        }
+    }
+    // Stable parallel sort: equal keys keep arrival order, so the last occurrence is the newest.
+    rows.par_sort_by(|a, b| a.0.cmp(b.0));
+
+    let options = staging_options();
+    let mut writer = SstFileWriter::create(&options);
+    writer.open(path).map_err(|e| e.to_string())?;
+    let mut bytes = 0;
+    for (index, (key, value)) in rows.iter().enumerate() {
+        if rows.get(index + 1).is_some_and(|next| next.0 == *key) {
+            continue;
+        }
+        bytes += key.len() + value.len();
+        writer
+            .put(key.as_ref(), value.as_ref())
+            .map_err(|e| e.to_string())?;
+    }
+    // `finish` syncs the file before it is linked into the DB.
+    writer.finish().map_err(|e| e.to_string())?;
+    Ok(bytes)
 }
 
 /// Sends one group to `commit`, returning false if it has stopped.
@@ -600,162 +655,126 @@ fn forward_group(sender: &mpsc::SyncSender<PreparedWrite>, group: PreparedWrite)
     true
 }
 
-/// Commits prepared groups one at a time (one ingested log SST each), publishing the durable
-/// frontier after each success and handing the group to `apply`. A group whose epoch was
-/// superseded by an earlier failure is rejected without being written; a failing group bumps the
-/// epoch so its frontier (and every later group assigned under it) is abandoned and re-allocated
-/// by `prepare`.
+/// Commits prepared groups one at a time: log ingestion, state ingestion, publish, ack. Stops on
+/// the first partial commit (log durable, state not), since publishing anything later would
+/// advertise completeness the state cannot back; a restart repairs the partial group from its
+/// log file. A group whose epoch was superseded by an earlier failure is rejected without being
+/// written; a failing group bumps the epoch so its frontier (and every later group assigned
+/// under it) is abandoned and re-allocated by `prepare`.
 fn run_commit(
     db: Arc<DB>,
-    ingest_dir: PathBuf,
     frontiers: Arc<Frontiers>,
     epoch: Arc<AtomicU64>,
     receiver: mpsc::Receiver<PreparedWrite>,
-    committed_sender: mpsc::SyncSender<CommittedWrite>,
 ) {
     while let Ok(group) = receiver.recv() {
-        let Some(committed) = commit_group(&db, &ingest_dir, &frontiers.durable, &epoch, group)
-        else {
-            continue;
-        };
-        if let Err(error) = committed_sender.send(committed) {
-            // The log rows are durable but the state rows can no longer be applied in this
-            // process; recovery replays them on the next open, so the callers only lose the ack.
-            fail_assigned_writes(error.0.writes, "rocks apply worker stopped".to_string());
+        if commit_group(&db, &frontiers, &epoch, group) == CommitOutcome::Poisoned {
+            // Exiting closes the group channel, so prepare fails all later waves.
             break;
         }
     }
 }
 
-/// Commits one group's log rows, returning the group for state application on success. Returns
-/// `None` when the group is empty, rejected, or failed (with its requests already resolved).
+#[derive(Debug, Eq, PartialEq)]
+enum CommitOutcome {
+    /// The group was committed and published, or cleanly rejected/failed (nothing durable).
+    Continue,
+    /// The group's log rows are durable but its state ingestion failed: the frontier must freeze
+    /// below the group until a restart replays its log file.
+    Poisoned,
+}
+
+/// Commits one group: ingests its log file (durability), then its state file (visibility), then
+/// publishes the frontier and resolves the requests.
 fn commit_group(
     db: &DB,
-    ingest_dir: &Path,
-    durable: &AtomicU64,
+    frontiers: &Frontiers,
     epoch: &AtomicU64,
     group: PreparedWrite,
-) -> Option<CommittedWrite> {
+) -> CommitOutcome {
     if group.writes.is_empty() {
-        return None;
+        return CommitOutcome::Continue;
     }
-    if group.epoch != epoch.load(Ordering::Acquire) {
-        // This group was assigned under a frontier an earlier commit failure has since abandoned
-        // (prepare can build one wave ahead before it observes the bump). Rejecting it keeps the
-        // durable log gap-free; the requests never reached the disk, so the caller is told to
-        // retry, which re-allocates them fresh sequence numbers under the current epoch.
-        fail_assigned_writes(
-            group.writes,
-            "rocks write batch superseded by an earlier failure, retry".to_string(),
-        );
-        return None;
-    }
-
-    let requests = group.writes.len();
-    let group_epoch = group.epoch;
     let PreparedWrite {
         writes,
-        log_rows,
-        state_batch,
-        batch_bytes,
-        ..
+        staged,
+        epoch: group_epoch,
     } = group;
+    let staged = match staged {
+        Ok(staged) => staged,
+        Err(error) => {
+            epoch.fetch_add(1, Ordering::AcqRel);
+            fail_assigned_writes(writes, error);
+            return CommitOutcome::Continue;
+        }
+    };
+    if group_epoch != epoch.load(Ordering::Acquire) {
+        // This group was assigned under a frontier an earlier commit failure has since abandoned
+        // (prepare can stage one wave ahead before it observes the bump). Rejecting it keeps the
+        // durable log gap-free; the requests never reached the DB, so the caller is told to
+        // retry, which re-allocates them fresh sequence numbers under the current epoch.
+        let _ = std::fs::remove_file(&staged.log);
+        let _ = std::fs::remove_file(&staged.state);
+        fail_assigned_writes(
+            writes,
+            "rocks write batch superseded by an earlier failure, retry".to_string(),
+        );
+        return CommitOutcome::Continue;
+    }
+
+    let requests = writes.len();
     let last_sequence = writes
         .last()
         .expect("non-empty group has a last write")
         .sequence;
-    let log_rows = match log_rows {
-        Ok(log_rows) => log_rows,
-        Err(error) => {
-            epoch.fetch_add(1, Ordering::AcqRel);
-            fail_assigned_writes(writes, error);
-            return None;
-        }
-    };
-    let committed = ingest_log_rows(db, ingest_dir, log_rows, last_sequence, group_epoch);
-    match committed {
-        Ok(()) => {
-            // Release so `prepare` re-syncs against a frontier whose log rows are already synced.
-            durable.store(last_sequence, Ordering::Release);
-            debug!(
-                requests,
-                batch_bytes,
-                sequence = last_sequence,
-                "committed write batch"
-            );
-            Some(CommittedWrite {
-                writes,
-                state_batch,
-                last_sequence,
-            })
-        }
-        Err(error) => {
-            // Bump before failing: any in-flight group sharing the failed epoch is then rejected,
-            // and `prepare` re-syncs to the durable frontier, leaving the abandoned numbers for
-            // reuse.
-            epoch.fetch_add(1, Ordering::AcqRel);
-            fail_assigned_writes(writes, error);
-            None
-        }
+
+    // Log first: its rows define durability, and an ingested state file without its log rows
+    // could leave keys in the store that were never part of a sequenced batch.
+    if let Err(error) = ingest_staged_file(db, LOG_CF, &staged.log) {
+        // Nothing is durable (ingestion is atomic), so the numbers can be reclaimed: bump the
+        // epoch so in-flight groups are rejected and `prepare` re-syncs to the durable frontier.
+        let _ = std::fs::remove_file(&staged.state);
+        epoch.fetch_add(1, Ordering::AcqRel);
+        fail_assigned_writes(writes, error);
+        return CommitOutcome::Continue;
     }
+    // Release so `prepare` re-syncs against a frontier whose log rows are already durable.
+    frontiers.durable.store(last_sequence, Ordering::Release);
+
+    if let Err(error) = ingest_staged_file(db, rocksdb::DEFAULT_COLUMN_FAMILY_NAME, &staged.state) {
+        // The log rows are durable but the state rows are not: the frontier freezes below this
+        // group so reads stay complete below the advertised sequence, and a restart repairs the
+        // state by replaying the group's log file.
+        fail_assigned_writes(writes, error);
+        return CommitOutcome::Poisoned;
+    }
+
+    // Release so `current_sequence` readers only observe frontiers whose rows are readable.
+    frontiers.published.store(last_sequence, Ordering::Release);
+    debug!(
+        requests,
+        staged_bytes = staged.staged_bytes,
+        sequence = last_sequence,
+        "committed write batch"
+    );
+    complete_assigned_writes(writes);
+    CommitOutcome::Continue
 }
 
-/// Applies committed state batches in commit order, advancing the visible frontier and resolving
-/// requests after each group's rows are readable. On loop exit the frontiers are persisted (with
-/// a state flush) so a clean reopen can skip the recovery replay.
-fn run_apply(db: Arc<DB>, frontiers: Arc<Frontiers>, receiver: mpsc::Receiver<CommittedWrite>) {
-    let mut poisoned = None;
-    while let Ok(committed) = receiver.recv() {
-        apply_committed_write(&db, &frontiers.published, &mut poisoned, committed);
+/// Ingests one staged SST file into `cf`. Ingestion links the file into the column family and
+/// syncs the manifest, so the rows are durable and readable once this returns.
+fn ingest_staged_file(db: &DB, cf: &str, path: &Path) -> Result<(), String> {
+    let cf = db.cf_handle(cf).expect("CFs exist (created on open)");
+    let mut ingest_options = IngestExternalFileOptions::default();
+    ingest_options.set_move_files(true);
+    if let Err(error) = db.ingest_external_file_cf_opts(cf, &ingest_options, vec![path]) {
+        let _ = std::fs::remove_file(path);
+        return Err(error.to_string());
     }
-    if poisoned.is_none() {
-        if let Err(error) = persist_frontiers(&db, &frontiers) {
-            debug!(error = %error, "failed to flush state rows on writer shutdown");
-        }
-    }
+    Ok(())
 }
 
-/// Applies one committed group's state rows and publishes its frontier. A failed state write
-/// poisons the stage: the frontier freezes below the missing rows (later groups are only failed,
-/// never published), so reads stay complete below the advertised sequence until a restart replays
-/// the durable log.
-fn apply_committed_write(
-    db: &DB,
-    sequence: &AtomicU64,
-    poisoned: &mut Option<String>,
-    committed: CommittedWrite,
-) {
-    if let Some(error) = poisoned.as_ref() {
-        fail_assigned_writes(
-            committed.writes,
-            format!("rocks state apply previously failed: {error}"),
-        );
-        return;
-    }
-    match write_state_batch(db, committed.state_batch) {
-        Ok(()) => {
-            // Release so `current_sequence` readers only observe frontiers whose rows are already
-            // readable (and, via the log commit, durable).
-            sequence.store(committed.last_sequence, Ordering::Release);
-            complete_assigned_writes(committed.writes);
-        }
-        Err(error) => {
-            fail_assigned_writes(committed.writes, error.clone());
-            *poisoned = Some(error);
-        }
-    }
-}
-
-/// Appends the current-state rows for one sequence to the state batch.
-fn append_state_entries(state_batch: &mut rocksdb::WriteBatch, requests: &[WriteRequest]) {
-    for request in requests {
-        for (k, v) in &request.kvs {
-            state_batch.put(k.as_ref(), v.as_ref());
-        }
-    }
-}
-
-/// Writes a batch with sync enabled, used for the meta rows that define durable frontiers.
+/// Writes a batch with sync enabled, used for the meta row that defines the durable floor.
 fn write_synced_batch(db: &DB, batch: rocksdb::WriteBatch) -> Result<(), String> {
     let mut write_options = WriteOptions::default();
     write_options.set_sync(true);
@@ -763,93 +782,24 @@ fn write_synced_batch(db: &DB, batch: rocksdb::WriteBatch) -> Result<(), String>
         .map_err(|e| e.to_string())
 }
 
-/// Commits one group's log rows by writing them as an SST file and ingesting it into the log
-/// column family. Ingestion syncs the file and the manifest before returning, so the rows — and
-/// with them the sequence numbers `open` re-derives from the retained log — are durable; no
-/// separate meta write (and fsync) is needed on the commit path.
-fn ingest_log_rows(
-    db: &DB,
-    ingest_dir: &Path,
-    log_rows: Vec<(u64, Vec<u8>)>,
-    last_sequence: u64,
-    epoch: u64,
-) -> Result<(), String> {
-    let first = log_rows
-        .first()
-        .expect("groups always carry log rows (empty batches are rejected on entry)")
-        .0;
-    // Leftover files from failed ingestions are deleted when the store reopens, and epochs make
-    // re-allocated sequence numbers unambiguous within one writer's lifetime.
-    let path = ingest_dir.join(format!("log-{first:020}-{last_sequence:020}-e{epoch}.sst"));
-
-    // Uncompressed for parity with what a WAL write would cost; compressing on the commit path
-    // would trade ack latency for bytes.
-    let mut options = Options::default();
-    options.set_compression_type(DBCompressionType::None);
-    let mut writer = SstFileWriter::create(&options);
-    writer.open(&path).map_err(|e| e.to_string())?;
-    for (sequence, value) in &log_rows {
-        writer
-            .put(sequence_log_key(*sequence), value)
-            .map_err(|e| e.to_string())?;
-    }
-    // `finish` syncs the file before it is linked into the DB.
-    writer.finish().map_err(|e| e.to_string())?;
-
-    let log_cf = db
-        .cf_handle(LOG_CF)
-        .expect("log CF must exist (created on open)");
-    let mut ingest_options = IngestExternalFileOptions::default();
-    ingest_options.set_move_files(true);
-    if let Err(error) = db.ingest_external_file_cf_opts(log_cf, &ingest_options, vec![&path]) {
-        let _ = std::fs::remove_file(&path);
-        return Err(error.to_string());
-    }
-    Ok(())
-}
-
-/// Writes current-state rows without a WAL: durability comes from the already-synced log batch,
-/// which `open` replays above the state-flushed watermark after a crash.
-fn write_state_batch(db: &DB, batch: rocksdb::WriteBatch) -> Result<(), String> {
-    let mut write_options = WriteOptions::default();
-    write_options.disable_wal(true);
-    db.write_opt(batch, &write_options)
-        .map_err(|e| e.to_string())
-}
-
-/// Persists the sequence frontiers with one synced meta write: the durable-sequence floor (so a
-/// later log prune cannot regress the frontier `open` re-derives from retained rows) and the
-/// state-flushed watermark, flushing the default column family first so every published state row
-/// is in SSTs. Recovery replays retained log rows above the watermark, so the watermark must only
-/// advance after the flush completes; the lock keeps concurrent callers from persisting stale,
-/// lower values over newer ones.
-fn persist_frontiers(db: &DB, frontiers: &Frontiers) -> Result<(), String> {
+/// Persists the durable-sequence floor with one synced meta write, so a later log prune cannot
+/// regress the frontier `open` re-derives from retained rows. The lock keeps concurrent callers
+/// from persisting stale, lower values over newer ones.
+fn persist_durable_floor(db: &DB, frontiers: &Frontiers) -> Result<(), String> {
     let _guard = frontiers
         .persist
         .lock()
         .map_err(|e| format!("rocks frontier persist lock poisoned: {e}"))?;
-    let published = frontiers.published.load(Ordering::Acquire);
     let durable = frontiers.durable.load(Ordering::Acquire);
-    if frontiers.flushed.load(Ordering::Acquire) >= published
-        && frontiers.persisted_durable.load(Ordering::Acquire) >= durable
-    {
+    if frontiers.persisted_durable.load(Ordering::Acquire) >= durable {
         return Ok(());
     }
-    if frontiers.flushed.load(Ordering::Acquire) < published {
-        let default_cf = db
-            .cf_handle(rocksdb::DEFAULT_COLUMN_FAMILY_NAME)
-            .expect("default CF must exist (created on open)");
-        db.flush_cf(default_cf).map_err(|e| e.to_string())?;
-    }
-
     let meta_cf = db
         .cf_handle(META_CF)
         .expect("meta CF must exist (created on open)");
     let mut batch = rocksdb::WriteBatch::default();
     batch.put_cf(meta_cf, SEQ_META_KEY, durable.to_le_bytes());
-    batch.put_cf(meta_cf, STATE_FLUSHED_META_KEY, published.to_le_bytes());
     write_synced_batch(db, batch)?;
-    frontiers.flushed.fetch_max(published, Ordering::AcqRel);
     frontiers
         .persisted_durable
         .fetch_max(durable, Ordering::AcqRel);
@@ -900,34 +850,42 @@ fn read_meta_sequence(db: &DB, key: &[u8]) -> Result<u64, String> {
     }
 }
 
-/// Re-applies the retained log rows in `(from_exclusive, to_inclusive]` to the default column
-/// family. State rows are written without a WAL, so after a crash the rows above the flushed
-/// watermark only exist in the log; replaying them in sequence order (last writer wins) rebuilds
-/// the exact current state. Rows already covered by an earlier flush may have been pruned and are
-/// simply absent from the iteration.
-fn replay_state_from_log(db: &DB, from_exclusive: u64, to_inclusive: u64) -> Result<(), String> {
+/// Repairs the current state after a crash that hit between a group's two ingestions: the log
+/// file is durable but the state file may be missing, and only for the last committed group
+/// (commit ingests strictly in order and publishes before starting the next group). Re-applies
+/// every row of the last retained log file — the group whose state might be missing is always
+/// the one that ends at the durable frontier — which is idempotent because those rows are the
+/// newest writes for their keys.
+fn replay_last_log_file(db: &DB) -> Result<(), String> {
+    let last_file_start = db
+        .live_files()
+        .map_err(|e| e.to_string())?
+        .into_iter()
+        .filter(|file| file.column_family_name == LOG_CF)
+        .filter_map(|file| file.start_key.zip(file.end_key))
+        .max_by(|a, b| a.1.cmp(&b.1))
+        .map(|(start, _)| sequence_from_log_key(&start))
+        .transpose()?;
+    let Some(start) = last_file_start else {
+        return Ok(());
+    };
+
     let log_cf = db
         .cf_handle(LOG_CF)
         .expect("log CF must exist (created on open)");
-    let start = sequence_log_key(from_exclusive.saturating_add(1));
     let mut batch = rocksdb::WriteBatch::default();
-    for item in db.iterator_cf(log_cf, IteratorMode::From(&start, Direction::Forward)) {
+    let from = sequence_log_key(start);
+    for item in db.iterator_cf(log_cf, IteratorMode::From(&from, Direction::Forward)) {
         let (key, value) = item.map_err(|e| e.to_string())?;
         let sequence = sequence_from_log_key(key.as_ref())?;
-        if sequence > to_inclusive {
-            break;
-        }
         let response = StreamGetResponseView::decode_view(value.as_ref())
             .map_err(|e| format!("corrupt log row for sequence {sequence}: {e}"))?;
         for entry in response.entries.iter() {
             batch.put(entry.key, entry.value);
         }
-        if batch.size_in_bytes() >= DEFAULT_COMMIT_COALESCE_MAX_BATCH_BYTES {
-            write_state_batch(db, std::mem::take(&mut batch))?;
-        }
     }
     if !batch.is_empty() {
-        write_state_batch(db, batch)?;
+        db.write(batch).map_err(|e| e.to_string())?;
     }
     Ok(())
 }
@@ -1022,9 +980,9 @@ pub struct RocksStore {
 impl RocksStore {
     /// Open the store with stock RocksDB defaults, unless `config` overrides
     /// the database and column-family options. Re-derives the durable frontier from the retained
-    /// log rows and the sequence meta row, then replays log rows above the state-flushed
-    /// watermark into the default column family so the current state is complete below the
-    /// durable sequence even after a crash that lost un-flushed (WAL-less) state rows.
+    /// log rows and the sequence meta row, then replays the last retained log file into the
+    /// default column family so the current state is complete below the durable sequence even
+    /// after a crash between a group's log and state ingestions.
     pub fn open(path: &Path, config: Option<RocksConfig>) -> Result<Self, String> {
         let RocksConfig {
             mut db_options,
@@ -1048,16 +1006,11 @@ impl RocksStore {
         // Commits do not write the sequence meta row; the log rows are the durable record.
         let meta_seq = read_meta_sequence(&db, SEQ_META_KEY)?;
         let seq = meta_seq.max(highest_log_row(&db)?);
-        let flushed_seq = read_meta_sequence(&db, STATE_FLUSHED_META_KEY)?;
 
         let ingest_dir = prepare_ingest_dir(path)?;
+        replay_last_log_file(&db)?;
 
-        let frontiers = Arc::new(Frontiers::new(seq, flushed_seq, meta_seq));
-        if flushed_seq < seq {
-            replay_state_from_log(&db, flushed_seq, seq)?;
-            persist_frontiers(&db, &frontiers)?;
-        }
-
+        let frontiers = Arc::new(Frontiers::new(seq, meta_seq));
         let writer = Arc::new(Writer::start(
             db.clone(),
             ingest_dir,
@@ -1185,20 +1138,15 @@ impl RocksStore {
         for (_group_key, entries) in groups {
             all_deletes.extend(keys_to_delete(entries, scope, retain)?);
         }
-        self.delete_keys(&all_deletes).map_err(|e| e.to_string())?;
-        // Flush so a crash-recovery replay (which starts above the watermark) cannot re-apply the
-        // puts of keys this policy just deleted.
-        persist_frontiers(&self.db, &self.frontiers)
+        self.delete_keys(&all_deletes).map_err(|e| e.to_string())
     }
 
     /// Computes the replay-log cutoff for a sequence policy and prunes only log rows.
     fn apply_sequence_prune_policy(&self, retain: &RetainPolicy) -> Result<(), String> {
         let current = self.frontiers.published.load(Ordering::Acquire);
-        // Log rows below the cutoff may still be needed to rebuild WAL-less state rows after a
-        // crash, and `open` re-derives the durable frontier from the retained rows, so both
-        // frontiers must be durable (synced meta write, after a state flush) before any row or
-        // file is deleted.
-        persist_frontiers(&self.db, &self.frontiers)?;
+        // `open` re-derives the durable frontier from the retained rows, so the floor must be
+        // durable (synced meta write) before any row or file is deleted.
+        persist_durable_floor(&self.db, &self.frontiers)?;
         let cutoff_exclusive = match retain {
             RetainPolicy::KeepLatest { count } => {
                 let count = *count as u64;
@@ -1208,14 +1156,10 @@ impl RocksStore {
             RetainPolicy::GreaterThanOrEqual { threshold } => *threshold,
             RetainPolicy::DropAll => current.saturating_add(1),
         };
-        // Never delete log rows above the flushed watermark: sequences committed but not yet
-        // visible may still need them to rebuild their WAL-less state rows after a crash.
-        let cutoff_exclusive = cutoff_exclusive.min(
-            self.frontiers
-                .flushed
-                .load(Ordering::Acquire)
-                .saturating_add(1),
-        );
+        // Never delete log rows above the published frontier: a group whose log ingestion
+        // committed but whose state ingestion did not still needs its rows for the repair replay
+        // at the next open.
+        let cutoff_exclusive = cutoff_exclusive.min(current.saturating_add(1));
         self.prune_log(cutoff_exclusive)
     }
 }
@@ -1471,8 +1415,8 @@ mod tests {
         .encode_to_vec()
     }
 
-    /// Builds a group whose log batch is already an error, modeling a build/commit failure for a
-    /// contiguous run of assigned sequence numbers tagged with `epoch`.
+    /// Builds a group whose staging already failed, modeling a build failure for a contiguous
+    /// run of assigned sequence numbers tagged with `epoch`.
     fn failing_group(
         epoch: u64,
         entries: &[(u64, &'static [u8], &'static [u8])],
@@ -1488,28 +1432,17 @@ mod tests {
         (
             PreparedWrite {
                 writes,
-                log_rows: Err(error.to_string()),
-                state_batch: rocksdb::WriteBatch::default(),
-                batch_bytes: 0,
+                staged: Err(error.to_string()),
                 epoch,
             },
             receivers,
         )
     }
 
-    /// Commits one group and applies its state rows, mirroring the commit and apply stages.
-    /// Returns the durable frontier afterwards.
-    fn commit_and_apply(
-        store: &RocksStore,
-        durable: &AtomicU64,
-        epoch: &AtomicU64,
-        group: PreparedWrite,
-    ) -> u64 {
-        let ingest_dir = store.db.path().join(LOG_INGEST_DIR);
-        if let Some(committed) = commit_group(&store.db, &ingest_dir, durable, epoch, group) {
-            apply_committed_write(&store.db, &store.frontiers.published, &mut None, committed);
-        }
-        durable.load(Ordering::Acquire)
+    /// Commits one group through the commit stage, returning the durable frontier afterwards.
+    fn commit_and_apply(store: &RocksStore, epoch: &AtomicU64, group: PreparedWrite) -> u64 {
+        commit_group(&store.db, &store.frontiers, epoch, group);
+        store.frontiers.durable.load(Ordering::Acquire)
     }
 
     fn commit_sequence_requests(
@@ -1523,7 +1456,11 @@ mod tests {
             .ok_or_else(|| "rocks sequence number overflowed".to_string())?;
         let mut state_batch = rocksdb::WriteBatch::default();
         let mut log_batch = rocksdb::WriteBatch::default();
-        append_state_entries(&mut state_batch, requests);
+        for request in requests {
+            for (k, v) in &request.kvs {
+                state_batch.put(k.as_ref(), v.as_ref());
+            }
+        }
         if let Some(value) = encode_log_value(next, requests) {
             let log_cf = db
                 .cf_handle(LOG_CF)
@@ -1532,7 +1469,7 @@ mod tests {
         }
         append_sequence_meta(db, &mut log_batch, next);
         write_synced_batch(db, log_batch)?;
-        write_state_batch(db, state_batch)?;
+        db.write(state_batch).map_err(|e| e.to_string())?;
         sequence.store(next, Ordering::Release);
         Ok(next)
     }
@@ -1559,23 +1496,12 @@ mod tests {
         )
     }
 
-    fn prepared_write(epoch: u64, writes: Vec<AssignedWrite>) -> PreparedWrite {
-        let mut state_batch = rocksdb::WriteBatch::default();
-        let mut log_rows = Vec::new();
-        let mut log_bytes = 0;
-        for write in &writes {
-            let requests = std::slice::from_ref(&write.request);
-            append_state_entries(&mut state_batch, requests);
-            if let Some(value) = encode_log_value(write.sequence, requests) {
-                log_bytes += LOG_BATCH_KEY_LEN + value.len();
-                log_rows.push((write.sequence, value));
-            }
-        }
+    fn prepared_write(store: &RocksStore, epoch: u64, writes: Vec<AssignedWrite>) -> PreparedWrite {
+        let ingest_dir = store.db.path().join(LOG_INGEST_DIR);
+        let staged = stage_group_files(&ingest_dir, &writes, epoch);
         PreparedWrite {
             writes,
-            log_rows: Ok(log_rows),
-            batch_bytes: state_batch.size_in_bytes() + log_bytes,
-            state_batch,
+            staged,
             epoch,
         }
     }
@@ -1653,6 +1579,7 @@ mod tests {
 
     #[test]
     fn prepare_queued_write_collects_all_pending_below_byte_cap() {
+        let dir = tempdir().expect("tempdir");
         let (sender, receiver) = mpsc::channel();
         sender.send(write_request(b"a")).expect("send");
         sender.send(write_request(b"b")).expect("send");
@@ -1661,6 +1588,7 @@ mod tests {
 
         let first = receiver.recv().expect("first request");
         let (group, disconnected) = match prepare_queued_write(
+            dir.path(),
             &receiver,
             first,
             0,
@@ -1671,14 +1599,17 @@ mod tests {
             Err((_, error)) => panic!("{error}"),
         };
         assert_eq!(group.writes.len(), 3);
-        assert!(group.log_rows.is_ok());
-        assert!(group.batch_bytes > 0);
+        let staged = group.staged.expect("staged files");
+        assert!(staged.log.exists());
+        assert!(staged.state.exists());
+        assert!(staged.staged_bytes > 0);
         assert_eq!(group.epoch, 7);
         assert!(disconnected);
     }
 
     #[test]
     fn prepare_queued_write_stops_after_soft_byte_cap() {
+        let dir = tempdir().expect("tempdir");
         let (sender, receiver) = mpsc::channel();
         sender.send(write_request(b"a")).expect("send");
         sender.send(write_request(b"b")).expect("send");
@@ -1686,15 +1617,15 @@ mod tests {
         drop(sender);
 
         let first = receiver.recv().expect("first request");
-        let (group, disconnected) = match prepare_queued_write(&receiver, first, 0, 1, 7) {
-            Ok(prepared) => prepared,
-            Err((_, error)) => panic!("{error}"),
-        };
+        let (group, disconnected) =
+            match prepare_queued_write(dir.path(), &receiver, first, 0, 1, 7) {
+                Ok(prepared) => prepared,
+                Err((_, error)) => panic!("{error}"),
+            };
 
         assert_eq!(group.writes.len(), 1);
         assert_eq!(group.writes[0].request.kvs[0].0.as_ref(), b"a");
-        assert!(group.log_rows.is_ok());
-        assert!(group.batch_bytes >= 1);
+        assert!(group.staged.is_ok());
         assert_eq!(group.epoch, 7);
         assert!(!disconnected);
         assert_eq!(
@@ -1710,11 +1641,13 @@ mod tests {
 
     #[tokio::test]
     async fn forward_group_fails_request_when_commit_stopped() {
+        let dir = tempdir().expect("tempdir");
+        let store = RocksStore::open(dir.path(), None).expect("open db");
         let (group_sender, group_receiver) = mpsc::sync_channel(0);
         drop(group_receiver);
 
         let (write, result) = assigned_write_with_response(1, b"a", b"1");
-        let group = prepared_write(0, vec![write]);
+        let group = prepared_write(&store, 0, vec![write]);
         let forwarded = forward_group(&group_sender, group);
 
         assert!(!forwarded);
@@ -1729,12 +1662,11 @@ mod tests {
     async fn failed_group_supersedes_epoch_and_frees_sequence_numbers() {
         let dir = tempdir().expect("tempdir");
         let store = RocksStore::open(dir.path(), None).expect("open db");
-        let durable = AtomicU64::new(0);
         let epoch = AtomicU64::new(0);
 
         // A group that cannot commit (modeled with an already-failed batch) at sequences 1 and 2.
         let (group, receivers) = failing_group(0, &[(1, b"a", b"1"), (2, b"b", b"2")], "disk full");
-        let committed = commit_and_apply(&store, &durable, &epoch, group);
+        let committed = commit_and_apply(&store, &epoch, group);
 
         // Nothing was published, and the epoch advanced so the abandoned numbers can be re-used.
         assert_eq!(committed, 0);
@@ -1750,8 +1682,8 @@ mod tests {
         // The next epoch re-allocates sequences 1 and 2 to fresh requests, which commit cleanly.
         let (write_x, result_x) = assigned_write_with_response(1, b"x", b"24");
         let (write_y, result_y) = assigned_write_with_response(2, b"y", b"25");
-        let group = prepared_write(1, vec![write_x, write_y]);
-        let committed = commit_and_apply(&store, &durable, &epoch, group);
+        let group = prepared_write(&store, 1, vec![write_x, write_y]);
+        let committed = commit_and_apply(&store, &epoch, group);
 
         assert_eq!(committed, 2);
         assert_eq!(store.current_sequence(), 2);
@@ -1771,13 +1703,12 @@ mod tests {
     async fn superseded_epoch_group_is_rejected_without_write() {
         let dir = tempdir().expect("tempdir");
         let store = RocksStore::open(dir.path(), None).expect("open db");
-        let durable = AtomicU64::new(0);
         // The current epoch is 1: an earlier failure already superseded epoch 0.
         let epoch = AtomicU64::new(1);
 
         let (write, result) = assigned_write_with_response(1, b"a", b"1");
-        let group = prepared_write(0, vec![write]);
-        let committed = commit_and_apply(&store, &durable, &epoch, group);
+        let group = prepared_write(&store, 0, vec![write]);
+        let committed = commit_and_apply(&store, &epoch, group);
 
         assert_eq!(committed, 0);
         assert_eq!(store.current_sequence(), 0);
@@ -1793,14 +1724,13 @@ mod tests {
     async fn writer_reallocates_sequence_numbers_after_failed_batch() {
         let dir = tempdir().expect("tempdir");
         let store = RocksStore::open(dir.path(), None).expect("open db");
-        let durable = AtomicU64::new(0);
         let epoch = AtomicU64::new(5);
 
         // Two successive failures both abandon sequence 1 without ever consuming it.
         for attempt in [b"first" as &[u8], b"second"] {
             let current = epoch.load(Ordering::Acquire);
             let (group, receivers) = failing_group(current, &[(1, b"k", b"v")], "boom");
-            let committed = commit_and_apply(&store, &durable, &epoch, group);
+            let committed = commit_and_apply(&store, &epoch, group);
             assert_eq!(
                 committed, 0,
                 "attempt {attempt:?} must not advance the frontier"
@@ -1814,8 +1744,8 @@ mod tests {
         // The first durable write still takes sequence 1.
         let current = epoch.load(Ordering::Acquire);
         let (write, result) = assigned_write_with_response(1, b"k", b"v");
-        let group = prepared_write(current, vec![write]);
-        let committed = commit_and_apply(&store, &durable, &epoch, group);
+        let group = prepared_write(&store, current, vec![write]);
+        let committed = commit_and_apply(&store, &epoch, group);
         assert_eq!(committed, 1);
         assert_eq!(result.await.expect("response"), Ok(1));
         assert_eq!(store.current_sequence(), 1);
@@ -1825,7 +1755,6 @@ mod tests {
     async fn reused_sequence_overwrites_abandoned_log_row() {
         let dir = tempdir().expect("tempdir");
         let store = RocksStore::open(dir.path(), None).expect("open db");
-        let durable = AtomicU64::new(0);
         let epoch = AtomicU64::new(0);
 
         // Model an abandoned sequence index: the durable frontier is still 0, but a row
@@ -1842,7 +1771,7 @@ mod tests {
         assert!(store.get_batch(1).await.expect("get").is_none());
 
         let (failed, receivers) = failing_group(0, &[(1, b"k", b"failed")], "boom");
-        let committed = commit_and_apply(&store, &durable, &epoch, failed);
+        let committed = commit_and_apply(&store, &epoch, failed);
         assert_eq!(committed, 0);
         assert_eq!(store.current_sequence(), 0);
         assert_eq!(epoch.load(Ordering::Acquire), 1);
@@ -1851,8 +1780,8 @@ mod tests {
         }
 
         let (write, result) = assigned_write_with_response(1, b"k", b"new");
-        let group = prepared_write(1, vec![write]);
-        let committed = commit_and_apply(&store, &durable, &epoch, group);
+        let group = prepared_write(&store, 1, vec![write]);
+        let committed = commit_and_apply(&store, &epoch, group);
 
         assert_eq!(committed, 1);
         assert_eq!(result.await.expect("response"), Ok(1));
@@ -2100,9 +2029,9 @@ mod tests {
     async fn prepared_write_preserves_contiguous_sequence_logs() {
         let dir = tempdir().expect("tempdir");
         let store = RocksStore::open(dir.path(), None).expect("open db");
-        let durable = AtomicU64::new(0);
         let epoch = AtomicU64::new(0);
         let prepared = prepared_write(
+            &store,
             0,
             vec![
                 assigned_write(1, b"a", b"1"),
@@ -2112,8 +2041,8 @@ mod tests {
         );
 
         assert_eq!(prepared.writes.len(), 3);
-        assert!(prepared.batch_bytes > 0);
-        let committed = commit_and_apply(&store, &durable, &epoch, prepared);
+        assert!(prepared.staged.is_ok());
+        let committed = commit_and_apply(&store, &epoch, prepared);
         assert_eq!(committed, 3);
 
         assert_eq!(store.current_sequence(), 3);

--- a/examples/simulator/src/rocks.rs
+++ b/examples/simulator/src/rocks.rs
@@ -7,13 +7,14 @@
 //! Both structures are written as SST files and ingested, bypassing the WAL and the memtables
 //! entirely: `prepare` stages one sorted state file and one log file per commit group, and
 //! `commit` ingests the log file first (its rows alone define durability — `open` derives the
-//! frontier from the highest retained row and the sequence meta row), then the state file, and
-//! only then publishes and acks. The two ingestions are not atomic, but the window is one group
-//! wide: a crash between them leaves the log durable and the state missing for at most the last
-//! group, which `open` repairs by replaying the rows of the last retained log file before the
-//! store serves reads. The sequence meta row is written only by pruning, atomically with the
-//! range tombstone (deleting log rows must not regress the derived frontier), so a store
-//! recovers by reading one meta row, one file listing, and replaying at most one group.
+//! frontier from the highest retained row and the state-floor meta row), then the state file,
+//! and only then publishes and acks. The two ingestions are not atomic, but the window is one
+//! group wide: a crash between them leaves the log durable and the state missing for at most the
+//! last group, which `open` repairs by replaying the retained log rows above the state floor
+//! within the last retained log file, before the store serves reads. The floor meta row is
+//! written only by pruning — atomically with the log range tombstone or the pruned state keys —
+//! so a store recovers by reading one meta row, one file listing, and replaying at most one
+//! group.
 
 use std::cmp::Ordering as CmpOrdering;
 use std::collections::BTreeMap;
@@ -44,9 +45,11 @@ use tokio::sync::oneshot;
 use tracing::debug;
 
 const META_CF: &str = "meta";
-/// Durable-sequence floor. The frontier at open is the maximum of this row and the highest
-/// retained log row; it is only written atomically with a prune's range tombstone (deleting log
-/// rows must not regress the derived frontier) — commits never write it.
+/// State floor: the published frontier at the time of the last prune. The state below it is
+/// authoritative — log rows at or below it are never replayed at open (replaying them could
+/// resurrect key-pruned rows), and the frontier at open is the maximum of this row and the
+/// highest retained log row (deleting log rows must not regress the derived frontier). Only
+/// pruning writes it, atomically with its deletes — commits never do.
 const SEQ_META_KEY: &[u8] = b"sequence";
 const LOG_CF: &str = "log";
 const LOG_BATCH_KEY_LEN: usize = 8;
@@ -300,9 +303,12 @@ struct Frontiers {
     published: AtomicU64,
     /// Highest sequence whose log rows are durable. Runs ahead of `published` only while a
     /// group's state ingestion is in flight; re-derived at open from the retained log rows and
-    /// the sequence meta row.
+    /// the state-floor meta row.
     durable: AtomicU64,
-    /// Serializes log pruning so the persisted durable-sequence floor never moves backward.
+    /// Serializes prunes (so the persisted state floor never moves backward) and orders state
+    /// visibility against floor reads: `commit` ingests and publishes each group's state under
+    /// this lock, so a prune that loads `published` under it sees a frontier covering every row
+    /// its scan could have observed.
     persist: Mutex<()>,
 }
 
@@ -347,8 +353,9 @@ struct PreparedWrite {
 }
 
 struct Writer {
-    sender: Mutex<Option<mpsc::Sender<WriteRequest>>>,
-    handles: Mutex<Vec<thread::JoinHandle<()>>>,
+    /// `None` only during `Drop`, which closes the channel before joining the workers.
+    sender: Option<mpsc::Sender<WriteRequest>>,
+    handles: Vec<thread::JoinHandle<()>>,
 }
 
 impl Writer {
@@ -396,8 +403,8 @@ impl Writer {
             .expect("failed to spawn RocksDB prepare worker");
 
         Self {
-            sender: Mutex::new(Some(request_sender)),
-            handles: Mutex::new(vec![prepare, commit]),
+            sender: Some(request_sender),
+            handles: vec![prepare, commit],
         }
     }
 
@@ -410,14 +417,9 @@ impl Writer {
             return Err("cannot ingest an empty batch".to_string());
         }
         let (response, result) = oneshot::channel();
-        let sender = self
-            .sender
-            .lock()
-            .map_err(|e| format!("rocks writer lock poisoned: {e}"))?
+        self.sender
             .as_ref()
-            .cloned()
-            .ok_or_else(|| "rocks writer stopped".to_string())?;
-        sender
+            .expect("sender lives until drop")
             .send(WriteRequest { kvs, response })
             .map_err(|_| "rocks writer stopped".to_string())?;
         result
@@ -431,13 +433,9 @@ impl Drop for Writer {
         // Closing the request channel lets `prepare` drain and exit, which drops the group
         // channel and stops `commit`; joining keeps background RocksDB writers from outliving
         // the store.
-        if let Ok(mut sender) = self.sender.lock() {
-            sender.take();
-        }
-        if let Ok(mut handles) = self.handles.lock() {
-            for handle in handles.drain(..) {
-                let _ = handle.join();
-            }
+        self.sender.take();
+        for handle in self.handles.drain(..) {
+            let _ = handle.join();
         }
     }
 }
@@ -480,9 +478,11 @@ fn run_prepare(
                 continue;
             }
         };
-        if let Some(last) = group.writes.last() {
-            next = last.sequence;
-        }
+        next = group
+            .writes
+            .last()
+            .expect("groups are never empty")
+            .sequence;
         if !forward_group(&sender, group) {
             break;
         }
@@ -601,8 +601,7 @@ fn stage_log_file(path: &Path, writes: &[AssignedWrite]) -> Result<usize, String
     writer.open(path).map_err(|e| e.to_string())?;
     let mut bytes = 0;
     for write in writes {
-        let value = encode_log_value(write.sequence, std::slice::from_ref(&write.request))
-            .expect("requests always carry rows (empty batches are rejected on entry)");
+        let value = encode_log_value(write.sequence, &write.request.kvs);
         bytes += LOG_BATCH_KEY_LEN + value.len();
         writer
             .put(sequence_log_key(write.sequence), &value)
@@ -689,14 +688,29 @@ fn commit_group(
     epoch: &AtomicU64,
     group: PreparedWrite,
 ) -> CommitOutcome {
-    if group.writes.is_empty() {
-        return CommitOutcome::Continue;
-    }
+    debug_assert!(!group.writes.is_empty(), "groups are never empty");
     let PreparedWrite {
         writes,
         staged,
         epoch: group_epoch,
     } = group;
+    if group_epoch != epoch.load(Ordering::Acquire) {
+        // This group was assigned under a frontier an earlier commit failure has since abandoned
+        // (prepare can stage one wave ahead before it observes the bump). Rejecting it keeps the
+        // durable log gap-free; the requests never reached the DB, so the caller is told to
+        // retry, which re-allocates them fresh sequence numbers under the current epoch. Checked
+        // before the staging result so a stale group's own staging failure cannot bump the epoch
+        // again and spuriously reject the wave prepare has already re-synced.
+        if let Ok(staged) = &staged {
+            let _ = std::fs::remove_file(&staged.log);
+            let _ = std::fs::remove_file(&staged.state);
+        }
+        fail_assigned_writes(
+            writes,
+            "rocks write batch superseded by an earlier failure, retry".to_string(),
+        );
+        return CommitOutcome::Continue;
+    }
     let staged = match staged {
         Ok(staged) => staged,
         Err(error) => {
@@ -705,19 +719,6 @@ fn commit_group(
             return CommitOutcome::Continue;
         }
     };
-    if group_epoch != epoch.load(Ordering::Acquire) {
-        // This group was assigned under a frontier an earlier commit failure has since abandoned
-        // (prepare can stage one wave ahead before it observes the bump). Rejecting it keeps the
-        // durable log gap-free; the requests never reached the DB, so the caller is told to
-        // retry, which re-allocates them fresh sequence numbers under the current epoch.
-        let _ = std::fs::remove_file(&staged.log);
-        let _ = std::fs::remove_file(&staged.state);
-        fail_assigned_writes(
-            writes,
-            "rocks write batch superseded by an earlier failure, retry".to_string(),
-        );
-        return CommitOutcome::Continue;
-    }
 
     let requests = writes.len();
     let last_sequence = writes
@@ -738,6 +739,13 @@ fn commit_group(
     // Release so `prepare` re-syncs against a frontier whose log rows are already durable.
     frontiers.durable.store(last_sequence, Ordering::Release);
 
+    // Ingest and publish under the floor lock: a prune loads the published frontier as its
+    // state floor under the same lock, so no scan-visible state row can outrun the frontier
+    // covering it (a key prune must never delete a row the floor does not cover).
+    let publish_guard = frontiers
+        .persist
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
     if let Err(error) = ingest_staged_file(db, rocksdb::DEFAULT_COLUMN_FAMILY_NAME, &staged.state) {
         // The log rows are durable but the state rows are not: the frontier freezes below this
         // group so reads stay complete below the advertised sequence, and a restart repairs the
@@ -748,6 +756,7 @@ fn commit_group(
 
     // Release so `current_sequence` readers only observe frontiers whose rows are readable.
     frontiers.published.store(last_sequence, Ordering::Release);
+    drop(publish_guard);
     debug!(
         requests,
         staged_bytes = staged.staged_bytes,
@@ -797,8 +806,8 @@ fn prepare_ingest_dir(store_path: &Path) -> Result<PathBuf, String> {
 
 /// Returns the sequence of the highest retained log row, or zero when the log is empty. Rows are
 /// only ever ingested by sequential, atomic commits, so the highest retained row is a lower bound
-/// on the durable frontier (pruning persists the sequence meta row before deleting rows, so the
-/// meta row covers whatever was pruned).
+/// on the durable frontier (pruning persists the state floor atomically with its deletes, so the
+/// floor covers whatever was pruned).
 fn highest_log_row(db: &DB) -> Result<u64, String> {
     let log_cf = db
         .cf_handle(LOG_CF)
@@ -812,12 +821,15 @@ fn highest_log_row(db: &DB) -> Result<u64, String> {
     }
 }
 
-/// Reads a little-endian u64 sequence value from the meta column family, defaulting to zero.
-fn read_meta_sequence(db: &DB, key: &[u8]) -> Result<u64, String> {
+/// Reads the state-floor meta row, defaulting to zero when no prune has written it yet.
+fn read_state_floor(db: &DB) -> Result<u64, String> {
     let meta_cf = db
         .cf_handle(META_CF)
         .expect("meta CF must exist (created on open)");
-    match db.get_cf(meta_cf, key).map_err(|e| e.to_string())? {
+    match db
+        .get_cf(meta_cf, SEQ_META_KEY)
+        .map_err(|e| e.to_string())?
+    {
         Some(bytes) if bytes.len() == 8 => Ok(u64::from_le_bytes(bytes.try_into().unwrap())),
         _ => Ok(0),
     }
@@ -826,10 +838,11 @@ fn read_meta_sequence(db: &DB, key: &[u8]) -> Result<u64, String> {
 /// Repairs the current state after a crash that hit between a group's two ingestions: the log
 /// file is durable but the state file may be missing, and only for the last committed group
 /// (commit ingests strictly in order and publishes before starting the next group). Re-applies
-/// every row of the last retained log file — the group whose state might be missing is always
+/// the rows of the last retained log file — the group whose state might be missing is always
 /// the one that ends at the durable frontier — which is idempotent because those rows are the
-/// newest writes for their keys.
-fn replay_last_log_file(db: &DB) -> Result<(), String> {
+/// newest writes for their keys. Rows at or below `floor` are skipped: their state is already
+/// authoritative, and key pruning may have deleted rows a replay would resurrect.
+fn replay_last_log_file(db: &DB, floor: u64) -> Result<(), String> {
     let last_file_start = db
         .live_files()
         .map_err(|e| e.to_string())?
@@ -842,6 +855,11 @@ fn replay_last_log_file(db: &DB) -> Result<(), String> {
     let Some(start) = last_file_start else {
         return Ok(());
     };
+    let Some(above_floor) = floor.checked_add(1) else {
+        // The floor covers every representable sequence; nothing can need replay.
+        return Ok(());
+    };
+    let start = start.max(above_floor);
 
     let log_cf = db
         .cf_handle(LOG_CF)
@@ -858,7 +876,9 @@ fn replay_last_log_file(db: &DB) -> Result<(), String> {
         }
     }
     if !batch.is_empty() {
-        db.write(batch).map_err(|e| e.to_string())?;
+        // Synced: once a later commit moves the last-file replay bound past this group, a
+        // repair lost to power loss would never be re-run.
+        write_synced_batch(db, batch)?;
     }
     Ok(())
 }
@@ -916,8 +936,10 @@ pub struct RocksConfig {
 }
 
 impl Default for RocksConfig {
-    /// RocksDB options tuned for the simulator's ingest profile (hundreds of thousands of keys
-    /// per batch) instead of stock RocksDB defaults.
+    /// Stock RocksDB options, plus background parallelism sized to the machine: commits ingest
+    /// overlapping state SSTs that compactions must keep merging. Memtables are off the hot
+    /// path (only the open-time replay and prune deletes write them), so they stay at stock
+    /// defaults.
     fn default() -> Self {
         let cores = thread::available_parallelism()
             .map(|n| n.get())
@@ -925,15 +947,9 @@ impl Default for RocksConfig {
         let mut db_options = Options::default();
         db_options.increase_parallelism(cores);
 
-        // Smaller, more numerous state memtables keep skiplist inserts shallow and shift work to
-        // background flushes.
-        let mut default_cf_options = Options::default();
-        default_cf_options.set_write_buffer_size(32 * 1024 * 1024);
-        default_cf_options.set_max_write_buffer_number(4);
-
         Self {
             db_options,
-            default_cf_options,
+            default_cf_options: Options::default(),
             meta_cf_options: Options::default(),
             log_cf_options: Options::default(),
             write_pipeline: RocksWritePipelineConfig::default(),
@@ -953,9 +969,9 @@ pub struct RocksStore {
 impl RocksStore {
     /// Open the store with stock RocksDB defaults, unless `config` overrides
     /// the database and column-family options. Re-derives the durable frontier from the retained
-    /// log rows and the sequence meta row, then replays the last retained log file into the
-    /// default column family so the current state is complete below the durable sequence even
-    /// after a crash between a group's log and state ingestions.
+    /// log rows and the state-floor meta row, then replays the last retained log file's rows
+    /// above the floor into the default column family so the current state is complete below
+    /// the durable sequence even after a crash between a group's log and state ingestions.
     pub fn open(path: &Path, config: Option<RocksConfig>) -> Result<Self, String> {
         let RocksConfig {
             mut db_options,
@@ -976,12 +992,12 @@ impl RocksStore {
             DB::open_cf_descriptors(&db_options, path, vec![cf_default, cf_meta, cf_log])
                 .map_err(|e| e.to_string())?,
         );
-        // Commits do not write the sequence meta row; the log rows are the durable record.
-        let meta_seq = read_meta_sequence(&db, SEQ_META_KEY)?;
-        let seq = meta_seq.max(highest_log_row(&db)?);
+        // Commits do not write the state-floor meta row; the log rows are the durable record.
+        let floor = read_state_floor(&db)?;
+        let seq = floor.max(highest_log_row(&db)?);
 
         let ingest_dir = prepare_ingest_dir(path)?;
-        replay_last_log_file(&db)?;
+        replay_last_log_file(&db, floor)?;
 
         let frontiers = Arc::new(Frontiers::new(seq));
         let writer = Arc::new(Writer::start(
@@ -1004,23 +1020,50 @@ impl RocksStore {
             .expect("log CF must exist (created on open)")
     }
 
+    /// Returns the meta column-family handle created during open.
+    fn meta_cf(&self) -> &ColumnFamily {
+        self.db
+            .cf_handle(META_CF)
+            .expect("meta CF must exist (created on open)")
+    }
+
+    /// Serializes prunes: each loads the monotonic published frontier and persists it as the
+    /// state floor under this lock, so the floor never moves backward.
+    fn lock_persisted_floor(&self) -> Result<std::sync::MutexGuard<'_, ()>, String> {
+        self.frontiers
+            .persist
+            .lock()
+            .map_err(|e| format!("rocks prune lock poisoned: {e}"))
+    }
+
     /// Reads the current value for one default-column-family key.
     fn get_raw(&self, key: &[u8]) -> Result<Option<Vec<u8>>, rocksdb::Error> {
         self.db.get(key)
     }
 
-    /// Deletes current rows without touching sequence metadata or the replay log.
-    fn delete_keys(&self, keys: &[Bytes]) -> Result<(), rocksdb::Error> {
+    /// Deletes key-pruned current rows, atomically raising the state floor to the published
+    /// frontier in the same synced batch. Every deleted row's log entry sits at or below that
+    /// floor, so the replay at the next open cannot resurrect it — and the sync makes an acked
+    /// prune durable.
+    fn delete_keys(&self, keys: &[Bytes]) -> Result<(), String> {
         if keys.is_empty() {
             return Ok(());
         }
 
+        let _guard = self.lock_persisted_floor()?;
         let mut batch = rocksdb::WriteBatch::default();
+        batch.put_cf(
+            self.meta_cf(),
+            SEQ_META_KEY,
+            self.frontiers
+                .published
+                .load(Ordering::Acquire)
+                .to_le_bytes(),
+        );
         for k in keys {
             batch.delete(k.as_ref());
         }
-        self.db.write(batch)?;
-        Ok(())
+        write_synced_batch(&self.db, batch)
     }
 
     /// Deletes replay-log batches with sequence numbers below `cutoff_exclusive`.
@@ -1028,25 +1071,16 @@ impl RocksStore {
         if cutoff_exclusive == 0 {
             return Ok(());
         }
-        // Serializes concurrent prunes: `durable` is monotonic, so ordering the loads and writes
-        // keeps the persisted floor from ever moving backward.
-        let _guard = self
-            .frontiers
-            .persist
-            .lock()
-            .map_err(|e| format!("rocks prune lock poisoned: {e}"))?;
+        let _guard = self.lock_persisted_floor()?;
         let cf = self.log_cf();
-        let meta_cf = self
-            .db
-            .cf_handle(META_CF)
-            .expect("meta CF must exist (created on open)");
 
         // One synced, atomic batch: the range tombstone that logically deletes the rows, and the
-        // durable-sequence floor that keeps `open` from re-deriving a regressed frontier once
-        // those rows are gone. Nothing is deleted unless the floor covering it is durable.
-        let durable = self.frontiers.durable.load(Ordering::Acquire);
+        // state floor that keeps `open` from re-deriving a regressed frontier once those rows
+        // are gone. The published frontier covers every pruned row (the cutoff is capped at
+        // published + 1), and everything at or below it is durable and applied to the state.
+        let published = self.frontiers.published.load(Ordering::Acquire);
         let mut batch = rocksdb::WriteBatch::default();
-        batch.put_cf(meta_cf, SEQ_META_KEY, durable.to_le_bytes());
+        batch.put_cf(self.meta_cf(), SEQ_META_KEY, published.to_le_bytes());
         batch.delete_range_cf(cf, sequence_log_key(0), sequence_log_key(cutoff_exclusive));
         write_synced_batch(&self.db, batch)?;
 
@@ -1128,7 +1162,7 @@ impl RocksStore {
         for (_group_key, entries) in groups {
             all_deletes.extend(keys_to_delete(entries, scope, retain)?);
         }
-        self.delete_keys(&all_deletes).map_err(|e| e.to_string())
+        self.delete_keys(&all_deletes)
     }
 
     /// Computes the replay-log cutoff for a sequence policy and prunes only log rows.
@@ -1206,10 +1240,14 @@ impl Query for RocksStore {
     }
 }
 
+// Pruning scans the full selector range and issues synced writes, so it runs on the blocking
+// pool instead of occupying a Tokio worker.
 impl Prune for RocksStore {
     async fn apply_prune_policies(&self, document: PrunePolicyDocument) -> Result<(), String> {
         let store = self.clone();
-        store.apply_prune_policies(document)
+        tokio::task::spawn_blocking(move || store.apply_prune_policies(document))
+            .await
+            .map_err(|e| format!("prune task failed: {e}"))?
     }
 }
 
@@ -1242,7 +1280,14 @@ impl Log for RocksStore {
             None => Ok(None),
             Some(item) => {
                 let (key, _) = item.map_err(|e| e.to_string())?;
-                Ok(Some(sequence_from_log_key(key.as_ref())?))
+                let sequence = sequence_from_log_key(key.as_ref())?;
+                // Gate on the published frontier like `get_batch`: never advertise an oldest
+                // batch that `get_batch` would then hide (log rows can outrun the published
+                // frontier while a group's state ingestion is in flight or has failed).
+                if sequence > self.frontiers.published.load(Ordering::Acquire) {
+                    return Ok(None);
+                }
+                Ok(Some(sequence))
             }
         }
     }
@@ -1299,24 +1344,17 @@ fn encoded_entry_body_len(key: &[u8], value: &[u8]) -> usize {
     len
 }
 
-/// Encodes the replay payload for every key/value row folded into one sequence.
+/// Encodes the replay payload for one sequence's key/value rows.
 ///
 /// Writes the `log.stream.v1.GetResponse` wire format directly from the borrowed
 /// key/value slices so a large batch is encoded with a single presized allocation
 /// instead of one owned `Entry` per row. `log_value_matches_generated_encoder`
 /// pins byte-for-byte equality with the generated encoder.
-fn encode_log_value(sequence: u64, requests: &[WriteRequest]) -> Option<Vec<u8>> {
+fn encode_log_value(sequence: u64, kvs: &[(Bytes, Bytes)]) -> Vec<u8> {
     let mut total = 0;
-    let mut entries = 0usize;
-    for request in requests {
-        entries += request.kvs.len();
-        for (key, value) in &request.kvs {
-            let body_len = encoded_entry_body_len(key, value);
-            total += 1 + varint_len(body_len as u64) + body_len;
-        }
-    }
-    if entries == 0 {
-        return None;
+    for (key, value) in kvs {
+        let body_len = encoded_entry_body_len(key, value);
+        total += 1 + varint_len(body_len as u64) + body_len;
     }
     if sequence != 0 {
         total += 1 + varint_len(sequence);
@@ -1327,24 +1365,22 @@ fn encode_log_value(sequence: u64, requests: &[WriteRequest]) -> Option<Vec<u8>>
         buf.push(LOG_VALUE_SEQUENCE_TAG);
         put_varint(&mut buf, sequence);
     }
-    for request in requests {
-        for (key, value) in &request.kvs {
-            buf.push(LOG_VALUE_ENTRY_TAG);
-            put_varint(&mut buf, encoded_entry_body_len(key, value) as u64);
-            if !key.is_empty() {
-                buf.push(LOG_ENTRY_KEY_TAG);
-                put_varint(&mut buf, key.len() as u64);
-                buf.extend_from_slice(key);
-            }
-            if !value.is_empty() {
-                buf.push(LOG_ENTRY_VALUE_TAG);
-                put_varint(&mut buf, value.len() as u64);
-                buf.extend_from_slice(value);
-            }
+    for (key, value) in kvs {
+        buf.push(LOG_VALUE_ENTRY_TAG);
+        put_varint(&mut buf, encoded_entry_body_len(key, value) as u64);
+        if !key.is_empty() {
+            buf.push(LOG_ENTRY_KEY_TAG);
+            put_varint(&mut buf, key.len() as u64);
+            buf.extend_from_slice(key);
+        }
+        if !value.is_empty() {
+            buf.push(LOG_ENTRY_VALUE_TAG);
+            put_varint(&mut buf, value.len() as u64);
+            buf.extend_from_slice(value);
         }
     }
     debug_assert_eq!(buf.len(), total);
-    Some(buf)
+    buf
 }
 
 #[cfg(test)]
@@ -1357,13 +1393,6 @@ mod tests {
     use exoware_sdk::log::stream::v1::GetResponse as StreamGetResponse;
     use exoware_server::{Ingest, Log, Sequence};
     use tempfile::tempdir;
-
-    fn append_sequence_meta(db: &DB, batch: &mut rocksdb::WriteBatch, sequence: u64) {
-        let meta_cf = db
-            .cf_handle(META_CF)
-            .expect("meta CF must exist (created on open)");
-        batch.put_cf(meta_cf, SEQ_META_KEY, sequence.to_le_bytes());
-    }
 
     fn write_request(key: &'static [u8]) -> WriteRequest {
         let (response, _result) = oneshot::channel();
@@ -1379,10 +1408,6 @@ mod tests {
             .into_iter()
             .map(|entry| (Bytes::from(entry.key), entry.value))
             .collect()
-    }
-
-    fn decode_log_entries(value: &[u8]) -> Vec<(Bytes, Bytes)> {
-        response_entries(StreamGetResponse::decode_from_slice(value).expect("decode log value"))
     }
 
     fn batch_entries(batch: LogBatch) -> Vec<(Bytes, Bytes)> {
@@ -1432,35 +1457,6 @@ mod tests {
         store.frontiers.durable.load(Ordering::Acquire)
     }
 
-    fn commit_sequence_requests(
-        db: &DB,
-        sequence: &AtomicU64,
-        requests: &[WriteRequest],
-    ) -> Result<u64, String> {
-        let next = sequence
-            .load(Ordering::Acquire)
-            .checked_add(1)
-            .ok_or_else(|| "rocks sequence number overflowed".to_string())?;
-        let mut state_batch = rocksdb::WriteBatch::default();
-        let mut log_batch = rocksdb::WriteBatch::default();
-        for request in requests {
-            for (k, v) in &request.kvs {
-                state_batch.put(k.as_ref(), v.as_ref());
-            }
-        }
-        if let Some(value) = encode_log_value(next, requests) {
-            let log_cf = db
-                .cf_handle(LOG_CF)
-                .expect("log CF must exist (created on open)");
-            log_batch.put_cf(log_cf, sequence_log_key(next), value);
-        }
-        append_sequence_meta(db, &mut log_batch, next);
-        write_synced_batch(db, log_batch)?;
-        db.write(state_batch).map_err(|e| e.to_string())?;
-        sequence.store(next, Ordering::Release);
-        Ok(next)
-    }
-
     fn assigned_write(sequence: u64, key: &'static [u8], value: &'static [u8]) -> AssignedWrite {
         assigned_write_with_response(sequence, key, value).0
     }
@@ -1495,72 +1491,53 @@ mod tests {
 
     #[test]
     fn log_value_matches_generated_encoder() {
-        type RequestKvs = Vec<Vec<(Bytes, Bytes)>>;
-        let cases: Vec<(u64, RequestKvs)> = vec![
+        let cases: Vec<(u64, Vec<(Bytes, Bytes)>)> = vec![
             (
                 1,
-                vec![vec![(Bytes::from_static(b"a"), Bytes::from_static(b"1"))]],
+                vec![(Bytes::from_static(b"a"), Bytes::from_static(b"1"))],
             ),
-            // Coalesced requests, empty keys/values, and multi-byte varint lengths.
+            // Empty keys/values and multi-byte varint lengths.
             (
                 u64::MAX,
                 vec![
-                    vec![
-                        (Bytes::new(), Bytes::from_static(b"value-for-empty-key")),
-                        (Bytes::from_static(b"empty-value"), Bytes::new()),
-                        (Bytes::new(), Bytes::new()),
-                    ],
-                    vec![(Bytes::from(vec![7u8; 200]), Bytes::from(vec![9u8; 20_000]))],
+                    (Bytes::new(), Bytes::from_static(b"value-for-empty-key")),
+                    (Bytes::from_static(b"empty-value"), Bytes::new()),
+                    (Bytes::new(), Bytes::new()),
+                    (Bytes::from(vec![7u8; 200]), Bytes::from(vec![9u8; 20_000])),
                 ],
             ),
         ];
 
-        for (sequence, kvs_per_request) in cases {
-            let requests = kvs_per_request
-                .into_iter()
-                .map(|kvs| WriteRequest {
-                    kvs,
-                    response: oneshot::channel().0,
-                })
-                .collect::<Vec<_>>();
+        for (sequence, kvs) in cases {
             let expected = StreamGetResponse {
                 sequence_number: sequence,
-                entries: requests
+                entries: kvs
                     .iter()
-                    .flat_map(|request| {
-                        request.kvs.iter().map(|(key, value)| Entry {
-                            key: key.to_vec(),
-                            value: value.clone(),
-                            ..Default::default()
-                        })
+                    .map(|(key, value)| Entry {
+                        key: key.to_vec(),
+                        value: value.clone(),
+                        ..Default::default()
                     })
                     .collect(),
                 ..Default::default()
             }
             .encode_to_vec();
-            let encoded = encode_log_value(sequence, &requests).expect("encode");
-            assert_eq!(encoded, expected, "sequence {sequence}");
+            assert_eq!(
+                encode_log_value(sequence, &kvs),
+                expected,
+                "sequence {sequence}"
+            );
         }
-
-        let empty = WriteRequest {
-            kvs: Vec::new(),
-            response: oneshot::channel().0,
-        };
-        assert!(encode_log_value(3, std::slice::from_ref(&empty)).is_none());
     }
 
     #[test]
-    fn rocks_config_defaults_preserve_write_pipeline_profile() {
+    fn rocks_config_default_pins_commit_batch_cap() {
         assert_eq!(
-            RocksWritePipelineConfig::default(),
-            RocksWritePipelineConfig {
-                max_commit_batch_bytes: NonZeroUsize::new(DEFAULT_COMMIT_COALESCE_MAX_BATCH_BYTES,)
-                    .expect("nonzero"),
-            }
-        );
-        assert_eq!(
-            RocksConfig::default().write_pipeline,
-            RocksWritePipelineConfig::default()
+            RocksConfig::default()
+                .write_pipeline
+                .max_commit_batch_bytes
+                .get(),
+            16 * 1024 * 1024
         );
     }
 
@@ -1705,6 +1682,28 @@ mod tests {
             Err("rocks write batch superseded by an earlier failure, retry".to_string())
         );
         assert!(store.get_batch(1).await.expect("get").is_none());
+    }
+
+    #[tokio::test]
+    async fn stale_group_with_staging_error_does_not_bump_epoch() {
+        let dir = tempdir().expect("tempdir");
+        let store = RocksStore::open(dir.path(), None).expect("open db");
+        // The current epoch is 1: an earlier failure already superseded epoch 0.
+        let epoch = AtomicU64::new(1);
+
+        let (group, receivers) = failing_group(0, &[(1, b"a", b"1")], "disk full");
+        let committed = commit_and_apply(&store, &epoch, group);
+
+        // The stale group is rejected as superseded; its own staging error must not bump the
+        // epoch again, which would spuriously reject the wave prepare re-synced under epoch 1.
+        assert_eq!(committed, 0);
+        assert_eq!(epoch.load(Ordering::Acquire), 1);
+        for receiver in receivers {
+            assert_eq!(
+                receiver.await.expect("response"),
+                Err("rocks write batch superseded by an earlier failure, retry".to_string())
+            );
+        }
     }
 
     #[tokio::test]
@@ -1916,7 +1915,7 @@ mod tests {
                 "key {key:?}"
             );
         }
-        // A second reopen skips the replay because the watermark advanced with a flush.
+        // A second reopen replays again (the floor only advances on prune); idempotent.
         drop(store);
         let store = RocksStore::open(dir.path(), None).expect("reopen db again");
         assert_eq!(store.current_sequence(), 3);
@@ -1955,61 +1954,6 @@ mod tests {
             .expect("put");
         assert_eq!(sequence, 1);
         assert_eq!(store.current_sequence(), 1);
-    }
-
-    #[tokio::test]
-    async fn single_sequence_write_logs_all_requests() {
-        let dir = tempdir().expect("tempdir");
-        let store = RocksStore::open(dir.path(), None).expect("open db");
-        let (response_a, _rx_a) = oneshot::channel();
-        let (response_b, _rx_b) = oneshot::channel();
-        let requests = vec![
-            WriteRequest {
-                kvs: vec![(Bytes::from_static(b"a"), Bytes::from_static(b"1"))],
-                response: response_a,
-            },
-            WriteRequest {
-                kvs: vec![
-                    (Bytes::from_static(b"b"), Bytes::from_static(b"2")),
-                    (Bytes::from_static(b"c"), Bytes::from_static(b"3")),
-                ],
-                response: response_b,
-            },
-        ];
-
-        let sequence = commit_sequence_requests(&store.db, &store.frontiers.published, &requests)
-            .expect("write");
-        assert_eq!(sequence, 1);
-        assert_eq!(store.current_sequence(), 1);
-        let log_cf = store.log_cf();
-        let log_rows = store
-            .db
-            .iterator_cf(log_cf, IteratorMode::Start)
-            .collect::<Result<Vec<_>, _>>()
-            .expect("read log rows");
-        assert_eq!(log_rows.len(), 1);
-        assert_eq!(log_rows[0].0.as_ref(), sequence_log_key(sequence));
-        assert_eq!(
-            decode_log_entries(log_rows[0].1.as_ref()),
-            vec![
-                (Bytes::from_static(b"a"), Bytes::from_static(b"1")),
-                (Bytes::from_static(b"b"), Bytes::from_static(b"2")),
-                (Bytes::from_static(b"c"), Bytes::from_static(b"3")),
-            ]
-        );
-        let batch = store
-            .get_batch(sequence)
-            .await
-            .expect("get batch")
-            .expect("batch retained");
-        assert_eq!(
-            batch_entries(batch),
-            vec![
-                (Bytes::from_static(b"a"), Bytes::from_static(b"1")),
-                (Bytes::from_static(b"b"), Bytes::from_static(b"2")),
-                (Bytes::from_static(b"c"), Bytes::from_static(b"3")),
-            ]
-        );
     }
 
     #[tokio::test]
@@ -2088,6 +2032,25 @@ mod tests {
             }
         }
         assert_eq!(logged_keys, (0u8..32).collect::<BTreeSet<_>>());
+    }
+
+    #[tokio::test]
+    async fn oldest_retained_batch_hides_rows_above_published_frontier() {
+        let dir = tempdir().expect("tempdir");
+        let store = RocksStore::open(dir.path(), None).expect("open db");
+        store
+            .db
+            .put_cf(
+                store.log_cf(),
+                sequence_log_key(1),
+                encoded_log_entry(1, b"k", b"v"),
+            )
+            .expect("seed log row");
+
+        // The row's group never published (e.g. its state ingestion is still in flight), so it
+        // must stay invisible to both the point read and the oldest-retained probe.
+        assert!(store.get_batch(1).await.expect("get").is_none());
+        assert_eq!(store.oldest_retained_batch().await.expect("oldest"), None);
     }
 
     #[tokio::test]

--- a/examples/simulator/src/rocks.rs
+++ b/examples/simulator/src/rocks.rs
@@ -4,13 +4,12 @@
 //! can serve replay and point lookups. Batch-log pruning is driven exclusively by the compact
 //! service's `Sequence` scope.
 //!
-//! Durability is anchored on the replay log: each commit group makes its log rows plus the
-//! durable-sequence meta row durable first (one synced batch for small groups; an ingested SST
-//! file followed by a synced meta write for large ones), then the current-state rows are applied
-//! without a WAL and the visible sequence frontier advances. The state rows are recovered from
-//! the log, so `open` replays retained log rows above the persisted state-flushed watermark, and
-//! pruning flushes the default column family (advancing that watermark) before deleting log rows
-//! it may otherwise still need for recovery.
+//! Durability is anchored on the replay log: each commit group makes its log rows durable first
+//! (an ingested SST file followed by a synced write of the durable-sequence meta row), then the
+//! current-state rows are applied without a WAL and the visible sequence frontier advances. The
+//! state rows are recovered from the log, so `open` replays retained log rows above the persisted
+//! state-flushed watermark, and pruning flushes the default column family (advancing that
+//! watermark) before deleting log rows it may otherwise still need for recovery.
 
 use std::cmp::Ordering as CmpOrdering;
 use std::collections::BTreeMap;
@@ -51,11 +50,6 @@ const PRUNE_SCAN_BATCH_SIZE: usize = 4096;
 const DEFAULT_COMMIT_COALESCE_MAX_BATCH_BYTES: usize = 16 * 1024 * 1024;
 /// Directory under the store path where log SST files are staged before ingestion.
 const LOG_INGEST_DIR: &str = "ingest";
-/// Minimum accumulated log payload before a commit group's log rows are written as an ingested
-/// SST file instead of a WAL-backed batch. Ingested rows reach the disk once, while WAL-backed
-/// rows are written twice (WAL now, SST on flush), so large groups ingest and small groups keep
-/// the cheaper single-fsync WAL commit.
-const LOG_INGEST_MIN_BYTES: usize = 4 * 1024 * 1024;
 type RocksIterItem = Result<(Box<[u8]>, Box<[u8]>), rocksdb::Error>;
 
 /// Owns the DB handle for a RocksDB iterator that is moved through blocking tasks.
@@ -306,23 +300,15 @@ struct AssignedWrite {
     request: WriteRequest,
 }
 
-/// How one commit group's replay-log rows (and the durable-sequence meta row) reach the disk.
-/// Either way the log alone defines durability; the state rows are recoverable from it.
-enum PreparedLog {
-    /// Log rows plus the meta row in one WAL-backed batch, committed atomically by one synced
-    /// write. Used for small groups, where a single fsync beats the ingestion overhead.
-    Batch(rocksdb::WriteBatch),
-    /// Encoded log rows (ascending sequence order) written as one SST file and ingested directly
-    /// into the log column family, followed by a synced meta write. Large payloads reach the disk
-    /// once instead of twice (WAL now, SST again on flush), and being ingested at the bottom
-    /// level they are never rewritten by compaction.
-    Ingest(Vec<(u64, Vec<u8>)>),
-}
-
 /// One commit group covering a contiguous run of assigned sequence numbers.
 struct PreparedWrite {
     writes: Vec<AssignedWrite>,
-    log: Result<PreparedLog, String>,
+    /// Encoded replay-log rows in ascending sequence order. They alone define durability (the
+    /// state rows are recoverable from them): `commit` writes them as one SST file ingested
+    /// directly into the log column family, followed by a synced meta write, so the payload
+    /// reaches the disk once instead of twice (WAL now, SST again on flush) and, sitting at the
+    /// bottom level, is never rewritten by compaction.
+    log_rows: Result<Vec<(u64, Vec<u8>)>, String>,
     /// Current-state rows for the same sequences, applied without a WAL once the log is durable.
     state_batch: rocksdb::WriteBatch,
     batch_bytes: usize,
@@ -345,11 +331,11 @@ struct Writer {
 impl Writer {
     /// Starts the three-stage write pipeline. `prepare` drains queued requests up to the
     /// configured byte cap, assigns a contiguous sequence number to each, and builds each wave's
-    /// state batch and encoded log rows; `commit` makes each group's log rows durable (synced
-    /// batch or ingested SST), publishing the durable frontier; `apply` inserts the state rows
-    /// without a WAL, advances the visible frontier, and resolves the requests. The stages
-    /// overlap, so while one group is being fsync'd the next is being built and the previous
-    /// group's state rows are being applied.
+    /// state batch and encoded log rows; `commit` makes each group's log rows durable (an
+    /// ingested SST followed by a synced meta write), publishing the durable frontier; `apply`
+    /// inserts the state rows without a WAL, advances the visible frontier, and resolves the
+    /// requests. The stages overlap, so while one group is being synced the next is being built
+    /// and the previous group's state rows are being applied.
     fn start(
         db: Arc<DB>,
         ingest_dir: PathBuf,
@@ -378,14 +364,13 @@ impl Writer {
             .spawn(move || run_apply(apply_db, apply_sequence, flushed, committed_receiver))
             .expect("failed to spawn RocksDB apply worker");
 
-        let commit_db = db.clone();
         let commit_durable = durable.clone();
         let commit_epoch = epoch.clone();
         let commit = thread::Builder::new()
             .name("simulator-rocks-commit".to_string())
             .spawn(move || {
                 run_commit(
-                    commit_db,
+                    db,
                     ingest_dir,
                     commit_durable,
                     commit_epoch,
@@ -399,7 +384,6 @@ impl Writer {
             .name("simulator-rocks-prepare".to_string())
             .spawn(move || {
                 run_prepare(
-                    db,
                     durable,
                     epoch,
                     request_receiver,
@@ -455,7 +439,6 @@ impl Drop for Writer {
 /// next wave re-syncs `next` to the durable frontier so the abandoned sequence numbers are
 /// re-allocated.
 fn run_prepare(
-    db: Arc<DB>,
     durable: Arc<AtomicU64>,
     epoch: Arc<AtomicU64>,
     receiver: mpsc::Receiver<WriteRequest>,
@@ -468,14 +451,13 @@ fn run_prepare(
     while let Ok(first) = receiver.recv() {
         let current_epoch = epoch.load(Ordering::Acquire);
         if current_epoch != seen_epoch {
-            // A commit failed: each log batch commits atomically so nothing past the durable
-            // frontier persisted, and the failed numbers can be reclaimed.
+            // A commit failed: each group commits its log rows and meta in order, so nothing
+            // past the durable frontier persisted, and the failed numbers can be reclaimed.
             seen_epoch = current_epoch;
             next = durable.load(Ordering::Acquire);
         }
 
         let (group, disconnected) = match prepare_queued_write(
-            &db,
             &receiver,
             first,
             next,
@@ -512,7 +494,6 @@ fn write_batch_capacity(request: &WriteRequest) -> usize {
 /// arrivals, stopping once the accumulated RocksDB batches reach the soft byte cap. The request
 /// that crosses the cap stays in the wave so a single large request can still make progress.
 fn prepare_queued_write(
-    db: &DB,
     receiver: &mpsc::Receiver<WriteRequest>,
     first: WriteRequest,
     from: u64,
@@ -561,10 +542,14 @@ fn prepare_queued_write(
         }
     }
 
-    Ok((
-        finalize_prepared_write(db, writes, state_batch, log_rows, log_bytes, epoch),
-        disconnected,
-    ))
+    let group = PreparedWrite {
+        writes,
+        log_rows: Ok(log_rows),
+        batch_bytes: state_batch.size_in_bytes() + log_bytes,
+        state_batch,
+        epoch,
+    };
+    Ok((group, disconnected))
 }
 
 /// Sends one group to `commit`, returning false if it has stopped.
@@ -576,10 +561,11 @@ fn forward_group(sender: &mpsc::SyncSender<PreparedWrite>, group: PreparedWrite)
     true
 }
 
-/// Commits prepared groups one at a time with a synced log write, publishing the durable frontier
-/// after each success and handing the group to `apply`. A group whose epoch was superseded by an
-/// earlier failure is rejected without being written; a failing group bumps the epoch so its
-/// frontier (and every later group assigned under it) is abandoned and re-allocated by `prepare`.
+/// Commits prepared groups one at a time (ingested log SST, then a synced meta write), publishing
+/// the durable frontier after each success and handing the group to `apply`. A group whose epoch
+/// was superseded by an earlier failure is rejected without being written; a failing group bumps
+/// the epoch so its frontier (and every later group assigned under it) is abandoned and
+/// re-allocated by `prepare`.
 fn run_commit(
     db: Arc<DB>,
     ingest_dir: PathBuf,
@@ -593,7 +579,7 @@ fn run_commit(
             continue;
         };
         if let Err(error) = committed_sender.send(committed) {
-            // The log batch is durable but the state rows can no longer be applied in this
+            // The log rows are durable but the state rows can no longer be applied in this
             // process; recovery replays them on the next open, so the callers only lose the ack.
             fail_assigned_writes(error.0.writes, "rocks apply worker stopped".to_string());
             break;
@@ -629,7 +615,7 @@ fn commit_group(
     let group_epoch = group.epoch;
     let PreparedWrite {
         writes,
-        log,
+        log_rows,
         state_batch,
         batch_bytes,
         ..
@@ -638,20 +624,15 @@ fn commit_group(
         .last()
         .expect("non-empty group has a last write")
         .sequence;
-    let log = match log {
-        Ok(log) => log,
+    let log_rows = match log_rows {
+        Ok(log_rows) => log_rows,
         Err(error) => {
             epoch.fetch_add(1, Ordering::AcqRel);
             fail_assigned_writes(writes, error);
             return None;
         }
     };
-    let committed = match log {
-        PreparedLog::Batch(log_batch) => write_sequence_batch(db, log_batch),
-        PreparedLog::Ingest(log_rows) => {
-            ingest_log_rows(db, ingest_dir, log_rows, last_sequence, group_epoch)
-        }
-    };
+    let committed = ingest_log_rows(db, ingest_dir, log_rows, last_sequence, group_epoch);
     match committed {
         Ok(()) => {
             // Release so `prepare` re-syncs against a frontier whose log rows are already synced.
@@ -730,39 +711,6 @@ fn apply_committed_write(
     }
 }
 
-fn finalize_prepared_write(
-    db: &DB,
-    writes: Vec<AssignedWrite>,
-    state_batch: rocksdb::WriteBatch,
-    log_rows: Vec<(u64, Vec<u8>)>,
-    log_bytes: usize,
-    epoch: u64,
-) -> PreparedWrite {
-    let batch_bytes = state_batch.size_in_bytes() + log_bytes;
-    let log = if log_bytes >= LOG_INGEST_MIN_BYTES {
-        PreparedLog::Ingest(log_rows)
-    } else {
-        let log_cf = db
-            .cf_handle(LOG_CF)
-            .expect("log CF must exist (created on open)");
-        let mut log_batch = rocksdb::WriteBatch::with_capacity_bytes(log_bytes + 64);
-        for (sequence, value) in log_rows {
-            log_batch.put_cf(log_cf, sequence_log_key(sequence), value);
-        }
-        if let Some(write) = writes.last() {
-            append_sequence_meta(db, &mut log_batch, write.sequence);
-        }
-        PreparedLog::Batch(log_batch)
-    };
-    PreparedWrite {
-        writes,
-        log: Ok(log),
-        state_batch,
-        batch_bytes,
-        epoch,
-    }
-}
-
 /// Appends the current-state rows for one sequence to the state batch.
 fn append_state_entries(state_batch: &mut rocksdb::WriteBatch, requests: &[WriteRequest]) {
     for request in requests {
@@ -779,8 +727,8 @@ fn append_sequence_meta(db: &DB, batch: &mut rocksdb::WriteBatch, sequence: u64)
     batch.put_cf(meta_cf, SEQ_META_KEY, sequence.to_le_bytes());
 }
 
-/// Writes a log batch with sync enabled because it defines the durable high-water mark.
-fn write_sequence_batch(db: &DB, batch: rocksdb::WriteBatch) -> Result<(), String> {
+/// Writes a batch with sync enabled, used for the meta rows that define durable frontiers.
+fn write_synced_batch(db: &DB, batch: rocksdb::WriteBatch) -> Result<(), String> {
     let mut write_options = WriteOptions::default();
     write_options.set_sync(true);
     db.write_opt(batch, &write_options)
@@ -791,7 +739,7 @@ fn write_sequence_batch(db: &DB, batch: rocksdb::WriteBatch) -> Result<(), Strin
 /// family, and then durably advancing the sequence meta row. Ingestion syncs the file and the
 /// manifest, so the rows are durable before the meta write publishes them; if the meta write is
 /// lost, the orphaned rows sit above the durable frontier where `get_batch` cannot see them and
-/// `open` deletes them.
+/// `open` deletes them. A group whose requests carried no rows only advances the meta row.
 fn ingest_log_rows(
     db: &DB,
     ingest_dir: &Path,
@@ -799,41 +747,39 @@ fn ingest_log_rows(
     last_sequence: u64,
     epoch: u64,
 ) -> Result<(), String> {
-    let first = log_rows
-        .first()
-        .expect("ingested log groups are never empty")
-        .0;
-    // Leftover files from failed ingestions are deleted when the store reopens, and epochs make
-    // re-allocated sequence numbers unambiguous within one writer's lifetime.
-    let path = ingest_dir.join(format!("log-{first:020}-{last_sequence:020}-e{epoch}.sst"));
+    if let Some((first, _)) = log_rows.first() {
+        // Leftover files from failed ingestions are deleted when the store reopens, and epochs
+        // make re-allocated sequence numbers unambiguous within one writer's lifetime.
+        let path = ingest_dir.join(format!("log-{first:020}-{last_sequence:020}-e{epoch}.sst"));
 
-    // Uncompressed for parity with the WAL-backed path (WAL payloads are not compressed either);
-    // compressing on the commit path would trade ack latency for bytes.
-    let mut options = Options::default();
-    options.set_compression_type(DBCompressionType::None);
-    let mut writer = SstFileWriter::create(&options);
-    writer.open(&path).map_err(|e| e.to_string())?;
-    for (sequence, value) in &log_rows {
-        writer
-            .put(sequence_log_key(*sequence), value)
-            .map_err(|e| e.to_string())?;
-    }
-    // `finish` syncs the file before it is linked into the DB.
-    writer.finish().map_err(|e| e.to_string())?;
+        // Uncompressed for parity with what a WAL write would cost; compressing on the commit
+        // path would trade ack latency for bytes.
+        let mut options = Options::default();
+        options.set_compression_type(DBCompressionType::None);
+        let mut writer = SstFileWriter::create(&options);
+        writer.open(&path).map_err(|e| e.to_string())?;
+        for (sequence, value) in &log_rows {
+            writer
+                .put(sequence_log_key(*sequence), value)
+                .map_err(|e| e.to_string())?;
+        }
+        // `finish` syncs the file before it is linked into the DB.
+        writer.finish().map_err(|e| e.to_string())?;
 
-    let log_cf = db
-        .cf_handle(LOG_CF)
-        .expect("log CF must exist (created on open)");
-    let mut ingest_options = IngestExternalFileOptions::default();
-    ingest_options.set_move_files(true);
-    if let Err(error) = db.ingest_external_file_cf_opts(log_cf, &ingest_options, vec![&path]) {
-        let _ = std::fs::remove_file(&path);
-        return Err(error.to_string());
+        let log_cf = db
+            .cf_handle(LOG_CF)
+            .expect("log CF must exist (created on open)");
+        let mut ingest_options = IngestExternalFileOptions::default();
+        ingest_options.set_move_files(true);
+        if let Err(error) = db.ingest_external_file_cf_opts(log_cf, &ingest_options, vec![&path]) {
+            let _ = std::fs::remove_file(&path);
+            return Err(error.to_string());
+        }
     }
 
     let mut meta_batch = rocksdb::WriteBatch::default();
     append_sequence_meta(db, &mut meta_batch, last_sequence);
-    write_sequence_batch(db, meta_batch)
+    write_synced_batch(db, meta_batch)
 }
 
 /// Writes current-state rows without a WAL: durability comes from the already-synced log batch,
@@ -862,7 +808,7 @@ fn advance_state_flushed(db: &DB, flushed: &AtomicU64, target: u64) -> Result<()
         .expect("meta CF must exist (created on open)");
     let mut batch = rocksdb::WriteBatch::default();
     batch.put_cf(meta_cf, STATE_FLUSHED_META_KEY, target.to_le_bytes());
-    write_sequence_batch(db, batch)?;
+    write_synced_batch(db, batch)?;
     flushed.fetch_max(target, Ordering::AcqRel);
     Ok(())
 }
@@ -1015,19 +961,11 @@ impl Default for RocksConfig {
         default_cf_options.set_write_buffer_size(32 * 1024 * 1024);
         default_cf_options.set_max_write_buffer_number(4);
 
-        // Replay-log values are large (one blob per ingest batch) and immutable until pruned.
-        // Storing them in blob files keeps log-CF compactions rewriting only the 8-byte keys and
-        // blob references instead of re-copying every batch payload.
-        let mut log_cf_options = Options::default();
-        log_cf_options.set_enable_blob_files(true);
-        log_cf_options.set_min_blob_size(4096);
-        log_cf_options.set_enable_blob_gc(true);
-
         Self {
             db_options,
             default_cf_options,
             meta_cf_options: Options::default(),
-            log_cf_options,
+            log_cf_options: Options::default(),
             write_pipeline: RocksWritePipelineConfig::default(),
         }
     }
@@ -1496,7 +1434,7 @@ mod tests {
         (
             PreparedWrite {
                 writes,
-                log: Err(error.to_string()),
+                log_rows: Err(error.to_string()),
                 state_batch: rocksdb::WriteBatch::default(),
                 batch_bytes: 0,
                 epoch,
@@ -1539,7 +1477,7 @@ mod tests {
             log_batch.put_cf(log_cf, sequence_log_key(next), value);
         }
         append_sequence_meta(db, &mut log_batch, next);
-        write_sequence_batch(db, log_batch)?;
+        write_synced_batch(db, log_batch)?;
         write_state_batch(db, state_batch)?;
         sequence.store(next, Ordering::Release);
         Ok(next)
@@ -1567,7 +1505,7 @@ mod tests {
         )
     }
 
-    fn prepared_write(db: &DB, epoch: u64, writes: Vec<AssignedWrite>) -> PreparedWrite {
+    fn prepared_write(epoch: u64, writes: Vec<AssignedWrite>) -> PreparedWrite {
         let mut state_batch = rocksdb::WriteBatch::default();
         let mut log_rows = Vec::new();
         let mut log_bytes = 0;
@@ -1579,7 +1517,13 @@ mod tests {
                 log_rows.push((write.sequence, value));
             }
         }
-        finalize_prepared_write(db, writes, state_batch, log_rows, log_bytes, epoch)
+        PreparedWrite {
+            writes,
+            log_rows: Ok(log_rows),
+            batch_bytes: state_batch.size_in_bytes() + log_bytes,
+            state_batch,
+            epoch,
+        }
     }
 
     #[test]
@@ -1655,8 +1599,6 @@ mod tests {
 
     #[test]
     fn prepare_queued_write_collects_all_pending_below_byte_cap() {
-        let dir = tempdir().expect("tempdir");
-        let store = RocksStore::open(dir.path(), None).expect("open db");
         let (sender, receiver) = mpsc::channel();
         sender.send(write_request(b"a")).expect("send");
         sender.send(write_request(b"b")).expect("send");
@@ -1665,7 +1607,6 @@ mod tests {
 
         let first = receiver.recv().expect("first request");
         let (group, disconnected) = match prepare_queued_write(
-            &store.db,
             &receiver,
             first,
             0,
@@ -1676,7 +1617,7 @@ mod tests {
             Err((_, error)) => panic!("{error}"),
         };
         assert_eq!(group.writes.len(), 3);
-        assert!(group.log.is_ok());
+        assert!(group.log_rows.is_ok());
         assert!(group.batch_bytes > 0);
         assert_eq!(group.epoch, 7);
         assert!(disconnected);
@@ -1684,8 +1625,6 @@ mod tests {
 
     #[test]
     fn prepare_queued_write_stops_after_soft_byte_cap() {
-        let dir = tempdir().expect("tempdir");
-        let store = RocksStore::open(dir.path(), None).expect("open db");
         let (sender, receiver) = mpsc::channel();
         sender.send(write_request(b"a")).expect("send");
         sender.send(write_request(b"b")).expect("send");
@@ -1693,15 +1632,14 @@ mod tests {
         drop(sender);
 
         let first = receiver.recv().expect("first request");
-        let (group, disconnected) = match prepare_queued_write(&store.db, &receiver, first, 0, 1, 7)
-        {
+        let (group, disconnected) = match prepare_queued_write(&receiver, first, 0, 1, 7) {
             Ok(prepared) => prepared,
             Err((_, error)) => panic!("{error}"),
         };
 
         assert_eq!(group.writes.len(), 1);
         assert_eq!(group.writes[0].request.kvs[0].0.as_ref(), b"a");
-        assert!(group.log.is_ok());
+        assert!(group.log_rows.is_ok());
         assert!(group.batch_bytes >= 1);
         assert_eq!(group.epoch, 7);
         assert!(!disconnected);
@@ -1718,13 +1656,11 @@ mod tests {
 
     #[tokio::test]
     async fn forward_group_fails_request_when_commit_stopped() {
-        let dir = tempdir().expect("tempdir");
-        let store = RocksStore::open(dir.path(), None).expect("open db");
         let (group_sender, group_receiver) = mpsc::sync_channel(0);
         drop(group_receiver);
 
         let (write, result) = assigned_write_with_response(1, b"a", b"1");
-        let group = prepared_write(&store.db, 0, vec![write]);
+        let group = prepared_write(0, vec![write]);
         let forwarded = forward_group(&group_sender, group);
 
         assert!(!forwarded);
@@ -1760,7 +1696,7 @@ mod tests {
         // The next epoch re-allocates sequences 1 and 2 to fresh requests, which commit cleanly.
         let (write_x, result_x) = assigned_write_with_response(1, b"x", b"24");
         let (write_y, result_y) = assigned_write_with_response(2, b"y", b"25");
-        let group = prepared_write(&store.db, 1, vec![write_x, write_y]);
+        let group = prepared_write(1, vec![write_x, write_y]);
         let committed = commit_and_apply(&store, &durable, &epoch, group);
 
         assert_eq!(committed, 2);
@@ -1786,7 +1722,7 @@ mod tests {
         let epoch = AtomicU64::new(1);
 
         let (write, result) = assigned_write_with_response(1, b"a", b"1");
-        let group = prepared_write(&store.db, 0, vec![write]);
+        let group = prepared_write(0, vec![write]);
         let committed = commit_and_apply(&store, &durable, &epoch, group);
 
         assert_eq!(committed, 0);
@@ -1824,7 +1760,7 @@ mod tests {
         // The first durable write still takes sequence 1.
         let current = epoch.load(Ordering::Acquire);
         let (write, result) = assigned_write_with_response(1, b"k", b"v");
-        let group = prepared_write(&store.db, current, vec![write]);
+        let group = prepared_write(current, vec![write]);
         let committed = commit_and_apply(&store, &durable, &epoch, group);
         assert_eq!(committed, 1);
         assert_eq!(result.await.expect("response"), Ok(1));
@@ -1861,7 +1797,7 @@ mod tests {
         }
 
         let (write, result) = assigned_write_with_response(1, b"k", b"new");
-        let group = prepared_write(&store.db, 1, vec![write]);
+        let group = prepared_write(1, vec![write]);
         let committed = commit_and_apply(&store, &durable, &epoch, group);
 
         assert_eq!(committed, 1);
@@ -1873,9 +1809,9 @@ mod tests {
         );
     }
 
-    /// One batch large enough to commit through the SST-ingestion path instead of a WAL batch.
+    /// One multi-megabyte batch, sized to exercise multi-block ingested log SSTs.
     fn large_batch(tag: u8) -> Vec<(Bytes, Bytes)> {
-        (0..(LOG_INGEST_MIN_BYTES / 4096 + 16))
+        (0..1040)
             .map(|i| {
                 let mut key = vec![tag];
                 key.extend_from_slice(&(i as u64).to_be_bytes());
@@ -1885,7 +1821,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn large_batches_commit_through_ingestion_and_survive_reopen() {
+    async fn batches_commit_through_ingestion_and_survive_reopen() {
         let dir = tempdir().expect("tempdir");
         let (first, second) = {
             let store = RocksStore::open(dir.path(), None).expect("open db");
@@ -1976,7 +1912,7 @@ mod tests {
                 .encode_to_vec(),
             );
             append_sequence_meta(&store.db, &mut log_batch, 3);
-            write_sequence_batch(&store.db, log_batch).expect("write log rows");
+            write_synced_batch(&store.db, log_batch).expect("write log rows");
         }
 
         let store = RocksStore::open(dir.path(), None).expect("reopen db");
@@ -2087,7 +2023,6 @@ mod tests {
         let durable = AtomicU64::new(0);
         let epoch = AtomicU64::new(0);
         let prepared = prepared_write(
-            &store.db,
             0,
             vec![
                 assigned_write(1, b"a", b"1"),

--- a/examples/simulator/src/rocks.rs
+++ b/examples/simulator/src/rocks.rs
@@ -61,6 +61,9 @@ const PRUNE_SCAN_BATCH_SIZE: usize = 4096;
 const DEFAULT_COMMIT_COALESCE_MAX_BATCH_BYTES: usize = 16 * 1024 * 1024;
 /// Directory under the store path where SST files are staged before ingestion.
 const LOG_INGEST_DIR: &str = "ingest";
+/// Name prefix for the store's writer threads, whose panics are fatal by design. The binary's
+/// panic hook matches on it to turn a writer panic into a process exit.
+pub const WRITER_THREAD_PREFIX: &str = "simulator-rocks-";
 type RocksIterItem = Result<(Box<[u8]>, Box<[u8]>), rocksdb::Error>;
 
 /// Owns the DB handle for a RocksDB iterator that is moved through blocking tasks.
@@ -384,12 +387,12 @@ impl Writer {
         let max_commit_batch_bytes = write_pipeline.max_commit_batch_bytes.get();
 
         let commit = thread::Builder::new()
-            .name("simulator-rocks-commit".to_string())
+            .name(format!("{WRITER_THREAD_PREFIX}commit"))
             .spawn(move || run_commit(db, frontiers, group_receiver))
             .expect("failed to spawn RocksDB commit worker");
 
         let prepare = thread::Builder::new()
-            .name("simulator-rocks-prepare".to_string())
+            .name(format!("{WRITER_THREAD_PREFIX}prepare"))
             .spawn(move || {
                 run_prepare(
                     ingest_dir,
@@ -529,7 +532,7 @@ fn stage_group_files(ingest_dir: &Path, writes: &[AssignedWrite]) -> StagedFiles
 
     let (log_result, state_result) = thread::scope(|scope| {
         let state = thread::Builder::new()
-            .name("simulator-rocks-stage".to_string())
+            .name(format!("{WRITER_THREAD_PREFIX}stage"))
             .spawn_scoped(scope, || stage_state_file(&state_path, writes))
             .expect("failed to spawn SST staging thread");
         let log_result = stage_log_file(&log_path, writes);

--- a/examples/simulator/src/rocks.rs
+++ b/examples/simulator/src/rocks.rs
@@ -12,11 +12,8 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{mpsc, Arc, Mutex};
 use std::thread;
 
-use buffa::Message;
 use bytes::Bytes;
-use exoware_sdk::common::kv::v1::Entry;
 use exoware_sdk::keys::KeyCodec;
-use exoware_sdk::log::stream::v1::GetResponse as StreamGetResponse;
 use exoware_sdk::prune_policy::{
     KeysScope, OrderEncoding, PolicyScope, PrunePolicyDocument, RetainPolicy,
 };
@@ -990,29 +987,88 @@ fn sequence_from_log_key(key: &[u8]) -> Result<u64, String> {
     Ok(u64::from_be_bytes(raw))
 }
 
+/// `log.stream.v1.GetResponse.sequence_number` (varint).
+const LOG_VALUE_SEQUENCE_TAG: u8 = 0x08;
+/// `log.stream.v1.GetResponse.entries` (length-delimited).
+const LOG_VALUE_ENTRY_TAG: u8 = 0x12;
+/// `common.kv.v1.Entry.key` (length-delimited).
+const LOG_ENTRY_KEY_TAG: u8 = 0x0a;
+/// `common.kv.v1.Entry.value` (length-delimited).
+const LOG_ENTRY_VALUE_TAG: u8 = 0x12;
+
+/// Number of bytes a value occupies as a protobuf varint.
+fn varint_len(value: u64) -> usize {
+    (63 - (value | 1).leading_zeros() as usize) / 7 + 1
+}
+
+/// Appends a protobuf varint to `buf`.
+fn put_varint(buf: &mut Vec<u8>, mut value: u64) {
+    while value >= 0x80 {
+        buf.push(value as u8 | 0x80);
+        value >>= 7;
+    }
+    buf.push(value as u8);
+}
+
+/// Encoded size of one `common.kv.v1.Entry` body. Empty fields are omitted,
+/// matching the generated encoder.
+fn encoded_entry_body_len(key: &[u8], value: &[u8]) -> usize {
+    let mut len = 0;
+    if !key.is_empty() {
+        len += 1 + varint_len(key.len() as u64) + key.len();
+    }
+    if !value.is_empty() {
+        len += 1 + varint_len(value.len() as u64) + value.len();
+    }
+    len
+}
+
 /// Encodes the replay payload for every key/value row folded into one sequence.
+///
+/// Writes the `log.stream.v1.GetResponse` wire format directly from the borrowed
+/// key/value slices so a large batch is encoded with a single presized allocation
+/// instead of one owned `Entry` per row. `log_value_matches_generated_encoder`
+/// pins byte-for-byte equality with the generated encoder.
 fn encode_log_value(sequence: u64, requests: &[WriteRequest]) -> Option<Vec<u8>> {
-    let entries = requests
-        .iter()
-        .flat_map(|request| {
-            request.kvs.iter().map(|(key, value)| Entry {
-                key: key.to_vec(),
-                value: value.clone(),
-                ..Default::default()
-            })
-        })
-        .collect::<Vec<_>>();
-    if entries.is_empty() {
+    let mut total = 0;
+    let mut entries = 0usize;
+    for request in requests {
+        entries += request.kvs.len();
+        for (key, value) in &request.kvs {
+            let body_len = encoded_entry_body_len(key, value);
+            total += 1 + varint_len(body_len as u64) + body_len;
+        }
+    }
+    if entries == 0 {
         return None;
     }
-    Some(
-        StreamGetResponse {
-            sequence_number: sequence,
-            entries,
-            ..Default::default()
+    if sequence != 0 {
+        total += 1 + varint_len(sequence);
+    }
+
+    let mut buf = Vec::with_capacity(total);
+    if sequence != 0 {
+        buf.push(LOG_VALUE_SEQUENCE_TAG);
+        put_varint(&mut buf, sequence);
+    }
+    for request in requests {
+        for (key, value) in &request.kvs {
+            buf.push(LOG_VALUE_ENTRY_TAG);
+            put_varint(&mut buf, encoded_entry_body_len(key, value) as u64);
+            if !key.is_empty() {
+                buf.push(LOG_ENTRY_KEY_TAG);
+                put_varint(&mut buf, key.len() as u64);
+                buf.extend_from_slice(key);
+            }
+            if !value.is_empty() {
+                buf.push(LOG_ENTRY_VALUE_TAG);
+                put_varint(&mut buf, value.len() as u64);
+                buf.extend_from_slice(value);
+            }
         }
-        .encode_to_vec(),
-    )
+    }
+    debug_assert_eq!(buf.len(), total);
+    Some(buf)
 }
 
 #[cfg(test)]
@@ -1020,6 +1076,9 @@ mod tests {
     use super::*;
     use std::collections::BTreeSet;
 
+    use buffa::Message;
+    use exoware_sdk::common::kv::v1::Entry;
+    use exoware_sdk::log::stream::v1::GetResponse as StreamGetResponse;
     use exoware_server::{Ingest, Log, Sequence};
     use tempfile::tempdir;
 
@@ -1140,6 +1199,61 @@ mod tests {
             prepared.push(write);
         }
         finalize_prepared_write(db, prepared, batch, epoch)
+    }
+
+    #[test]
+    fn log_value_matches_generated_encoder() {
+        let cases: Vec<(u64, Vec<Vec<(Bytes, Bytes)>>)> = vec![
+            (1, vec![vec![(Bytes::from_static(b"a"), Bytes::from_static(b"1"))]]),
+            // Coalesced requests, empty keys/values, and multi-byte varint lengths.
+            (
+                u64::MAX,
+                vec![
+                    vec![
+                        (Bytes::new(), Bytes::from_static(b"value-for-empty-key")),
+                        (Bytes::from_static(b"empty-value"), Bytes::new()),
+                        (Bytes::new(), Bytes::new()),
+                    ],
+                    vec![(
+                        Bytes::from(vec![7u8; 200]),
+                        Bytes::from(vec![9u8; 20_000]),
+                    )],
+                ],
+            ),
+        ];
+
+        for (sequence, kvs_per_request) in cases {
+            let requests = kvs_per_request
+                .into_iter()
+                .map(|kvs| WriteRequest {
+                    kvs,
+                    response: oneshot::channel().0,
+                })
+                .collect::<Vec<_>>();
+            let expected = StreamGetResponse {
+                sequence_number: sequence,
+                entries: requests
+                    .iter()
+                    .flat_map(|request| {
+                        request.kvs.iter().map(|(key, value)| Entry {
+                            key: key.to_vec(),
+                            value: value.clone(),
+                            ..Default::default()
+                        })
+                    })
+                    .collect(),
+                ..Default::default()
+            }
+            .encode_to_vec();
+            let encoded = encode_log_value(sequence, &requests).expect("encode");
+            assert_eq!(encoded, expected, "sequence {sequence}");
+        }
+
+        let empty = WriteRequest {
+            kvs: Vec::new(),
+            response: oneshot::channel().0,
+        };
+        assert!(encode_log_value(3, std::slice::from_ref(&empty)).is_none());
     }
 
     #[test]

--- a/examples/simulator/src/rocks.rs
+++ b/examples/simulator/src/rocks.rs
@@ -304,10 +304,13 @@ fn keys_to_delete(
 
 /// Sequence frontier shared by the store and its writer stages.
 struct Frontiers {
-    /// Highest sequence readers may observe: log rows and state rows both ingested. The durable
-    /// frontier (highest sequence whose log rows are durable) is not tracked in-process — it
-    /// only runs ahead of `published` while a group's state ingestion is in flight, and is
-    /// re-derived at open from the retained log rows and the state-floor meta row.
+    /// Highest sequence whose log rows and state rows are both ingested; gates every
+    /// sequence-addressed read (`current_sequence`, `get_batch`, `oldest_retained_batch`).
+    /// Point reads of current state are deliberately ungated: state may lead this frontier by
+    /// the one group being published, but never lags it. The durable frontier (highest sequence
+    /// whose log rows are durable) is not tracked in-process — it only runs ahead of `published`
+    /// while a group's state ingestion is in flight, and is re-derived at open from the retained
+    /// log rows and the state-floor meta row.
     published: AtomicU64,
     /// Serializes prunes (so the persisted state floor never moves backward) and orders state
     /// visibility against floor reads: `commit` ingests and publishes each group's state under
@@ -371,6 +374,7 @@ impl Writer {
     fn start(
         db: Arc<DB>,
         ingest_dir: PathBuf,
+        staging_pool: rayon::ThreadPool,
         frontiers: Arc<Frontiers>,
         next: u64,
         write_pipeline: RocksWritePipelineConfig,
@@ -391,6 +395,7 @@ impl Writer {
             .spawn(move || {
                 run_prepare(
                     ingest_dir,
+                    staging_pool,
                     next,
                     request_receiver,
                     group_sender,
@@ -442,14 +447,21 @@ impl Drop for Writer {
 /// (store drop); panics if `commit` died, since that only happens on a fatal write error.
 fn run_prepare(
     ingest_dir: PathBuf,
+    staging_pool: rayon::ThreadPool,
     mut next: u64,
     receiver: mpsc::Receiver<WriteRequest>,
     sender: mpsc::SyncSender<PreparedWrite>,
     max_commit_batch_bytes: usize,
 ) {
     while let Ok(first) = receiver.recv() {
-        let (group, disconnected) =
-            prepare_queued_write(&ingest_dir, &receiver, first, next, max_commit_batch_bytes);
+        let (group, disconnected) = prepare_queued_write(
+            &ingest_dir,
+            &staging_pool,
+            &receiver,
+            first,
+            next,
+            max_commit_batch_bytes,
+        );
         next = group
             .writes
             .last()
@@ -470,6 +482,7 @@ fn run_prepare(
 /// crosses the cap stays in the wave so a single large request can still make progress.
 fn prepare_queued_write(
     ingest_dir: &Path,
+    staging_pool: &rayon::ThreadPool,
     receiver: &mpsc::Receiver<WriteRequest>,
     first: WriteRequest,
     from: u64,
@@ -509,15 +522,16 @@ fn prepare_queued_write(
         }
     }
 
-    let staged = stage_group_files(ingest_dir, &writes);
+    let staged = staging_pool.install(|| stage_group_files(ingest_dir, &writes));
     (PreparedWrite { writes, staged }, disconnected)
 }
 
 /// Writes and syncs one commit group's two SST files: the replay-log rows (already in ascending
 /// sequence order) and the current-state rows (sorted by key in parallel, keeping the last write
-/// per key). The two files are built concurrently; ingestion later links them into their column
-/// families, so each payload byte reaches the disk exactly once, in its final resting place.
-/// A staging failure is fatal; leftover files are removed by the next open.
+/// per key). The two files are built concurrently on the caller's rayon pool (the store's
+/// staging pool, sized by [`RocksWritePipelineConfig::staging_threads`]); ingestion later links
+/// them into their column families, so each payload byte reaches the disk exactly once, in its
+/// final resting place. A staging failure is fatal; leftover files are removed by the next open.
 fn stage_group_files(ingest_dir: &Path, writes: &[AssignedWrite]) -> StagedFiles {
     let first = writes.first().expect("groups are never empty").sequence;
     let last = writes.last().expect("groups are never empty").sequence;
@@ -718,6 +732,11 @@ fn read_state_floor(db: &DB) -> Result<u64, String> {
 /// the one that ends at the durable frontier — which is idempotent because those rows are the
 /// newest writes for their keys. Rows at or below `floor` are skipped: their state is already
 /// authoritative, and key pruning may have deleted rows a replay would resurrect.
+///
+/// Bounding the replay by the last file's start key assumes log-CF file boundaries stay aligned
+/// with commit groups. That holds under stock options: ingested log files land at the bottom
+/// level (their sequence ranges never overlap) where automatic compaction never rewrites them
+/// (verified against the bundled RocksDB's level-selection and compaction-trigger sources).
 fn replay_last_log_file(db: &DB, floor: u64) -> Result<(), String> {
     let last_file_start = db
         .live_files()
@@ -772,6 +791,9 @@ pub struct RocksWritePipelineConfig {
     /// Soft maximum combined size (state rows plus encoded log rows) before cutting a prepared
     /// commit group.
     pub max_commit_batch_bytes: NonZeroUsize,
+    /// Threads in the pool that sorts and stages each commit group's SST files — CPU work on
+    /// the ack path. Defaults to the machine's available parallelism.
+    pub staging_threads: NonZeroUsize,
 }
 
 impl Default for RocksWritePipelineConfig {
@@ -779,12 +801,22 @@ impl Default for RocksWritePipelineConfig {
         Self {
             max_commit_batch_bytes: NonZeroUsize::new(DEFAULT_COMMIT_COALESCE_MAX_BATCH_BYTES)
                 .expect("default commit batch byte limit must be nonzero"),
+            staging_threads: available_parallelism(),
         }
     }
 }
 
+/// The machine's available parallelism, defaulting to two when it cannot be queried.
+fn available_parallelism() -> NonZeroUsize {
+    thread::available_parallelism().unwrap_or_else(|_| NonZeroUsize::new(2).expect("nonzero"))
+}
+
 /// RocksDB engine and application-level write pipeline options used by [`RocksStore::open`].
 pub struct RocksConfig {
+    /// Background jobs RocksDB may run concurrently: flushes and the compactions that must keep
+    /// merging the overlapping ingested state SSTs. Applied on top of `db_options` at open.
+    /// Defaults to the machine's available parallelism.
+    pub background_jobs: NonZeroUsize,
     /// Database-wide options.
     pub db_options: Options,
     /// Options for the default column family, which stores the current key-value state.
@@ -798,19 +830,13 @@ pub struct RocksConfig {
 }
 
 impl Default for RocksConfig {
-    /// Stock RocksDB options, plus background parallelism sized to the machine: commits ingest
-    /// overlapping state SSTs that compactions must keep merging. Memtables are off the hot
-    /// path (only the open-time replay and prune deletes write them), so they stay at stock
-    /// defaults.
+    /// Stock RocksDB options, with background jobs defaulting to the machine's available cores.
+    /// Memtables are off the hot path (only the open-time replay and prune deletes write
+    /// them), so they stay at stock defaults.
     fn default() -> Self {
-        let cores = thread::available_parallelism()
-            .map(|n| n.get())
-            .unwrap_or(2) as i32;
-        let mut db_options = Options::default();
-        db_options.increase_parallelism(cores);
-
         Self {
-            db_options,
+            background_jobs: available_parallelism(),
+            db_options: Options::default(),
             default_cf_options: Options::default(),
             meta_cf_options: Options::default(),
             log_cf_options: Options::default(),
@@ -836,6 +862,7 @@ impl RocksStore {
     /// the durable sequence even after a crash between a group's log and state ingestions.
     pub fn open(path: &Path, config: Option<RocksConfig>) -> Result<Self, String> {
         let RocksConfig {
+            background_jobs,
             mut db_options,
             default_cf_options,
             meta_cf_options,
@@ -845,6 +872,12 @@ impl RocksStore {
 
         db_options.create_if_missing(true);
         db_options.create_missing_column_families(true);
+        db_options.increase_parallelism(background_jobs.get() as i32);
+        let staging_pool = rayon::ThreadPoolBuilder::new()
+            .num_threads(write_pipeline.staging_threads.get())
+            .thread_name(|i| format!("simulator-rocks-stage-{i}"))
+            .build()
+            .map_err(|e| format!("failed to build SST staging thread pool: {e}"))?;
 
         let cf_default =
             ColumnFamilyDescriptor::new(rocksdb::DEFAULT_COLUMN_FAMILY_NAME, default_cf_options);
@@ -865,6 +898,7 @@ impl RocksStore {
         let writer = Arc::new(Writer::start(
             db.clone(),
             ingest_dir,
+            staging_pool,
             frontiers.clone(),
             seq,
             write_pipeline,
@@ -1315,6 +1349,13 @@ mod tests {
         PreparedWrite { writes, staged }
     }
 
+    fn staging_pool() -> rayon::ThreadPool {
+        rayon::ThreadPoolBuilder::new()
+            .num_threads(1)
+            .build()
+            .expect("build staging pool")
+    }
+
     #[test]
     fn log_value_matches_generated_encoder() {
         let cases: Vec<(u64, Vec<(Bytes, Bytes)>)> = vec![
@@ -1379,6 +1420,7 @@ mod tests {
         let first = receiver.recv().expect("first request");
         let (group, disconnected) = prepare_queued_write(
             dir.path(),
+            &staging_pool(),
             &receiver,
             first,
             0,
@@ -1401,7 +1443,8 @@ mod tests {
         drop(sender);
 
         let first = receiver.recv().expect("first request");
-        let (group, disconnected) = prepare_queued_write(dir.path(), &receiver, first, 0, 1);
+        let (group, disconnected) =
+            prepare_queued_write(dir.path(), &staging_pool(), &receiver, first, 0, 1);
 
         assert_eq!(group.writes.len(), 1);
         assert_eq!(group.writes[0].request.kvs[0].0.as_ref(), b"a");
@@ -1587,13 +1630,15 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn rocks_store_accepts_configured_write_pipeline() {
+    async fn rocks_store_accepts_custom_config() {
         let dir = tempdir().expect("tempdir");
         let store = RocksStore::open(
             dir.path(),
             Some(RocksConfig {
+                background_jobs: NonZeroUsize::new(1).expect("nonzero"),
                 write_pipeline: RocksWritePipelineConfig {
                     max_commit_batch_bytes: NonZeroUsize::new(1).expect("nonzero"),
+                    staging_threads: NonZeroUsize::new(1).expect("nonzero"),
                 },
                 ..Default::default()
             }),

--- a/examples/simulator/src/rocks.rs
+++ b/examples/simulator/src/rocks.rs
@@ -397,6 +397,7 @@ impl Writer {
     ) -> Self {
         let next = frontiers.published.load(Ordering::Acquire);
         let (request_sender, request_receiver) = mpsc::channel();
+
         // Rendezvous so `prepare` runs at most one wave ahead of `commit`: it hands off a
         // staged group, then stages the next while `commit` ingests this one.
         let (group_sender, group_receiver) = mpsc::sync_channel(0);
@@ -579,6 +580,7 @@ fn stage_log_file(path: &Path, sequence: u64, rows: &[(Bytes, Bytes)]) -> Result
     writer
         .put(sequence_log_key(sequence), &payload)
         .map_err(|e| e.to_string())?;
+
     // `finish` syncs the file before it is linked into the DB.
     writer.finish().map_err(|e| e.to_string())?;
     Ok(LOG_BATCH_KEY_LEN + payload.len())
@@ -590,6 +592,7 @@ fn stage_log_file(path: &Path, sequence: u64, rows: &[(Bytes, Bytes)]) -> Result
 /// compaction per the CF options.
 fn stage_state_file(path: &Path, rows: &[(Bytes, Bytes)]) -> Result<usize, String> {
     let mut rows: Vec<(&Bytes, &Bytes)> = rows.iter().map(|(key, value)| (key, value)).collect();
+
     // Stable sort: equal keys keep arrival order, so the last occurrence is the newest.
     rows.sort_by(|a, b| a.0.cmp(b.0));
 
@@ -607,6 +610,7 @@ fn stage_state_file(path: &Path, rows: &[(Bytes, Bytes)]) -> Result<usize, Strin
             .put(key.as_ref(), value.as_ref())
             .map_err(|e| e.to_string())?;
     }
+
     // `finish` syncs the file before it is linked into the DB.
     writer.finish().map_err(|e| e.to_string())?;
     Ok(bytes)
@@ -773,6 +777,7 @@ fn replay_newest_log_row(db: &DB, floor: u64) -> Result<(), String> {
     for entry in response.entries.iter() {
         batch.put(entry.key, entry.value);
     }
+
     // Synced: once a later commit moves the newest row past this group, a repair lost to power
     // loss would never be re-run.
     write_synced_batch(db, batch)
@@ -876,6 +881,7 @@ impl RocksStore {
         });
 
         let ingest_dir = prepare_ingest_dir(path)?;
+
         // Commits do not write the state-floor meta row; the log rows are the durable record.
         let floor = read_state_floor(&db)?;
         let seq = floor.max(highest_log_row(&db)?);
@@ -1061,6 +1067,7 @@ impl RocksStore {
             RetainPolicy::GreaterThanOrEqual { threshold } => *threshold,
             RetainPolicy::DropAll => current.saturating_add(1),
         };
+
         // Never delete log rows above the published frontier: a group whose log ingestion
         // committed but whose state ingestion did not still needs its rows for the repair replay
         // at the next open.
@@ -1166,6 +1173,7 @@ impl Log for RocksStore {
             Some(item) => {
                 let (key, _) = item.map_err(|e| e.to_string())?;
                 let sequence = sequence_from_log_key(key.as_ref())?;
+
                 // Gate on the published frontier like `get_batch`: never advertise an oldest
                 // batch that `get_batch` would then hide (a log row can outrun the published
                 // frontier while its group's state ingestion is in flight or has failed).
@@ -1484,6 +1492,7 @@ mod tests {
 
         let store = RocksStore::open(dir.path(), None).expect("reopen db");
         assert_eq!(store.current_sequence(), 2);
+
         // Replay applied the missing rows in arrival order: last writer wins for k2.
         for (key, value) in [
             (b"k1" as &[u8], b"v1" as &[u8]),
@@ -1496,6 +1505,7 @@ mod tests {
                 "key {key:?}"
             );
         }
+
         // A second reopen replays again (the floor only advances on prune); idempotent.
         drop(store);
         let store = RocksStore::open(dir.path(), None).expect("reopen db again");
@@ -1631,6 +1641,7 @@ mod tests {
     async fn sequence_prune_spares_log_rows_above_published_frontier() {
         let dir = tempdir().expect("tempdir");
         let store = RocksStore::open(dir.path(), None).expect("open db");
+
         // A durable log row whose group never published (its state ingestion was in flight at
         // a crash): pruning must spare it. It is the repair replay's input at the next open.
         seed_log_row(&store, 1, &encoded_log_entry(1, b"k", b"v"));

--- a/examples/simulator/src/rocks.rs
+++ b/examples/simulator/src/rocks.rs
@@ -1,8 +1,8 @@
 //! Naive reference storage for local development: user keys and values are written as-is to
-//! RocksDB. A `meta` column family stores the monotonically increasing sequence number for RPCs.
-//! A separate `log` column family keeps per-sequence-number batch payloads so the stream service
-//! can serve replay and point lookups. Batch-log pruning is driven exclusively by the compact
-//! service's `Sequence` scope.
+//! RocksDB. A `meta` column family holds the state-floor row (see below). A separate `log`
+//! column family keeps per-sequence-number batch payloads so the stream service can serve
+//! replay and point lookups. Batch-log pruning is driven exclusively by the compact service's
+//! `Sequence` scope.
 //!
 //! Both structures are written as SST files and ingested, bypassing the WAL and the memtables
 //! entirely: `prepare` stages one sorted state file and one log file per commit group, and
@@ -15,13 +15,17 @@
 //! written only by pruning — atomically with the log range tombstone or the pruned state keys —
 //! so a store recovers by reading one meta row, one file listing, and replaying at most one
 //! group.
+//!
+//! Any write failure in the pipeline is fatal: once a group's log rows are durable it cannot be
+//! rolled back (its sequence numbers must never be re-issued), so the writer panics and the next
+//! open rolls the store forward instead of any in-process recovery.
 
 use std::cmp::Ordering as CmpOrdering;
 use std::collections::BTreeMap;
 use std::num::NonZeroUsize;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{mpsc, Arc, Mutex};
+use std::sync::{mpsc, Arc};
 use std::thread;
 
 use buffa::MessageView;
@@ -35,6 +39,7 @@ use exoware_sdk::selector::compile_payload_regex;
 use exoware_server::{
     Ingest, Log, LogBatch, Prune, Query, QueryExtra, RangeScan, RangeScanBatch, Sequence,
 };
+use parking_lot::Mutex;
 use rayon::slice::ParallelSliceMut;
 use regex::bytes::Regex;
 use rocksdb::{
@@ -297,14 +302,13 @@ fn keys_to_delete(
     }
 }
 
-/// Sequence frontiers shared by the store and its writer stages.
+/// Sequence frontier shared by the store and its writer stages.
 struct Frontiers {
-    /// Highest sequence readers may observe: log rows and state rows both ingested.
+    /// Highest sequence readers may observe: log rows and state rows both ingested. The durable
+    /// frontier (highest sequence whose log rows are durable) is not tracked in-process — it
+    /// only runs ahead of `published` while a group's state ingestion is in flight, and is
+    /// re-derived at open from the retained log rows and the state-floor meta row.
     published: AtomicU64,
-    /// Highest sequence whose log rows are durable. Runs ahead of `published` only while a
-    /// group's state ingestion is in flight; re-derived at open from the retained log rows and
-    /// the state-floor meta row.
-    durable: AtomicU64,
     /// Serializes prunes (so the persisted state floor never moves backward) and orders state
     /// visibility against floor reads: `commit` ingests and publishes each group's state under
     /// this lock, so a prune that loads `published` under it sees a frontier covering every row
@@ -313,10 +317,9 @@ struct Frontiers {
 }
 
 impl Frontiers {
-    fn new(durable: u64) -> Self {
+    fn new(published: u64) -> Self {
         Self {
-            published: AtomicU64::new(durable),
-            durable: AtomicU64::new(durable),
+            published: AtomicU64::new(published),
             persist: Mutex::new(()),
         }
     }
@@ -346,10 +349,7 @@ struct StagedFiles {
 /// One commit group covering a contiguous run of assigned sequence numbers.
 struct PreparedWrite {
     writes: Vec<AssignedWrite>,
-    /// The group's staged SST files, or the error that aborted staging them.
-    staged: Result<StagedFiles, String>,
-    /// Assignment epoch; `commit` rejects a group whose epoch an earlier failure has superseded.
-    epoch: u64,
+    staged: StagedFiles,
 }
 
 struct Writer {
@@ -360,14 +360,19 @@ struct Writer {
 
 impl Writer {
     /// Starts the two-stage write pipeline. `prepare` drains queued requests up to the
-    /// configured byte cap, assigns a contiguous sequence number to each, and stages each wave's
-    /// log and state SST files (including their data syncs); `commit` ingests the log file, then
-    /// the state file, publishes the frontier, and resolves the requests. The stages overlap, so
-    /// one group's files are being staged while the previous group's are being ingested.
+    /// configured byte cap, assigns a contiguous sequence number to each (continuing from
+    /// `next`, the frontier derived at open), and stages each wave's log and state SST files
+    /// (including their data syncs); `commit` ingests the log file, then the state file,
+    /// publishes the frontier, and resolves the requests. The stages overlap, so one group's
+    /// files are being staged while the previous group's are being ingested. Any write failure
+    /// in either stage is fatal (the worker panics): the log rows alone define durability, so
+    /// the next open re-derives the frontier and repairs at most the last group — sequence
+    /// numbers never need to be reclaimed in-process.
     fn start(
         db: Arc<DB>,
         ingest_dir: PathBuf,
         frontiers: Arc<Frontiers>,
+        next: u64,
         write_pipeline: RocksWritePipelineConfig,
     ) -> Self {
         let (request_sender, request_receiver) = mpsc::channel();
@@ -376,16 +381,9 @@ impl Writer {
         let (group_sender, group_receiver) = mpsc::sync_channel(0);
         let max_commit_batch_bytes = write_pipeline.max_commit_batch_bytes.get();
 
-        // Bumped by `commit` whenever a group fails. That rejects the in-flight groups assigned
-        // under the failed frontier and signals `prepare` to re-sync its counter to the durable
-        // sequence, re-allocating the abandoned numbers.
-        let epoch = Arc::new(AtomicU64::new(0));
-
-        let commit_frontiers = frontiers.clone();
-        let commit_epoch = epoch.clone();
         let commit = thread::Builder::new()
             .name("simulator-rocks-commit".to_string())
-            .spawn(move || run_commit(db, commit_frontiers, commit_epoch, group_receiver))
+            .spawn(move || run_commit(db, frontiers, group_receiver))
             .expect("failed to spawn RocksDB commit worker");
 
         let prepare = thread::Builder::new()
@@ -393,8 +391,7 @@ impl Writer {
             .spawn(move || {
                 run_prepare(
                     ingest_dir,
-                    frontiers,
-                    epoch,
+                    next,
                     request_receiver,
                     group_sender,
                     max_commit_batch_bytes,
@@ -441,50 +438,25 @@ impl Drop for Writer {
 }
 
 /// Drains each byte-bounded wave of queued requests, assigns contiguous sequence numbers, stages
-/// the wave's SST files, and hands the group to `commit`. After a commit failure bumps the epoch,
-/// the next wave re-syncs `next` to the durable frontier so the abandoned sequence numbers are
-/// re-allocated.
+/// the wave's SST files, and hands the group to `commit`. Exits when the request channel closes
+/// (store drop); panics if `commit` died, since that only happens on a fatal write error.
 fn run_prepare(
     ingest_dir: PathBuf,
-    frontiers: Arc<Frontiers>,
-    epoch: Arc<AtomicU64>,
+    mut next: u64,
     receiver: mpsc::Receiver<WriteRequest>,
     sender: mpsc::SyncSender<PreparedWrite>,
     max_commit_batch_bytes: usize,
 ) {
-    let mut next = frontiers.durable.load(Ordering::Acquire);
-    let mut seen_epoch = epoch.load(Ordering::Acquire);
-
     while let Ok(first) = receiver.recv() {
-        let current_epoch = epoch.load(Ordering::Acquire);
-        if current_epoch != seen_epoch {
-            // A commit failed: nothing past the durable frontier persisted, so the failed
-            // numbers can be reclaimed.
-            seen_epoch = current_epoch;
-            next = frontiers.durable.load(Ordering::Acquire);
-        }
-
-        let (group, disconnected) = match prepare_queued_write(
-            &ingest_dir,
-            &receiver,
-            first,
-            next,
-            max_commit_batch_bytes,
-            seen_epoch,
-        ) {
-            Ok(prepared) => prepared,
-            Err((requests, error)) => {
-                fail_requests(requests, error);
-                continue;
-            }
-        };
+        let (group, disconnected) =
+            prepare_queued_write(&ingest_dir, &receiver, first, next, max_commit_batch_bytes);
         next = group
             .writes
             .last()
             .expect("groups are never empty")
             .sequence;
-        if !forward_group(&sender, group) {
-            break;
+        if sender.send(group).is_err() {
+            panic!("rocks commit worker died");
         }
 
         if disconnected {
@@ -502,8 +474,7 @@ fn prepare_queued_write(
     first: WriteRequest,
     from: u64,
     max_batch_bytes: usize,
-    epoch: u64,
-) -> Result<(PreparedWrite, bool), (Vec<WriteRequest>, String)> {
+) -> (PreparedWrite, bool) {
     let mut writes = Vec::with_capacity(64);
     let mut staged_bytes = 0usize;
     let mut next = from;
@@ -511,15 +482,9 @@ fn prepare_queued_write(
     let mut disconnected = false;
 
     loop {
-        next = match next.checked_add(1) {
-            Some(next) => next,
-            None => {
-                return Err((
-                    vec![request],
-                    "rocks sequence number overflowed".to_string(),
-                ));
-            }
-        };
+        next = next
+            .checked_add(1)
+            .expect("rocks sequence number overflowed");
         // Payload counted twice: once as state rows and once inside the encoded log row.
         staged_bytes += 2 * request
             .kvs
@@ -544,46 +509,33 @@ fn prepare_queued_write(
         }
     }
 
-    let staged = stage_group_files(ingest_dir, &writes, epoch);
-    let group = PreparedWrite {
-        writes,
-        staged,
-        epoch,
-    };
-    Ok((group, disconnected))
+    let staged = stage_group_files(ingest_dir, &writes);
+    (PreparedWrite { writes, staged }, disconnected)
 }
 
 /// Writes and syncs one commit group's two SST files: the replay-log rows (already in ascending
 /// sequence order) and the current-state rows (sorted by key in parallel, keeping the last write
 /// per key). The two files are built concurrently; ingestion later links them into their column
 /// families, so each payload byte reaches the disk exactly once, in its final resting place.
-fn stage_group_files(
-    ingest_dir: &Path,
-    writes: &[AssignedWrite],
-    epoch: u64,
-) -> Result<StagedFiles, String> {
+/// A staging failure is fatal; leftover files are removed by the next open.
+fn stage_group_files(ingest_dir: &Path, writes: &[AssignedWrite]) -> StagedFiles {
     let first = writes.first().expect("groups are never empty").sequence;
     let last = writes.last().expect("groups are never empty").sequence;
-    let log_path = ingest_dir.join(format!("log-{first:020}-{last:020}-e{epoch}.sst"));
-    let state_path = ingest_dir.join(format!("state-{first:020}-{last:020}-e{epoch}.sst"));
+    let log_path = ingest_dir.join(format!("log-{first:020}-{last:020}.sst"));
+    let state_path = ingest_dir.join(format!("state-{first:020}-{last:020}.sst"));
 
     let (log_result, state_result) = rayon::join(
         || stage_log_file(&log_path, writes),
         || stage_state_file(&state_path, writes),
     );
-    let staged = match (log_result, state_result) {
-        (Ok(log_bytes), Ok(state_bytes)) => Ok(StagedFiles {
-            log: log_path.clone(),
-            state: state_path.clone(),
-            staged_bytes: log_bytes + state_bytes,
-        }),
-        (log, state) => Err(log.err().or(state.err()).expect("one side failed")),
-    };
-    if staged.is_err() {
-        let _ = std::fs::remove_file(&log_path);
-        let _ = std::fs::remove_file(&state_path);
+    let log_bytes = log_result.unwrap_or_else(|error| panic!("failed to stage log SST: {error}"));
+    let state_bytes =
+        state_result.unwrap_or_else(|error| panic!("failed to stage state SST: {error}"));
+    StagedFiles {
+        log: log_path,
+        state: state_path,
+        staged_bytes: log_bytes + state_bytes,
     }
-    staged
 }
 
 /// Options for staged SST files. Uncompressed: compressing on the ingest path would trade ack
@@ -642,84 +594,24 @@ fn stage_state_file(path: &Path, writes: &[AssignedWrite]) -> Result<usize, Stri
     Ok(bytes)
 }
 
-/// Sends one group to `commit`, returning false if it has stopped.
-fn forward_group(sender: &mpsc::SyncSender<PreparedWrite>, group: PreparedWrite) -> bool {
-    if let Err(error) = sender.send(group) {
-        fail_assigned_writes(error.0.writes, "rocks commit worker stopped".to_string());
-        return false;
-    }
-    true
-}
-
-/// Commits prepared groups one at a time: log ingestion, state ingestion, publish, ack. Stops on
-/// the first partial commit (log durable, state not), since publishing anything later would
-/// advertise completeness the state cannot back; a restart repairs the partial group from its
-/// log file. A group whose epoch was superseded by an earlier failure is rejected without being
-/// written; a failing group bumps the epoch so its frontier (and every later group assigned
-/// under it) is abandoned and re-allocated by `prepare`.
-fn run_commit(
-    db: Arc<DB>,
-    frontiers: Arc<Frontiers>,
-    epoch: Arc<AtomicU64>,
-    receiver: mpsc::Receiver<PreparedWrite>,
-) {
+/// Commits prepared groups one at a time — log ingestion, state ingestion, publish, ack — until
+/// the group channel closes (store drop). Any write failure panics inside `commit_group`.
+fn run_commit(db: Arc<DB>, frontiers: Arc<Frontiers>, receiver: mpsc::Receiver<PreparedWrite>) {
     while let Ok(group) = receiver.recv() {
-        if commit_group(&db, &frontiers, &epoch, group) == CommitOutcome::Poisoned {
-            // Exiting closes the group channel, so prepare fails all later waves.
-            break;
-        }
+        commit_group(&db, &frontiers, group);
     }
-}
-
-#[derive(Debug, Eq, PartialEq)]
-enum CommitOutcome {
-    /// The group was committed and published, or cleanly rejected/failed (nothing durable).
-    Continue,
-    /// The group's log rows are durable but its state ingestion failed: the frontier must freeze
-    /// below the group until a restart replays its log file.
-    Poisoned,
 }
 
 /// Commits one group: ingests its log file (durability), then its state file (visibility), then
-/// publishes the frontier and resolves the requests.
-fn commit_group(
-    db: &DB,
-    frontiers: &Frontiers,
-    epoch: &AtomicU64,
-    group: PreparedWrite,
-) -> CommitOutcome {
+/// publishes the frontier and resolves the requests. Any write failure is fatal (panic): once
+/// the log rows are durable the group cannot be rolled back (its sequences must not be
+/// re-issued), and the next open rolls it forward by replaying the log file — so nothing is ever
+/// reclaimed or retried in-process. The panic drops the group's response channels, so waiting
+/// callers observe an error even though the group may resurface after the restart repair — an
+/// accepted at-least-once ambiguity of this severe error path.
+fn commit_group(db: &DB, frontiers: &Frontiers, group: PreparedWrite) {
     debug_assert!(!group.writes.is_empty(), "groups are never empty");
-    let PreparedWrite {
-        writes,
-        staged,
-        epoch: group_epoch,
-    } = group;
-    if group_epoch != epoch.load(Ordering::Acquire) {
-        // This group was assigned under a frontier an earlier commit failure has since abandoned
-        // (prepare can stage one wave ahead before it observes the bump). Rejecting it keeps the
-        // durable log gap-free; the requests never reached the DB, so the caller is told to
-        // retry, which re-allocates them fresh sequence numbers under the current epoch. Checked
-        // before the staging result so a stale group's own staging failure cannot bump the epoch
-        // again and spuriously reject the wave prepare has already re-synced.
-        if let Ok(staged) = &staged {
-            let _ = std::fs::remove_file(&staged.log);
-            let _ = std::fs::remove_file(&staged.state);
-        }
-        fail_assigned_writes(
-            writes,
-            "rocks write batch superseded by an earlier failure, retry".to_string(),
-        );
-        return CommitOutcome::Continue;
-    }
-    let staged = match staged {
-        Ok(staged) => staged,
-        Err(error) => {
-            epoch.fetch_add(1, Ordering::AcqRel);
-            fail_assigned_writes(writes, error);
-            return CommitOutcome::Continue;
-        }
-    };
-
+    let PreparedWrite { writes, staged } = group;
     let requests = writes.len();
     let last_sequence = writes
         .last()
@@ -728,31 +620,13 @@ fn commit_group(
 
     // Log first: its rows define durability, and an ingested state file without its log rows
     // could leave keys in the store that were never part of a sequenced batch.
-    if let Err(error) = ingest_staged_file(db, LOG_CF, &staged.log) {
-        // Nothing is durable (ingestion is atomic), so the numbers can be reclaimed: bump the
-        // epoch so in-flight groups are rejected and `prepare` re-syncs to the durable frontier.
-        let _ = std::fs::remove_file(&staged.state);
-        epoch.fetch_add(1, Ordering::AcqRel);
-        fail_assigned_writes(writes, error);
-        return CommitOutcome::Continue;
-    }
-    // Release so `prepare` re-syncs against a frontier whose log rows are already durable.
-    frontiers.durable.store(last_sequence, Ordering::Release);
+    ingest_staged_file(db, LOG_CF, &staged.log);
 
     // Ingest and publish under the floor lock: a prune loads the published frontier as its
     // state floor under the same lock, so no scan-visible state row can outrun the frontier
     // covering it (a key prune must never delete a row the floor does not cover).
-    let publish_guard = frontiers
-        .persist
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner);
-    if let Err(error) = ingest_staged_file(db, rocksdb::DEFAULT_COLUMN_FAMILY_NAME, &staged.state) {
-        // The log rows are durable but the state rows are not: the frontier freezes below this
-        // group so reads stay complete below the advertised sequence, and a restart repairs the
-        // state by replaying the group's log file.
-        fail_assigned_writes(writes, error);
-        return CommitOutcome::Poisoned;
-    }
+    let publish_guard = frontiers.persist.lock();
+    ingest_staged_file(db, rocksdb::DEFAULT_COLUMN_FAMILY_NAME, &staged.state);
 
     // Release so `current_sequence` readers only observe frontiers whose rows are readable.
     frontiers.published.store(last_sequence, Ordering::Release);
@@ -764,20 +638,22 @@ fn commit_group(
         "committed write batch"
     );
     complete_assigned_writes(writes);
-    CommitOutcome::Continue
 }
 
 /// Ingests one staged SST file into `cf`. Ingestion links the file into the column family and
-/// syncs the manifest, so the rows are durable and readable once this returns.
-fn ingest_staged_file(db: &DB, cf: &str, path: &Path) -> Result<(), String> {
-    let cf = db.cf_handle(cf).expect("CFs exist (created on open)");
+/// syncs the manifest, so the rows are durable and readable once this returns. Failure is fatal:
+/// see `commit_group`.
+fn ingest_staged_file(db: &DB, cf: &str, path: &Path) {
+    let handle = db.cf_handle(cf).expect("CFs exist (created on open)");
     let mut ingest_options = IngestExternalFileOptions::default();
     ingest_options.set_move_files(true);
-    if let Err(error) = db.ingest_external_file_cf_opts(cf, &ingest_options, vec![path]) {
-        let _ = std::fs::remove_file(path);
-        return Err(error.to_string());
-    }
-    Ok(())
+    db.ingest_external_file_cf_opts(handle, &ingest_options, vec![path])
+        .unwrap_or_else(|error| {
+            panic!(
+                "failed to ingest staged SST {} into {cf}: {error}",
+                path.display()
+            )
+        });
 }
 
 /// Writes a batch with sync enabled, used for the meta row that defines the durable floor.
@@ -881,20 +757,6 @@ fn replay_last_log_file(db: &DB, floor: u64) -> Result<(), String> {
         write_synced_batch(db, batch)?;
     }
     Ok(())
-}
-
-/// Sends the same assignment failure to every request in a wave.
-fn fail_requests(requests: Vec<WriteRequest>, error: String) {
-    for request in requests {
-        let _ = request.response.send(Err(error.clone()));
-    }
-}
-
-/// Fails every assigned write with the same error.
-fn fail_assigned_writes(writes: Vec<AssignedWrite>, error: String) {
-    for write in writes {
-        let _ = write.request.response.send(Err(error.clone()));
-    }
 }
 
 /// Resolves every assigned write with its own committed sequence number.
@@ -1004,6 +866,7 @@ impl RocksStore {
             db.clone(),
             ingest_dir,
             frontiers.clone(),
+            seq,
             write_pipeline,
         ));
         Ok(Self {
@@ -1027,15 +890,6 @@ impl RocksStore {
             .expect("meta CF must exist (created on open)")
     }
 
-    /// Serializes prunes: each loads the monotonic published frontier and persists it as the
-    /// state floor under this lock, so the floor never moves backward.
-    fn lock_persisted_floor(&self) -> Result<std::sync::MutexGuard<'_, ()>, String> {
-        self.frontiers
-            .persist
-            .lock()
-            .map_err(|e| format!("rocks prune lock poisoned: {e}"))
-    }
-
     /// Reads the current value for one default-column-family key.
     fn get_raw(&self, key: &[u8]) -> Result<Option<Vec<u8>>, rocksdb::Error> {
         self.db.get(key)
@@ -1050,7 +904,7 @@ impl RocksStore {
             return Ok(());
         }
 
-        let _guard = self.lock_persisted_floor()?;
+        let _guard = self.frontiers.persist.lock();
         let mut batch = rocksdb::WriteBatch::default();
         batch.put_cf(
             self.meta_cf(),
@@ -1071,7 +925,7 @@ impl RocksStore {
         if cutoff_exclusive == 0 {
             return Ok(());
         }
-        let _guard = self.lock_persisted_floor()?;
+        let _guard = self.frontiers.persist.lock();
         let cf = self.log_cf();
 
         // One synced, atomic batch: the range tombstone that logically deletes the rows, and the
@@ -1427,34 +1281,10 @@ mod tests {
         .encode_to_vec()
     }
 
-    /// Builds a group whose staging already failed, modeling a build failure for a contiguous
-    /// run of assigned sequence numbers tagged with `epoch`.
-    fn failing_group(
-        epoch: u64,
-        entries: &[(u64, &'static [u8], &'static [u8])],
-        error: &str,
-    ) -> (PreparedWrite, Vec<oneshot::Receiver<Result<u64, String>>>) {
-        let mut writes = Vec::new();
-        let mut receivers = Vec::new();
-        for (sequence, key, value) in entries {
-            let (write, receiver) = assigned_write_with_response(*sequence, key, value);
-            writes.push(write);
-            receivers.push(receiver);
-        }
-        (
-            PreparedWrite {
-                writes,
-                staged: Err(error.to_string()),
-                epoch,
-            },
-            receivers,
-        )
-    }
-
-    /// Commits one group through the commit stage, returning the durable frontier afterwards.
-    fn commit_and_apply(store: &RocksStore, epoch: &AtomicU64, group: PreparedWrite) -> u64 {
-        commit_group(&store.db, &store.frontiers, epoch, group);
-        store.frontiers.durable.load(Ordering::Acquire)
+    /// Commits one group through the commit stage, returning the published frontier afterwards.
+    fn commit_and_apply(store: &RocksStore, group: PreparedWrite) -> u64 {
+        commit_group(&store.db, &store.frontiers, group);
+        store.frontiers.published.load(Ordering::Acquire)
     }
 
     fn assigned_write(sequence: u64, key: &'static [u8], value: &'static [u8]) -> AssignedWrite {
@@ -1479,14 +1309,10 @@ mod tests {
         )
     }
 
-    fn prepared_write(store: &RocksStore, epoch: u64, writes: Vec<AssignedWrite>) -> PreparedWrite {
+    fn prepared_write(store: &RocksStore, writes: Vec<AssignedWrite>) -> PreparedWrite {
         let ingest_dir = store.db.path().join(LOG_INGEST_DIR);
-        let staged = stage_group_files(&ingest_dir, &writes, epoch);
-        PreparedWrite {
-            writes,
-            staged,
-            epoch,
-        }
+        let staged = stage_group_files(&ingest_dir, &writes);
+        PreparedWrite { writes, staged }
     }
 
     #[test]
@@ -1551,23 +1377,17 @@ mod tests {
         drop(sender);
 
         let first = receiver.recv().expect("first request");
-        let (group, disconnected) = match prepare_queued_write(
+        let (group, disconnected) = prepare_queued_write(
             dir.path(),
             &receiver,
             first,
             0,
             DEFAULT_COMMIT_COALESCE_MAX_BATCH_BYTES,
-            7,
-        ) {
-            Ok(prepared) => prepared,
-            Err((_, error)) => panic!("{error}"),
-        };
+        );
         assert_eq!(group.writes.len(), 3);
-        let staged = group.staged.expect("staged files");
-        assert!(staged.log.exists());
-        assert!(staged.state.exists());
-        assert!(staged.staged_bytes > 0);
-        assert_eq!(group.epoch, 7);
+        assert!(group.staged.log.exists());
+        assert!(group.staged.state.exists());
+        assert!(group.staged.staged_bytes > 0);
         assert!(disconnected);
     }
 
@@ -1581,16 +1401,10 @@ mod tests {
         drop(sender);
 
         let first = receiver.recv().expect("first request");
-        let (group, disconnected) =
-            match prepare_queued_write(dir.path(), &receiver, first, 0, 1, 7) {
-                Ok(prepared) => prepared,
-                Err((_, error)) => panic!("{error}"),
-            };
+        let (group, disconnected) = prepare_queued_write(dir.path(), &receiver, first, 0, 1);
 
         assert_eq!(group.writes.len(), 1);
         assert_eq!(group.writes[0].request.kvs[0].0.as_ref(), b"a");
-        assert!(group.staged.is_ok());
-        assert_eq!(group.epoch, 7);
         assert!(!disconnected);
         assert_eq!(
             receiver
@@ -1603,179 +1417,17 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn forward_group_fails_request_when_commit_stopped() {
+    /// A missing staged file makes ingestion fail, which is fatal: the group cannot be rolled
+    /// back once any of it is durable, and the next open repairs whatever the dead writer left.
+    #[test]
+    #[should_panic(expected = "failed to ingest staged SST")]
+    fn write_errors_are_fatal() {
         let dir = tempdir().expect("tempdir");
         let store = RocksStore::open(dir.path(), None).expect("open db");
-        let (group_sender, group_receiver) = mpsc::sync_channel(0);
-        drop(group_receiver);
 
-        let (write, result) = assigned_write_with_response(1, b"a", b"1");
-        let group = prepared_write(&store, 0, vec![write]);
-        let forwarded = forward_group(&group_sender, group);
-
-        assert!(!forwarded);
-        let error = result
-            .await
-            .expect("request should receive an explicit worker error")
-            .expect_err("request should fail");
-        assert_eq!(error, "rocks commit worker stopped");
-    }
-
-    #[tokio::test]
-    async fn failed_group_supersedes_epoch_and_frees_sequence_numbers() {
-        let dir = tempdir().expect("tempdir");
-        let store = RocksStore::open(dir.path(), None).expect("open db");
-        let epoch = AtomicU64::new(0);
-
-        // A group that cannot commit (modeled with an already-failed batch) at sequences 1 and 2.
-        let (group, receivers) = failing_group(0, &[(1, b"a", b"1"), (2, b"b", b"2")], "disk full");
-        let committed = commit_and_apply(&store, &epoch, group);
-
-        // Nothing was published, and the epoch advanced so the abandoned numbers can be re-used.
-        assert_eq!(committed, 0);
-        assert_eq!(store.current_sequence(), 0);
-        assert_eq!(epoch.load(Ordering::Acquire), 1);
-        for receiver in receivers {
-            assert_eq!(
-                receiver.await.expect("response"),
-                Err("disk full".to_string())
-            );
-        }
-
-        // The next epoch re-allocates sequences 1 and 2 to fresh requests, which commit cleanly.
-        let (write_x, result_x) = assigned_write_with_response(1, b"x", b"24");
-        let (write_y, result_y) = assigned_write_with_response(2, b"y", b"25");
-        let group = prepared_write(&store, 1, vec![write_x, write_y]);
-        let committed = commit_and_apply(&store, &epoch, group);
-
-        assert_eq!(committed, 2);
-        assert_eq!(store.current_sequence(), 2);
-        assert_eq!(result_x.await.expect("response"), Ok(1));
-        assert_eq!(result_y.await.expect("response"), Ok(2));
-        assert_eq!(
-            batch_entries(store.get_batch(1).await.expect("get").expect("retained")),
-            vec![(Bytes::from_static(b"x"), Bytes::from_static(b"24"))]
-        );
-        assert_eq!(
-            batch_entries(store.get_batch(2).await.expect("get").expect("retained")),
-            vec![(Bytes::from_static(b"y"), Bytes::from_static(b"25"))]
-        );
-    }
-
-    #[tokio::test]
-    async fn superseded_epoch_group_is_rejected_without_write() {
-        let dir = tempdir().expect("tempdir");
-        let store = RocksStore::open(dir.path(), None).expect("open db");
-        // The current epoch is 1: an earlier failure already superseded epoch 0.
-        let epoch = AtomicU64::new(1);
-
-        let (write, result) = assigned_write_with_response(1, b"a", b"1");
-        let group = prepared_write(&store, 0, vec![write]);
-        let committed = commit_and_apply(&store, &epoch, group);
-
-        assert_eq!(committed, 0);
-        assert_eq!(store.current_sequence(), 0);
-        assert_eq!(epoch.load(Ordering::Acquire), 1);
-        assert_eq!(
-            result.await.expect("response"),
-            Err("rocks write batch superseded by an earlier failure, retry".to_string())
-        );
-        assert!(store.get_batch(1).await.expect("get").is_none());
-    }
-
-    #[tokio::test]
-    async fn stale_group_with_staging_error_does_not_bump_epoch() {
-        let dir = tempdir().expect("tempdir");
-        let store = RocksStore::open(dir.path(), None).expect("open db");
-        // The current epoch is 1: an earlier failure already superseded epoch 0.
-        let epoch = AtomicU64::new(1);
-
-        let (group, receivers) = failing_group(0, &[(1, b"a", b"1")], "disk full");
-        let committed = commit_and_apply(&store, &epoch, group);
-
-        // The stale group is rejected as superseded; its own staging error must not bump the
-        // epoch again, which would spuriously reject the wave prepare re-synced under epoch 1.
-        assert_eq!(committed, 0);
-        assert_eq!(epoch.load(Ordering::Acquire), 1);
-        for receiver in receivers {
-            assert_eq!(
-                receiver.await.expect("response"),
-                Err("rocks write batch superseded by an earlier failure, retry".to_string())
-            );
-        }
-    }
-
-    #[tokio::test]
-    async fn writer_reallocates_sequence_numbers_after_failed_batch() {
-        let dir = tempdir().expect("tempdir");
-        let store = RocksStore::open(dir.path(), None).expect("open db");
-        let epoch = AtomicU64::new(5);
-
-        // Two successive failures both abandon sequence 1 without ever consuming it.
-        for attempt in [b"first" as &[u8], b"second"] {
-            let current = epoch.load(Ordering::Acquire);
-            let (group, receivers) = failing_group(current, &[(1, b"k", b"v")], "boom");
-            let committed = commit_and_apply(&store, &epoch, group);
-            assert_eq!(
-                committed, 0,
-                "attempt {attempt:?} must not advance the frontier"
-            );
-            assert_eq!(epoch.load(Ordering::Acquire), current + 1);
-            for receiver in receivers {
-                assert_eq!(receiver.await.expect("response"), Err("boom".to_string()));
-            }
-        }
-
-        // The first durable write still takes sequence 1.
-        let current = epoch.load(Ordering::Acquire);
-        let (write, result) = assigned_write_with_response(1, b"k", b"v");
-        let group = prepared_write(&store, current, vec![write]);
-        let committed = commit_and_apply(&store, &epoch, group);
-        assert_eq!(committed, 1);
-        assert_eq!(result.await.expect("response"), Ok(1));
-        assert_eq!(store.current_sequence(), 1);
-    }
-
-    #[tokio::test]
-    async fn reused_sequence_overwrites_abandoned_log_row() {
-        let dir = tempdir().expect("tempdir");
-        let store = RocksStore::open(dir.path(), None).expect("open db");
-        let epoch = AtomicU64::new(0);
-
-        // Model an abandoned sequence index: the durable frontier is still 0, but a row
-        // already exists at the next log key and must be replaced by the successful retry.
-        store
-            .db
-            .put_cf(
-                store.log_cf(),
-                sequence_log_key(1),
-                encoded_log_entry(1, b"k", b"stale"),
-            )
-            .expect("seed abandoned log row");
-        // Rows above the visible frontier are unreadable, so the abandoned row cannot leak.
-        assert!(store.get_batch(1).await.expect("get").is_none());
-
-        let (failed, receivers) = failing_group(0, &[(1, b"k", b"failed")], "boom");
-        let committed = commit_and_apply(&store, &epoch, failed);
-        assert_eq!(committed, 0);
-        assert_eq!(store.current_sequence(), 0);
-        assert_eq!(epoch.load(Ordering::Acquire), 1);
-        for receiver in receivers {
-            assert_eq!(receiver.await.expect("response"), Err("boom".to_string()));
-        }
-
-        let (write, result) = assigned_write_with_response(1, b"k", b"new");
-        let group = prepared_write(&store, 1, vec![write]);
-        let committed = commit_and_apply(&store, &epoch, group);
-
-        assert_eq!(committed, 1);
-        assert_eq!(result.await.expect("response"), Ok(1));
-        assert_eq!(store.current_sequence(), 1);
-        assert_eq!(
-            batch_entries(store.get_batch(1).await.expect("get").expect("retained")),
-            vec![(Bytes::from_static(b"k"), Bytes::from_static(b"new"))]
-        );
+        let group = prepared_write(&store, vec![assigned_write(1, b"a", b"1")]);
+        std::fs::remove_file(&group.staged.state).expect("sabotage staged state file");
+        commit_and_apply(&store, group);
     }
 
     /// One multi-megabyte batch, sized to exercise multi-block ingested log SSTs.
@@ -1960,10 +1612,8 @@ mod tests {
     async fn prepared_write_preserves_contiguous_sequence_logs() {
         let dir = tempdir().expect("tempdir");
         let store = RocksStore::open(dir.path(), None).expect("open db");
-        let epoch = AtomicU64::new(0);
         let prepared = prepared_write(
             &store,
-            0,
             vec![
                 assigned_write(1, b"a", b"1"),
                 assigned_write(2, b"b", b"2"),
@@ -1972,8 +1622,7 @@ mod tests {
         );
 
         assert_eq!(prepared.writes.len(), 3);
-        assert!(prepared.staged.is_ok());
-        let committed = commit_and_apply(&store, &epoch, prepared);
+        let committed = commit_and_apply(&store, prepared);
         assert_eq!(committed, 3);
 
         assert_eq!(store.current_sequence(), 3);
@@ -2032,6 +1681,38 @@ mod tests {
             }
         }
         assert_eq!(logged_keys, (0u8..32).collect::<BTreeSet<_>>());
+    }
+
+    #[tokio::test]
+    async fn sequence_prune_spares_log_rows_above_published_frontier() {
+        let dir = tempdir().expect("tempdir");
+        let store = RocksStore::open(dir.path(), None).expect("open db");
+        // A durable log row whose group never published (its state ingestion was in flight at a
+        // crash): pruning must spare it — it is the repair replay's input at the next open.
+        store
+            .db
+            .put_cf(
+                store.log_cf(),
+                sequence_log_key(1),
+                encoded_log_entry(1, b"k", b"v"),
+            )
+            .expect("seed log row");
+
+        store
+            .apply_prune_policies(PrunePolicyDocument {
+                version: exoware_sdk::prune_policy::PRUNE_POLICY_DOCUMENT_VERSION,
+                policies: vec![exoware_sdk::prune_policy::PrunePolicy {
+                    scope: PolicyScope::Sequence,
+                    retain: RetainPolicy::DropAll,
+                }],
+            })
+            .expect("prune");
+
+        let survivors = store
+            .db
+            .iterator_cf(store.log_cf(), IteratorMode::Start)
+            .count();
+        assert_eq!(survivors, 1, "unpublished log row must survive the prune");
     }
 
     #[tokio::test]

--- a/examples/simulator/src/rocks.rs
+++ b/examples/simulator/src/rocks.rs
@@ -5,11 +5,13 @@
 //! service's `Sequence` scope.
 //!
 //! Durability is anchored on the replay log: each commit group makes its log rows durable first
-//! (an ingested SST file followed by a synced write of the durable-sequence meta row), then the
-//! current-state rows are applied without a WAL and the visible sequence frontier advances. The
-//! state rows are recovered from the log, so `open` replays retained log rows above the persisted
-//! state-flushed watermark, and pruning flushes the default column family (advancing that
-//! watermark) before deleting log rows it may otherwise still need for recovery.
+//! (one SST file ingested into the log column family), then the current-state rows are applied
+//! without a WAL and the visible sequence frontier advances. The log rows themselves define the
+//! durable frontier — `open` derives it from the highest retained row and the sequence meta row,
+//! which is only persisted when rows may go away (pruning) or applied state may be lost (writer
+//! shutdown). State rows are recovered from the log, so `open` replays retained log rows above
+//! the persisted state-flushed watermark, and pruning flushes the default column family
+//! (advancing that watermark) before deleting log rows it may otherwise still need for recovery.
 
 use std::cmp::Ordering as CmpOrdering;
 use std::collections::BTreeMap;
@@ -39,6 +41,9 @@ use tokio::sync::oneshot;
 use tracing::debug;
 
 const META_CF: &str = "meta";
+/// Durable-sequence floor. The frontier at open is the maximum of this row and the highest
+/// retained log row, so it is only persisted when log rows may be deleted (pruning) or the
+/// process winds down; commits never write it.
 const SEQ_META_KEY: &[u8] = b"sequence";
 /// Highest sequence whose current-state rows are durable in the default column family (flushed to
 /// SSTs). Recovery replays retained log rows above this watermark to rebuild the state rows that
@@ -290,6 +295,35 @@ fn keys_to_delete(
     }
 }
 
+/// Sequence frontiers shared by the store and its writer stages.
+struct Frontiers {
+    /// Highest sequence readers may observe: log rows durable and state rows applied.
+    published: AtomicU64,
+    /// Highest sequence whose log rows are durable. Runs ahead of `published` while state
+    /// application is in flight; re-derived at open from the retained log rows and the sequence
+    /// meta row.
+    durable: AtomicU64,
+    /// Highest sequence whose state rows are flushed to SSTs (the recovery-replay lower bound).
+    flushed: AtomicU64,
+    /// Highest durable-sequence value written to the meta row, so an unchanged store can skip
+    /// the flush and synced write entirely.
+    persisted_durable: AtomicU64,
+    /// Serializes frontier persistence so the meta rows never move backward.
+    persist: Mutex<()>,
+}
+
+impl Frontiers {
+    fn new(durable: u64, flushed: u64, persisted_durable: u64) -> Self {
+        Self {
+            published: AtomicU64::new(durable),
+            durable: AtomicU64::new(durable),
+            flushed: AtomicU64::new(flushed),
+            persisted_durable: AtomicU64::new(persisted_durable),
+            persist: Mutex::new(()),
+        }
+    }
+}
+
 struct WriteRequest {
     kvs: Vec<(Bytes, Bytes)>,
     response: oneshot::Sender<Result<u64, String>>,
@@ -331,24 +365,22 @@ struct Writer {
 impl Writer {
     /// Starts the three-stage write pipeline. `prepare` drains queued requests up to the
     /// configured byte cap, assigns a contiguous sequence number to each, and builds each wave's
-    /// state batch and encoded log rows; `commit` makes each group's log rows durable (an
-    /// ingested SST followed by a synced meta write), publishing the durable frontier; `apply`
-    /// inserts the state rows without a WAL, advances the visible frontier, and resolves the
-    /// requests. The stages overlap, so while one group is being synced the next is being built
-    /// and the previous group's state rows are being applied.
+    /// state batch and encoded log rows; `commit` makes each group's log rows durable (one
+    /// ingested SST), publishing the durable frontier; `apply` inserts the state rows without a
+    /// WAL, advances the visible frontier, and resolves the requests. The stages overlap, so
+    /// while one group is being synced the next is being built and the previous group's state
+    /// rows are being applied.
     fn start(
         db: Arc<DB>,
         ingest_dir: PathBuf,
-        sequence: Arc<AtomicU64>,
-        durable: Arc<AtomicU64>,
-        flushed: Arc<AtomicU64>,
+        frontiers: Arc<Frontiers>,
         write_pipeline: RocksWritePipelineConfig,
     ) -> Self {
         let (request_sender, request_receiver) = mpsc::channel();
         // Rendezvous so `prepare` runs at most one wave ahead of `commit`: it hands off a built
         // group, then builds the next while `commit` syncs this one.
         let (group_sender, group_receiver) = mpsc::sync_channel(0);
-        // Allow `commit` to fsync the next group while `apply` inserts this group's state rows.
+        // Allow `commit` to sync the next group while `apply` inserts this group's state rows.
         let (committed_sender, committed_receiver) = mpsc::sync_channel(1);
         let max_commit_batch_bytes = write_pipeline.max_commit_batch_bytes.get();
 
@@ -358,13 +390,13 @@ impl Writer {
         let epoch = Arc::new(AtomicU64::new(0));
 
         let apply_db = db.clone();
-        let apply_sequence = sequence.clone();
+        let apply_frontiers = frontiers.clone();
         let apply = thread::Builder::new()
             .name("simulator-rocks-apply".to_string())
-            .spawn(move || run_apply(apply_db, apply_sequence, flushed, committed_receiver))
+            .spawn(move || run_apply(apply_db, apply_frontiers, committed_receiver))
             .expect("failed to spawn RocksDB apply worker");
 
-        let commit_durable = durable.clone();
+        let commit_frontiers = frontiers.clone();
         let commit_epoch = epoch.clone();
         let commit = thread::Builder::new()
             .name("simulator-rocks-commit".to_string())
@@ -372,7 +404,7 @@ impl Writer {
                 run_commit(
                     db,
                     ingest_dir,
-                    commit_durable,
+                    commit_frontiers,
                     commit_epoch,
                     group_receiver,
                     committed_sender,
@@ -384,7 +416,7 @@ impl Writer {
             .name("simulator-rocks-prepare".to_string())
             .spawn(move || {
                 run_prepare(
-                    durable,
+                    frontiers,
                     epoch,
                     request_receiver,
                     group_sender,
@@ -401,6 +433,12 @@ impl Writer {
 
     /// Enqueues one ingest request and resolves once `commit` has durably published it.
     async fn put_batch(&self, kvs: Vec<(Bytes, Bytes)>) -> Result<u64, String> {
+        // An empty batch has no log row, so its sequence number could not be re-derived from the
+        // log after a crash; rejecting it keeps every acked sequence recoverable. The RPC layer
+        // already requires at least one entry per put.
+        if kvs.is_empty() {
+            return Err("cannot ingest an empty batch".to_string());
+        }
         let (response, result) = oneshot::channel();
         let sender = self
             .sender
@@ -439,22 +477,23 @@ impl Drop for Writer {
 /// next wave re-syncs `next` to the durable frontier so the abandoned sequence numbers are
 /// re-allocated.
 fn run_prepare(
-    durable: Arc<AtomicU64>,
+    frontiers: Arc<Frontiers>,
     epoch: Arc<AtomicU64>,
     receiver: mpsc::Receiver<WriteRequest>,
     sender: mpsc::SyncSender<PreparedWrite>,
     max_commit_batch_bytes: usize,
 ) {
-    let mut next = durable.load(Ordering::Acquire);
+    let mut next = frontiers.durable.load(Ordering::Acquire);
     let mut seen_epoch = epoch.load(Ordering::Acquire);
 
     while let Ok(first) = receiver.recv() {
         let current_epoch = epoch.load(Ordering::Acquire);
         if current_epoch != seen_epoch {
-            // A commit failed: each group commits its log rows and meta in order, so nothing
-            // past the durable frontier persisted, and the failed numbers can be reclaimed.
+            // A commit failed: each group commits its log rows atomically (one ingested file),
+            // so nothing past the durable frontier persisted, and the failed numbers can be
+            // reclaimed.
             seen_epoch = current_epoch;
-            next = durable.load(Ordering::Acquire);
+            next = frontiers.durable.load(Ordering::Acquire);
         }
 
         let (group, disconnected) = match prepare_queued_write(
@@ -561,21 +600,22 @@ fn forward_group(sender: &mpsc::SyncSender<PreparedWrite>, group: PreparedWrite)
     true
 }
 
-/// Commits prepared groups one at a time (ingested log SST, then a synced meta write), publishing
-/// the durable frontier after each success and handing the group to `apply`. A group whose epoch
-/// was superseded by an earlier failure is rejected without being written; a failing group bumps
-/// the epoch so its frontier (and every later group assigned under it) is abandoned and
-/// re-allocated by `prepare`.
+/// Commits prepared groups one at a time (one ingested log SST each), publishing the durable
+/// frontier after each success and handing the group to `apply`. A group whose epoch was
+/// superseded by an earlier failure is rejected without being written; a failing group bumps the
+/// epoch so its frontier (and every later group assigned under it) is abandoned and re-allocated
+/// by `prepare`.
 fn run_commit(
     db: Arc<DB>,
     ingest_dir: PathBuf,
-    durable: Arc<AtomicU64>,
+    frontiers: Arc<Frontiers>,
     epoch: Arc<AtomicU64>,
     receiver: mpsc::Receiver<PreparedWrite>,
     committed_sender: mpsc::SyncSender<CommittedWrite>,
 ) {
     while let Ok(group) = receiver.recv() {
-        let Some(committed) = commit_group(&db, &ingest_dir, &durable, &epoch, group) else {
+        let Some(committed) = commit_group(&db, &ingest_dir, &frontiers.durable, &epoch, group)
+        else {
             continue;
         };
         if let Err(error) = committed_sender.send(committed) {
@@ -661,20 +701,15 @@ fn commit_group(
 }
 
 /// Applies committed state batches in commit order, advancing the visible frontier and resolving
-/// requests after each group's rows are readable. On loop exit the applied rows are flushed so a
-/// clean reopen can skip the recovery replay.
-fn run_apply(
-    db: Arc<DB>,
-    sequence: Arc<AtomicU64>,
-    flushed: Arc<AtomicU64>,
-    receiver: mpsc::Receiver<CommittedWrite>,
-) {
+/// requests after each group's rows are readable. On loop exit the frontiers are persisted (with
+/// a state flush) so a clean reopen can skip the recovery replay.
+fn run_apply(db: Arc<DB>, frontiers: Arc<Frontiers>, receiver: mpsc::Receiver<CommittedWrite>) {
     let mut poisoned = None;
     while let Ok(committed) = receiver.recv() {
-        apply_committed_write(&db, &sequence, &mut poisoned, committed);
+        apply_committed_write(&db, &frontiers.published, &mut poisoned, committed);
     }
     if poisoned.is_none() {
-        if let Err(error) = advance_state_flushed(&db, &flushed, sequence.load(Ordering::Acquire)) {
+        if let Err(error) = persist_frontiers(&db, &frontiers) {
             debug!(error = %error, "failed to flush state rows on writer shutdown");
         }
     }
@@ -720,13 +755,6 @@ fn append_state_entries(state_batch: &mut rocksdb::WriteBatch, requests: &[Write
     }
 }
 
-fn append_sequence_meta(db: &DB, batch: &mut rocksdb::WriteBatch, sequence: u64) {
-    let meta_cf = db
-        .cf_handle(META_CF)
-        .expect("meta CF must exist (created on open)");
-    batch.put_cf(meta_cf, SEQ_META_KEY, sequence.to_le_bytes());
-}
-
 /// Writes a batch with sync enabled, used for the meta rows that define durable frontiers.
 fn write_synced_batch(db: &DB, batch: rocksdb::WriteBatch) -> Result<(), String> {
     let mut write_options = WriteOptions::default();
@@ -735,11 +763,10 @@ fn write_synced_batch(db: &DB, batch: rocksdb::WriteBatch) -> Result<(), String>
         .map_err(|e| e.to_string())
 }
 
-/// Commits one group's log rows by writing them as an SST file, ingesting it into the log column
-/// family, and then durably advancing the sequence meta row. Ingestion syncs the file and the
-/// manifest, so the rows are durable before the meta write publishes them; if the meta write is
-/// lost, the orphaned rows sit above the durable frontier where `get_batch` cannot see them and
-/// `open` deletes them. A group whose requests carried no rows only advances the meta row.
+/// Commits one group's log rows by writing them as an SST file and ingesting it into the log
+/// column family. Ingestion syncs the file and the manifest before returning, so the rows — and
+/// with them the sequence numbers `open` re-derives from the retained log — are durable; no
+/// separate meta write (and fsync) is needed on the commit path.
 fn ingest_log_rows(
     db: &DB,
     ingest_dir: &Path,
@@ -747,39 +774,38 @@ fn ingest_log_rows(
     last_sequence: u64,
     epoch: u64,
 ) -> Result<(), String> {
-    if let Some((first, _)) = log_rows.first() {
-        // Leftover files from failed ingestions are deleted when the store reopens, and epochs
-        // make re-allocated sequence numbers unambiguous within one writer's lifetime.
-        let path = ingest_dir.join(format!("log-{first:020}-{last_sequence:020}-e{epoch}.sst"));
+    let first = log_rows
+        .first()
+        .expect("groups always carry log rows (empty batches are rejected on entry)")
+        .0;
+    // Leftover files from failed ingestions are deleted when the store reopens, and epochs make
+    // re-allocated sequence numbers unambiguous within one writer's lifetime.
+    let path = ingest_dir.join(format!("log-{first:020}-{last_sequence:020}-e{epoch}.sst"));
 
-        // Uncompressed for parity with what a WAL write would cost; compressing on the commit
-        // path would trade ack latency for bytes.
-        let mut options = Options::default();
-        options.set_compression_type(DBCompressionType::None);
-        let mut writer = SstFileWriter::create(&options);
-        writer.open(&path).map_err(|e| e.to_string())?;
-        for (sequence, value) in &log_rows {
-            writer
-                .put(sequence_log_key(*sequence), value)
-                .map_err(|e| e.to_string())?;
-        }
-        // `finish` syncs the file before it is linked into the DB.
-        writer.finish().map_err(|e| e.to_string())?;
-
-        let log_cf = db
-            .cf_handle(LOG_CF)
-            .expect("log CF must exist (created on open)");
-        let mut ingest_options = IngestExternalFileOptions::default();
-        ingest_options.set_move_files(true);
-        if let Err(error) = db.ingest_external_file_cf_opts(log_cf, &ingest_options, vec![&path]) {
-            let _ = std::fs::remove_file(&path);
-            return Err(error.to_string());
-        }
+    // Uncompressed for parity with what a WAL write would cost; compressing on the commit path
+    // would trade ack latency for bytes.
+    let mut options = Options::default();
+    options.set_compression_type(DBCompressionType::None);
+    let mut writer = SstFileWriter::create(&options);
+    writer.open(&path).map_err(|e| e.to_string())?;
+    for (sequence, value) in &log_rows {
+        writer
+            .put(sequence_log_key(*sequence), value)
+            .map_err(|e| e.to_string())?;
     }
+    // `finish` syncs the file before it is linked into the DB.
+    writer.finish().map_err(|e| e.to_string())?;
 
-    let mut meta_batch = rocksdb::WriteBatch::default();
-    append_sequence_meta(db, &mut meta_batch, last_sequence);
-    write_synced_batch(db, meta_batch)
+    let log_cf = db
+        .cf_handle(LOG_CF)
+        .expect("log CF must exist (created on open)");
+    let mut ingest_options = IngestExternalFileOptions::default();
+    ingest_options.set_move_files(true);
+    if let Err(error) = db.ingest_external_file_cf_opts(log_cf, &ingest_options, vec![&path]) {
+        let _ = std::fs::remove_file(&path);
+        return Err(error.to_string());
+    }
+    Ok(())
 }
 
 /// Writes current-state rows without a WAL: durability comes from the already-synced log batch,
@@ -791,25 +817,42 @@ fn write_state_batch(db: &DB, batch: rocksdb::WriteBatch) -> Result<(), String> 
         .map_err(|e| e.to_string())
 }
 
-/// Makes every state row at or below `target` durable in the default column family, then persists
-/// and mirrors the watermark. Recovery replays retained log rows above this watermark, so it must
-/// only advance after the flush completes.
-fn advance_state_flushed(db: &DB, flushed: &AtomicU64, target: u64) -> Result<(), String> {
-    if flushed.load(Ordering::Acquire) >= target {
+/// Persists the sequence frontiers with one synced meta write: the durable-sequence floor (so a
+/// later log prune cannot regress the frontier `open` re-derives from retained rows) and the
+/// state-flushed watermark, flushing the default column family first so every published state row
+/// is in SSTs. Recovery replays retained log rows above the watermark, so the watermark must only
+/// advance after the flush completes; the lock keeps concurrent callers from persisting stale,
+/// lower values over newer ones.
+fn persist_frontiers(db: &DB, frontiers: &Frontiers) -> Result<(), String> {
+    let _guard = frontiers
+        .persist
+        .lock()
+        .map_err(|e| format!("rocks frontier persist lock poisoned: {e}"))?;
+    let published = frontiers.published.load(Ordering::Acquire);
+    let durable = frontiers.durable.load(Ordering::Acquire);
+    if frontiers.flushed.load(Ordering::Acquire) >= published
+        && frontiers.persisted_durable.load(Ordering::Acquire) >= durable
+    {
         return Ok(());
     }
-    let default_cf = db
-        .cf_handle(rocksdb::DEFAULT_COLUMN_FAMILY_NAME)
-        .expect("default CF must exist (created on open)");
-    db.flush_cf(default_cf).map_err(|e| e.to_string())?;
+    if frontiers.flushed.load(Ordering::Acquire) < published {
+        let default_cf = db
+            .cf_handle(rocksdb::DEFAULT_COLUMN_FAMILY_NAME)
+            .expect("default CF must exist (created on open)");
+        db.flush_cf(default_cf).map_err(|e| e.to_string())?;
+    }
 
     let meta_cf = db
         .cf_handle(META_CF)
         .expect("meta CF must exist (created on open)");
     let mut batch = rocksdb::WriteBatch::default();
-    batch.put_cf(meta_cf, STATE_FLUSHED_META_KEY, target.to_le_bytes());
+    batch.put_cf(meta_cf, SEQ_META_KEY, durable.to_le_bytes());
+    batch.put_cf(meta_cf, STATE_FLUSHED_META_KEY, published.to_le_bytes());
     write_synced_batch(db, batch)?;
-    flushed.fetch_max(target, Ordering::AcqRel);
+    frontiers.flushed.fetch_max(published, Ordering::AcqRel);
+    frontiers
+        .persisted_durable
+        .fetch_max(durable, Ordering::AcqRel);
     Ok(())
 }
 
@@ -829,25 +872,21 @@ fn prepare_ingest_dir(store_path: &Path) -> Result<PathBuf, String> {
     Ok(ingest_dir)
 }
 
-/// Deletes log rows above the durable frontier. A crash between an SST ingestion and its meta
-/// write can leave rows whose sequences were never published; those numbers will be re-allocated,
-/// so the abandoned rows must not resurface.
-fn remove_log_rows_above(db: &DB, durable: u64) -> Result<(), String> {
+/// Returns the sequence of the highest retained log row, or zero when the log is empty. Rows are
+/// only ever ingested by sequential, atomic commits, so the highest retained row is a lower bound
+/// on the durable frontier (pruning persists the sequence meta row before deleting rows, so the
+/// meta row covers whatever was pruned).
+fn highest_log_row(db: &DB) -> Result<u64, String> {
     let log_cf = db
         .cf_handle(LOG_CF)
         .expect("log CF must exist (created on open)");
-    if durable == u64::MAX {
-        return Ok(());
+    match db.iterator_cf(log_cf, IteratorMode::End).next() {
+        None => Ok(0),
+        Some(item) => {
+            let (key, _) = item.map_err(|e| e.to_string())?;
+            sequence_from_log_key(key.as_ref())
+        }
     }
-    let start = sequence_log_key(durable + 1);
-    let mut stale = db.iterator_cf(log_cf, IteratorMode::From(&start, Direction::Forward));
-    if stale.next().is_none() {
-        return Ok(());
-    }
-    db.delete_range_cf(log_cf, start, sequence_log_key(u64::MAX))
-        .map_err(|e| e.to_string())?;
-    db.delete_cf(log_cf, sequence_log_key(u64::MAX))
-        .map_err(|e| e.to_string())
 }
 
 /// Reads a little-endian u64 sequence value from the meta column family, defaulting to zero.
@@ -976,14 +1015,14 @@ impl Default for RocksConfig {
 #[derive(Clone)]
 pub struct RocksStore {
     db: Arc<DB>,
-    sequence: Arc<AtomicU64>,
-    flushed: Arc<AtomicU64>,
+    frontiers: Arc<Frontiers>,
     writer: Arc<Writer>,
 }
 
 impl RocksStore {
     /// Open the store with stock RocksDB defaults, unless `config` overrides
-    /// the database and column-family options. Replays retained log rows above the state-flushed
+    /// the database and column-family options. Re-derives the durable frontier from the retained
+    /// log rows and the sequence meta row, then replays log rows above the state-flushed
     /// watermark into the default column family so the current state is complete below the
     /// durable sequence even after a crash that lost un-flushed (WAL-less) state rows.
     pub fn open(path: &Path, config: Option<RocksConfig>) -> Result<Self, String> {
@@ -1006,32 +1045,28 @@ impl RocksStore {
             DB::open_cf_descriptors(&db_options, path, vec![cf_default, cf_meta, cf_log])
                 .map_err(|e| e.to_string())?,
         );
-        let seq = read_meta_sequence(&db, SEQ_META_KEY)?;
+        // Commits do not write the sequence meta row; the log rows are the durable record.
+        let meta_seq = read_meta_sequence(&db, SEQ_META_KEY)?;
+        let seq = meta_seq.max(highest_log_row(&db)?);
         let flushed_seq = read_meta_sequence(&db, STATE_FLUSHED_META_KEY)?;
 
         let ingest_dir = prepare_ingest_dir(path)?;
-        remove_log_rows_above(&db, seq)?;
 
-        let flushed = Arc::new(AtomicU64::new(flushed_seq));
+        let frontiers = Arc::new(Frontiers::new(seq, flushed_seq, meta_seq));
         if flushed_seq < seq {
             replay_state_from_log(&db, flushed_seq, seq)?;
-            advance_state_flushed(&db, &flushed, seq)?;
+            persist_frontiers(&db, &frontiers)?;
         }
 
-        let sequence = Arc::new(AtomicU64::new(seq));
-        let durable = Arc::new(AtomicU64::new(seq));
         let writer = Arc::new(Writer::start(
             db.clone(),
             ingest_dir,
-            sequence.clone(),
-            durable,
-            flushed.clone(),
+            frontiers.clone(),
             write_pipeline,
         ));
         Ok(Self {
             db,
-            sequence,
-            flushed,
+            frontiers,
             writer,
         })
     }
@@ -1141,21 +1176,17 @@ impl RocksStore {
         self.delete_keys(&all_deletes).map_err(|e| e.to_string())?;
         // Flush so a crash-recovery replay (which starts above the watermark) cannot re-apply the
         // puts of keys this policy just deleted.
-        advance_state_flushed(
-            &self.db,
-            &self.flushed,
-            self.sequence.load(Ordering::Acquire),
-        )
+        persist_frontiers(&self.db, &self.frontiers)
     }
 
     /// Computes the replay-log cutoff for a sequence policy and prunes only log rows.
     fn apply_sequence_prune_policy(&self, retain: &RetainPolicy) -> Result<(), String> {
-        let current = self.sequence.load(Ordering::Acquire);
+        let current = self.frontiers.published.load(Ordering::Acquire);
         // Log rows below the cutoff may still be needed to rebuild WAL-less state rows after a
-        // crash. Flushing first makes those state rows durable, so deleting their log rows is
-        // safe; the watermark write precedes the range delete in the WAL, preserving that order
-        // across a crash.
-        advance_state_flushed(&self.db, &self.flushed, current)?;
+        // crash, and `open` re-derives the durable frontier from the retained rows, so both
+        // frontiers must be persisted (with a state flush) before rows are deleted; the meta
+        // write precedes the range delete in the WAL, preserving that order across a crash.
+        persist_frontiers(&self.db, &self.frontiers)?;
         let cutoff_exclusive = match retain {
             RetainPolicy::KeepLatest { count } => {
                 let count = *count as u64;
@@ -1167,15 +1198,19 @@ impl RocksStore {
         };
         // Never delete log rows above the flushed watermark: sequences committed but not yet
         // visible may still need them to rebuild their WAL-less state rows after a crash.
-        let cutoff_exclusive =
-            cutoff_exclusive.min(self.flushed.load(Ordering::Acquire).saturating_add(1));
+        let cutoff_exclusive = cutoff_exclusive.min(
+            self.frontiers
+                .flushed
+                .load(Ordering::Acquire)
+                .saturating_add(1),
+        );
         self.prune_log(cutoff_exclusive)
     }
 }
 
 impl Sequence for RocksStore {
     fn current_sequence(&self) -> u64 {
-        self.sequence.load(Ordering::Acquire)
+        self.frontiers.published.load(Ordering::Acquire)
     }
 }
 
@@ -1238,8 +1273,8 @@ impl Prune for RocksStore {
 impl Log for RocksStore {
     async fn get_batch(&self, sequence_number: u64) -> Result<Option<LogBatch>, String> {
         // Serve only published batches: rows above the visible frontier are still being
-        // committed (or were abandoned by a crash) and must not be observable early.
-        if sequence_number > self.sequence.load(Ordering::Acquire) {
+        // committed and must not be observable early.
+        if sequence_number > self.frontiers.published.load(Ordering::Acquire) {
             return Ok(None);
         }
         let store = self.clone();
@@ -1380,6 +1415,13 @@ mod tests {
     use exoware_server::{Ingest, Log, Sequence};
     use tempfile::tempdir;
 
+    fn append_sequence_meta(db: &DB, batch: &mut rocksdb::WriteBatch, sequence: u64) {
+        let meta_cf = db
+            .cf_handle(META_CF)
+            .expect("meta CF must exist (created on open)");
+        batch.put_cf(meta_cf, SEQ_META_KEY, sequence.to_le_bytes());
+    }
+
     fn write_request(key: &'static [u8]) -> WriteRequest {
         let (response, _result) = oneshot::channel();
         WriteRequest {
@@ -1453,7 +1495,7 @@ mod tests {
     ) -> u64 {
         let ingest_dir = store.db.path().join(LOG_INGEST_DIR);
         if let Some(committed) = commit_group(&store.db, &ingest_dir, durable, epoch, group) {
-            apply_committed_write(&store.db, &store.sequence, &mut None, committed);
+            apply_committed_write(&store.db, &store.frontiers.published, &mut None, committed);
         }
         durable.load(Ordering::Acquire)
     }
@@ -1882,8 +1924,10 @@ mod tests {
                 .expect("put");
 
             // Simulate a crash that lost the WAL-less state rows for sequences 2 and 3 but kept
-            // the synced log batches: append the log rows and durable-sequence meta directly,
-            // bypassing the state apply stage.
+            // the durable log rows: append them directly, bypassing the state apply stage. No
+            // sequence meta row is written — the reopened store must re-derive the durable
+            // frontier from the retained rows alone, exactly as after a real crash (commits
+            // never write the meta row).
             let mut log_batch = rocksdb::WriteBatch::default();
             log_batch.put_cf(
                 store.log_cf(),
@@ -1911,7 +1955,6 @@ mod tests {
                 }
                 .encode_to_vec(),
             );
-            append_sequence_meta(&store.db, &mut log_batch, 3);
             write_synced_batch(&store.db, log_batch).expect("write log rows");
         }
 
@@ -1937,6 +1980,15 @@ mod tests {
             store.get_raw(b"k2").expect("get").as_deref(),
             Some(b"v2" as &[u8])
         );
+    }
+
+    #[tokio::test]
+    async fn empty_batches_are_rejected() {
+        let dir = tempdir().expect("tempdir");
+        let store = RocksStore::open(dir.path(), None).expect("open db");
+        let error = store.put_batch(Vec::new()).await.expect_err("must reject");
+        assert_eq!(error, "cannot ingest an empty batch");
+        assert_eq!(store.current_sequence(), 0);
     }
 
     #[tokio::test]
@@ -1981,8 +2033,8 @@ mod tests {
             },
         ];
 
-        let sequence =
-            commit_sequence_requests(&store.db, &store.sequence, &requests).expect("write");
+        let sequence = commit_sequence_requests(&store.db, &store.frontiers.published, &requests)
+            .expect("write");
         assert_eq!(sequence, 1);
         assert_eq!(store.current_sequence(), 1);
         let log_cf = store.log_cf();

--- a/examples/simulator/src/rocks.rs
+++ b/examples/simulator/src/rocks.rs
@@ -636,7 +636,12 @@ fn commit_group(db: &DB, frontiers: &Frontiers, group: PreparedWrite) {
         .sequence;
 
     // Log first: its rows define durability, and an ingested state file without its log rows
-    // could leave keys in the store that were never part of a sequenced batch.
+    // could leave keys in the store that were never part of a sequenced batch. This runs outside
+    // the floor lock, which is safe against a concurrent prune: every sequence in this file is
+    // above the published frontier (publish happens below, only after the state ingestion),
+    // while a prune's log deletes are capped at a published frontier it loaded earlier — so the
+    // prune's tombstone and file unlink are always disjoint from the file being ingested, and
+    // RocksDB serializes the metadata edits themselves.
     ingest_staged_file(db, LOG_CF, &staged.log);
 
     // Ingest and publish under the floor lock: a prune loads the published frontier as its
@@ -812,11 +817,10 @@ fn available_parallelism() -> NonZeroUsize {
 
 /// RocksDB engine and application-level write pipeline options used by [`RocksStore::open`].
 pub struct RocksConfig {
-    /// Background jobs RocksDB may run concurrently: flushes and the compactions that must keep
-    /// merging the overlapping ingested state SSTs. Applied on top of `db_options` at open.
-    /// Defaults to the machine's available parallelism.
-    pub background_jobs: NonZeroUsize,
-    /// Database-wide options.
+    /// Database-wide options. The default raises RocksDB's background-job budget (flushes and
+    /// the compactions that must keep merging the overlapping ingested state SSTs) from the
+    /// stock 2 to the machine's available parallelism; a caller replacing `db_options`
+    /// replaces that choice too — open applies these options as-is.
     pub db_options: Options,
     /// Options for the default column family, which stores the current key-value state.
     pub default_cf_options: Options,
@@ -829,13 +833,14 @@ pub struct RocksConfig {
 }
 
 impl Default for RocksConfig {
-    /// Stock RocksDB options, with background jobs defaulting to the machine's available cores.
-    /// Memtables are off the hot path (only the open-time replay and prune deletes write
+    /// Stock RocksDB options, with the background-job budget raised to the machine's available
+    /// cores. Memtables are off the hot path (only the open-time replay and prune deletes write
     /// them), so they stay at stock defaults.
     fn default() -> Self {
+        let mut db_options = Options::default();
+        db_options.increase_parallelism(available_parallelism().get() as i32);
         Self {
-            background_jobs: available_parallelism(),
-            db_options: Options::default(),
+            db_options,
             default_cf_options: Options::default(),
             meta_cf_options: Options::default(),
             log_cf_options: Options::default(),
@@ -861,7 +866,6 @@ impl RocksStore {
     /// the durable sequence even after a crash between a group's log and state ingestions.
     pub fn open(path: &Path, config: Option<RocksConfig>) -> Result<Self, String> {
         let RocksConfig {
-            background_jobs,
             mut db_options,
             default_cf_options,
             meta_cf_options,
@@ -871,7 +875,6 @@ impl RocksStore {
 
         db_options.create_if_missing(true);
         db_options.create_missing_column_families(true);
-        db_options.increase_parallelism(background_jobs.get() as i32);
 
         let cf_default =
             ColumnFamilyDescriptor::new(rocksdb::DEFAULT_COLUMN_FAMILY_NAME, default_cf_options);
@@ -959,6 +962,10 @@ impl RocksStore {
         // state floor that keeps `open` from re-deriving a regressed frontier once those rows
         // are gone. The published frontier covers every pruned row (the cutoff is capped at
         // published + 1), and everything at or below it is durable and applied to the state.
+        // That cap is also what makes this safe against `commit`'s concurrent, lock-free log
+        // ingestion: an in-flight group's rows all sit above every published frontier this
+        // prune could have loaded, so neither the tombstone nor the file unlink below can touch
+        // them (and `delete_file_in_range_cf` only drops files entirely inside its range).
         let published = self.frontiers.published.load(Ordering::Acquire);
         let mut batch = rocksdb::WriteBatch::default();
         batch.put_cf(self.meta_cf(), SEQ_META_KEY, published.to_le_bytes());
@@ -1517,7 +1524,6 @@ mod tests {
         let store = RocksStore::open(
             dir.path(),
             Some(RocksConfig {
-                background_jobs: NonZeroUsize::new(1).expect("nonzero"),
                 write_pipeline: RocksWritePipelineConfig {
                     max_commit_batch_bytes: NonZeroUsize::new(1).expect("nonzero"),
                 },

--- a/examples/simulator/src/rocks.rs
+++ b/examples/simulator/src/rocks.rs
@@ -581,7 +581,8 @@ fn stage_log_file(path: &Path, writes: &[AssignedWrite]) -> Result<usize, String
 /// Stages the current-state SST: the group's rows sorted by key, with the last write per key
 /// winning (across coalesced requests, in sequence order).
 fn stage_state_file(path: &Path, writes: &[AssignedWrite]) -> Result<usize, String> {
-    let mut rows: Vec<(&Bytes, &Bytes)> = Vec::new();
+    let mut rows: Vec<(&Bytes, &Bytes)> =
+        Vec::with_capacity(writes.iter().map(|write| write.request.kvs.len()).sum());
     for write in writes {
         for (key, value) in &write.request.kvs {
             rows.push((key, value));

--- a/examples/simulator/src/rocks.rs
+++ b/examples/simulator/src/rocks.rs
@@ -28,10 +28,13 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{mpsc, Arc};
 use std::thread;
 
-use buffa::MessageView;
+use buffa::{Message, MessageView};
 use bytes::Bytes;
+use exoware_sdk::common::kv::v1::Entry;
 use exoware_sdk::keys::KeyCodec;
-use exoware_sdk::log::stream::v1::GetResponseView as StreamGetResponseView;
+use exoware_sdk::log::stream::v1::{
+    GetResponse as StreamGetResponse, GetResponseView as StreamGetResponseView,
+};
 use exoware_sdk::prune_policy::{
     KeysScope, OrderEncoding, PolicyScope, PrunePolicyDocument, RetainPolicy,
 };
@@ -1186,79 +1189,21 @@ fn sequence_from_log_key(key: &[u8]) -> Result<u64, String> {
     Ok(u64::from_be_bytes(raw))
 }
 
-/// `log.stream.v1.GetResponse.sequence_number` (varint).
-const LOG_VALUE_SEQUENCE_TAG: u8 = 0x08;
-/// `log.stream.v1.GetResponse.entries` (length-delimited).
-const LOG_VALUE_ENTRY_TAG: u8 = 0x12;
-/// `common.kv.v1.Entry.key` (length-delimited).
-const LOG_ENTRY_KEY_TAG: u8 = 0x0a;
-/// `common.kv.v1.Entry.value` (length-delimited).
-const LOG_ENTRY_VALUE_TAG: u8 = 0x12;
-
-/// Number of bytes a value occupies as a protobuf varint.
-fn varint_len(value: u64) -> usize {
-    (63 - (value | 1).leading_zeros() as usize) / 7 + 1
-}
-
-/// Appends a protobuf varint to `buf`.
-fn put_varint(buf: &mut Vec<u8>, mut value: u64) {
-    while value >= 0x80 {
-        buf.push(value as u8 | 0x80);
-        value >>= 7;
-    }
-    buf.push(value as u8);
-}
-
-/// Encoded size of one `common.kv.v1.Entry` body. Empty fields are omitted,
-/// matching the generated encoder.
-fn encoded_entry_body_len(key: &[u8], value: &[u8]) -> usize {
-    let mut len = 0;
-    if !key.is_empty() {
-        len += 1 + varint_len(key.len() as u64) + key.len();
-    }
-    if !value.is_empty() {
-        len += 1 + varint_len(value.len() as u64) + value.len();
-    }
-    len
-}
-
 /// Encodes the replay payload for one sequence's key/value rows.
-///
-/// Writes the `log.stream.v1.GetResponse` wire format directly from the borrowed
-/// key/value slices so a large batch is encoded with a single presized allocation
-/// instead of one owned `Entry` per row. `log_value_matches_generated_encoder`
-/// pins byte-for-byte equality with the generated encoder.
 fn encode_log_value(sequence: u64, kvs: &[(Bytes, Bytes)]) -> Vec<u8> {
-    let mut total = 0;
-    for (key, value) in kvs {
-        let body_len = encoded_entry_body_len(key, value);
-        total += 1 + varint_len(body_len as u64) + body_len;
+    StreamGetResponse {
+        sequence_number: sequence,
+        entries: kvs
+            .iter()
+            .map(|(key, value)| Entry {
+                key: key.to_vec(),
+                value: value.clone(),
+                ..Default::default()
+            })
+            .collect(),
+        ..Default::default()
     }
-    if sequence != 0 {
-        total += 1 + varint_len(sequence);
-    }
-
-    let mut buf = Vec::with_capacity(total);
-    if sequence != 0 {
-        buf.push(LOG_VALUE_SEQUENCE_TAG);
-        put_varint(&mut buf, sequence);
-    }
-    for (key, value) in kvs {
-        buf.push(LOG_VALUE_ENTRY_TAG);
-        put_varint(&mut buf, encoded_entry_body_len(key, value) as u64);
-        if !key.is_empty() {
-            buf.push(LOG_ENTRY_KEY_TAG);
-            put_varint(&mut buf, key.len() as u64);
-            buf.extend_from_slice(key);
-        }
-        if !value.is_empty() {
-            buf.push(LOG_ENTRY_VALUE_TAG);
-            put_varint(&mut buf, value.len() as u64);
-            buf.extend_from_slice(value);
-        }
-    }
-    assert_eq!(buf.len(), total);
-    buf
+    .encode_to_vec()
 }
 
 #[cfg(test)]
@@ -1266,9 +1211,6 @@ mod tests {
     use super::*;
     use std::collections::BTreeSet;
 
-    use buffa::Message;
-    use exoware_sdk::common::kv::v1::Entry;
-    use exoware_sdk::log::stream::v1::GetResponse as StreamGetResponse;
     use exoware_server::{Ingest, Log, Sequence};
     use tempfile::tempdir;
 
@@ -1337,47 +1279,6 @@ mod tests {
         let ingest_dir = store.db.path().join(LOG_INGEST_DIR);
         let staged = stage_group_files(&ingest_dir, &writes);
         PreparedWrite { writes, staged }
-    }
-
-    #[test]
-    fn log_value_matches_generated_encoder() {
-        let cases: Vec<(u64, Vec<(Bytes, Bytes)>)> = vec![
-            (
-                1,
-                vec![(Bytes::from_static(b"a"), Bytes::from_static(b"1"))],
-            ),
-            // Empty keys/values and multi-byte varint lengths.
-            (
-                u64::MAX,
-                vec![
-                    (Bytes::new(), Bytes::from_static(b"value-for-empty-key")),
-                    (Bytes::from_static(b"empty-value"), Bytes::new()),
-                    (Bytes::new(), Bytes::new()),
-                    (Bytes::from(vec![7u8; 200]), Bytes::from(vec![9u8; 20_000])),
-                ],
-            ),
-        ];
-
-        for (sequence, kvs) in cases {
-            let expected = StreamGetResponse {
-                sequence_number: sequence,
-                entries: kvs
-                    .iter()
-                    .map(|(key, value)| Entry {
-                        key: key.to_vec(),
-                        value: value.clone(),
-                        ..Default::default()
-                    })
-                    .collect(),
-                ..Default::default()
-            }
-            .encode_to_vec();
-            assert_eq!(
-                encode_log_value(sequence, &kvs),
-                expected,
-                "sequence {sequence}"
-            );
-        }
     }
 
     #[test]

--- a/examples/simulator/src/rocks.rs
+++ b/examples/simulator/src/rocks.rs
@@ -11,9 +11,9 @@
 //! only then publishes and acks. The two ingestions are not atomic, but the window is one group
 //! wide: a crash between them leaves the log durable and the state missing for at most the last
 //! group, which `open` repairs by replaying the rows of the last retained log file before the
-//! store serves reads. The sequence meta row is persisted only before pruning deletes log rows,
-//! so an unpruned store recovers by reading one meta row, one file listing, and replaying at
-//! most one group.
+//! store serves reads. The sequence meta row is written only by pruning, atomically with the
+//! range tombstone (deleting log rows must not regress the derived frontier), so a store
+//! recovers by reading one meta row, one file listing, and replaying at most one group.
 
 use std::cmp::Ordering as CmpOrdering;
 use std::collections::BTreeMap;
@@ -45,8 +45,8 @@ use tracing::debug;
 
 const META_CF: &str = "meta";
 /// Durable-sequence floor. The frontier at open is the maximum of this row and the highest
-/// retained log row; it is only persisted before pruning deletes log rows — commits never write
-/// it.
+/// retained log row; it is only written atomically with a prune's range tombstone (deleting log
+/// rows must not regress the derived frontier) — commits never write it.
 const SEQ_META_KEY: &[u8] = b"sequence";
 const LOG_CF: &str = "log";
 const LOG_BATCH_KEY_LEN: usize = 8;
@@ -302,18 +302,15 @@ struct Frontiers {
     /// group's state ingestion is in flight; re-derived at open from the retained log rows and
     /// the sequence meta row.
     durable: AtomicU64,
-    /// Highest durable-sequence value written to the meta row, so redundant persists are free.
-    persisted_durable: AtomicU64,
-    /// Serializes floor persistence so the meta row never moves backward.
+    /// Serializes log pruning so the persisted durable-sequence floor never moves backward.
     persist: Mutex<()>,
 }
 
 impl Frontiers {
-    fn new(durable: u64, persisted_durable: u64) -> Self {
+    fn new(durable: u64) -> Self {
         Self {
             published: AtomicU64::new(durable),
             durable: AtomicU64::new(durable),
-            persisted_durable: AtomicU64::new(persisted_durable),
             persist: Mutex::new(()),
         }
     }
@@ -782,30 +779,6 @@ fn write_synced_batch(db: &DB, batch: rocksdb::WriteBatch) -> Result<(), String>
         .map_err(|e| e.to_string())
 }
 
-/// Persists the durable-sequence floor with one synced meta write, so a later log prune cannot
-/// regress the frontier `open` re-derives from retained rows. The lock keeps concurrent callers
-/// from persisting stale, lower values over newer ones.
-fn persist_durable_floor(db: &DB, frontiers: &Frontiers) -> Result<(), String> {
-    let _guard = frontiers
-        .persist
-        .lock()
-        .map_err(|e| format!("rocks frontier persist lock poisoned: {e}"))?;
-    let durable = frontiers.durable.load(Ordering::Acquire);
-    if frontiers.persisted_durable.load(Ordering::Acquire) >= durable {
-        return Ok(());
-    }
-    let meta_cf = db
-        .cf_handle(META_CF)
-        .expect("meta CF must exist (created on open)");
-    let mut batch = rocksdb::WriteBatch::default();
-    batch.put_cf(meta_cf, SEQ_META_KEY, durable.to_le_bytes());
-    write_synced_batch(db, batch)?;
-    frontiers
-        .persisted_durable
-        .fetch_max(durable, Ordering::AcqRel);
-    Ok(())
-}
-
 /// Creates the SST staging directory and deletes files a crashed ingestion left behind. Staged
 /// files are only ever moved into the DB by ingestion, so anything still here was never visible.
 fn prepare_ingest_dir(store_path: &Path) -> Result<PathBuf, String> {
@@ -1010,7 +983,7 @@ impl RocksStore {
         let ingest_dir = prepare_ingest_dir(path)?;
         replay_last_log_file(&db)?;
 
-        let frontiers = Arc::new(Frontiers::new(seq, meta_seq));
+        let frontiers = Arc::new(Frontiers::new(seq));
         let writer = Arc::new(Writer::start(
             db.clone(),
             ingest_dir,
@@ -1055,21 +1028,38 @@ impl RocksStore {
         if cutoff_exclusive == 0 {
             return Ok(());
         }
+        // Serializes concurrent prunes: `durable` is monotonic, so ordering the loads and writes
+        // keeps the persisted floor from ever moving backward.
+        let _guard = self
+            .frontiers
+            .persist
+            .lock()
+            .map_err(|e| format!("rocks prune lock poisoned: {e}"))?;
         let cf = self.log_cf();
+        let meta_cf = self
+            .db
+            .cf_handle(META_CF)
+            .expect("meta CF must exist (created on open)");
+
+        // One synced, atomic batch: the range tombstone that logically deletes the rows, and the
+        // durable-sequence floor that keeps `open` from re-deriving a regressed frontier once
+        // those rows are gone. Nothing is deleted unless the floor covering it is durable.
+        let durable = self.frontiers.durable.load(Ordering::Acquire);
+        let mut batch = rocksdb::WriteBatch::default();
+        batch.put_cf(meta_cf, SEQ_META_KEY, durable.to_le_bytes());
+        batch.delete_range_cf(cf, sequence_log_key(0), sequence_log_key(cutoff_exclusive));
+        write_synced_batch(&self.db, batch)?;
+
         // Unlink the ingested SST files that sit entirely below the cutoff (the common case,
         // since each file covers one commit group's contiguous sequence range). This reclaims
-        // their space immediately, without compaction ever reading the massive log payloads.
+        // their space immediately, without compaction ever reading the massive log payloads;
+        // rows in a file straddling the cutoff stay covered by the tombstone above.
         self.db
             .delete_file_in_range_cf(
                 cf,
                 sequence_log_key(0),
                 sequence_log_key(cutoff_exclusive - 1),
             )
-            .map_err(|e| e.to_string())?;
-        // Cover the leftovers — rows in a file straddling the cutoff and any L0 stragglers —
-        // with a range tombstone so they are logically gone right away.
-        self.db
-            .delete_range_cf(cf, sequence_log_key(0), sequence_log_key(cutoff_exclusive))
             .map_err(|e| e.to_string())
     }
 
@@ -1144,9 +1134,6 @@ impl RocksStore {
     /// Computes the replay-log cutoff for a sequence policy and prunes only log rows.
     fn apply_sequence_prune_policy(&self, retain: &RetainPolicy) -> Result<(), String> {
         let current = self.frontiers.published.load(Ordering::Acquire);
-        // `open` re-derives the durable frontier from the retained rows, so the floor must be
-        // durable (synced meta write) before any row or file is deleted.
-        persist_durable_floor(&self.db, &self.frontiers)?;
         let cutoff_exclusive = match retain {
             RetainPolicy::KeepLatest { count } => {
                 let count = *count as u64;

--- a/examples/simulator/src/rocks.rs
+++ b/examples/simulator/src/rocks.rs
@@ -51,6 +51,7 @@ use rocksdb::{
 use tokio::sync::oneshot;
 use tracing::debug;
 
+const STATE_CF: &str = rocksdb::DEFAULT_COLUMN_FAMILY_NAME;
 const META_CF: &str = "meta";
 /// State floor: the published frontier at the time of the last prune. The state below it is
 /// authoritative — log rows at or below it are never replayed at open (replaying them could
@@ -648,7 +649,7 @@ fn commit_group(db: &DB, frontiers: &Frontiers, group: PreparedWrite) {
     // state floor under the same lock, so no scan-visible state row can outrun the frontier
     // covering it (a key prune must never delete a row the floor does not cover).
     let publish_guard = frontiers.persist.lock();
-    ingest_staged_file(db, rocksdb::DEFAULT_COLUMN_FAMILY_NAME, &staged.state);
+    ingest_staged_file(db, STATE_CF, &staged.state);
 
     // Release so `current_sequence` readers only observe frontiers whose rows are readable.
     frontiers.published.store(last_sequence, Ordering::Release);
@@ -740,11 +741,6 @@ fn read_state_floor(db: &DB) -> Result<u64, String> {
 /// the one that ends at the durable frontier — which is idempotent because those rows are the
 /// newest writes for their keys. Rows at or below `floor` are skipped: their state is already
 /// authoritative, and key pruning may have deleted rows a replay would resurrect.
-///
-/// Bounding the replay by the last file's start key assumes log-CF file boundaries stay aligned
-/// with commit groups. That holds under stock options: ingested log files land at the bottom
-/// level (their sequence ranges never overlap) where automatic compaction never rewrites them
-/// (verified against the bundled RocksDB's level-selection and compaction-trigger sources).
 fn replay_last_log_file(db: &DB, floor: u64) -> Result<(), String> {
     let last_file_start = db
         .live_files()
@@ -816,18 +812,19 @@ fn available_parallelism() -> NonZeroUsize {
 }
 
 /// RocksDB engine and application-level write pipeline options used by [`RocksStore::open`].
+///
+/// Column-family options are deliberately not configurable — the store's correctness leans on
+/// stock CF behavior: staged state SSTs and range-scan bounds assume bytewise key order, crash
+/// repair depends on log-CF file boundaries staying aligned with commit groups (see
+/// `replay_last_log_file`), and rows must never be dropped by a caller-supplied compaction
+/// filter or TTL (acked writes must stay readable, the meta CF's state-floor row must persist,
+/// and the repair replay would nondeterministically resurrect expired state rows).
 pub struct RocksConfig {
     /// Database-wide options. The default raises RocksDB's background-job budget (flushes and
     /// the compactions that must keep merging the overlapping ingested state SSTs) from the
     /// stock 2 to the machine's available parallelism; a caller replacing `db_options`
     /// replaces that choice too — open applies these options as-is.
     pub db_options: Options,
-    /// Options for the default column family, which stores the current key-value state.
-    pub default_cf_options: Options,
-    /// Options for the metadata column family.
-    pub meta_cf_options: Options,
-    /// Options for the sequence log column family.
-    pub log_cf_options: Options,
     /// Options for the application-level ingest write pipeline.
     pub write_pipeline: RocksWritePipelineConfig,
 }
@@ -841,9 +838,6 @@ impl Default for RocksConfig {
         db_options.increase_parallelism(available_parallelism().get() as i32);
         Self {
             db_options,
-            default_cf_options: Options::default(),
-            meta_cf_options: Options::default(),
-            log_cf_options: Options::default(),
             write_pipeline: RocksWritePipelineConfig::default(),
         }
     }
@@ -859,29 +853,26 @@ pub struct RocksStore {
 }
 
 impl RocksStore {
-    /// Open the store with stock RocksDB defaults, unless `config` overrides
-    /// the database and column-family options. Re-derives the durable frontier from the retained
+    /// Open the store with default options, unless `config` overrides the database or
+    /// write-pipeline options (column families always run stock options — see [`RocksConfig`]).
+    /// Re-derives the durable frontier from the retained
     /// log rows and the state-floor meta row, then replays the last retained log file's rows
     /// above the floor into the default column family so the current state is complete below
     /// the durable sequence even after a crash between a group's log and state ingestions.
     pub fn open(path: &Path, config: Option<RocksConfig>) -> Result<Self, String> {
         let RocksConfig {
             mut db_options,
-            default_cf_options,
-            meta_cf_options,
-            log_cf_options,
             write_pipeline,
         } = config.unwrap_or_default();
 
         db_options.create_if_missing(true);
         db_options.create_missing_column_families(true);
 
-        let cf_default =
-            ColumnFamilyDescriptor::new(rocksdb::DEFAULT_COLUMN_FAMILY_NAME, default_cf_options);
-        let cf_meta = ColumnFamilyDescriptor::new(META_CF, meta_cf_options);
-        let cf_log = ColumnFamilyDescriptor::new(LOG_CF, log_cf_options);
+        let cf_state = ColumnFamilyDescriptor::new(STATE_CF, Options::default());
+        let cf_meta = ColumnFamilyDescriptor::new(META_CF, Options::default());
+        let cf_log = ColumnFamilyDescriptor::new(LOG_CF, Options::default());
         let db = Arc::new(
-            DB::open_cf_descriptors(&db_options, path, vec![cf_default, cf_meta, cf_log])
+            DB::open_cf_descriptors(&db_options, path, vec![cf_state, cf_meta, cf_log])
                 .map_err(|e| e.to_string())?,
         );
         // Commits do not write the state-floor meta row; the log rows are the durable record.

--- a/examples/simulator/src/rocks.rs
+++ b/examples/simulator/src/rocks.rs
@@ -344,11 +344,12 @@ struct Writer {
 
 impl Writer {
     /// Starts the three-stage write pipeline. `prepare` drains queued requests up to the
-    /// configured byte cap, assigns a contiguous sequence number to each, and builds one log
-    /// batch plus one state batch per wave; `commit` syncs each log batch, publishing the durable
-    /// frontier; `apply` inserts the state rows without a WAL, advances the visible frontier, and
-    /// resolves the requests. The stages overlap, so while one group is being fsync'd the next is
-    /// being built and the previous group's state rows are being applied.
+    /// configured byte cap, assigns a contiguous sequence number to each, and builds each wave's
+    /// state batch and encoded log rows; `commit` makes each group's log rows durable (synced
+    /// batch or ingested SST), publishing the durable frontier; `apply` inserts the state rows
+    /// without a WAL, advances the visible frontier, and resolves the requests. The stages
+    /// overlap, so while one group is being fsync'd the next is being built and the previous
+    /// group's state rows are being applied.
     fn start(
         db: Arc<DB>,
         ingest_dir: PathBuf,
@@ -970,7 +971,8 @@ fn complete_assigned_writes(writes: Vec<AssignedWrite>) {
 /// Application-level write pipeline options used by [`RocksStore::open`].
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct RocksWritePipelineConfig {
-    /// Soft maximum RocksDB `WriteBatch` size before cutting a prepared commit group.
+    /// Soft maximum combined size (state rows plus encoded log rows) before cutting a prepared
+    /// commit group.
     pub max_commit_batch_bytes: NonZeroUsize,
 }
 
@@ -1239,8 +1241,8 @@ impl Sequence for RocksStore {
     }
 }
 
-// Ingest uses a dedicated writer thread so blocking RocksDB writes do not occupy Tokio workers.
-// The writer folds already-queued requests into one RocksDB batch while preserving a contiguous
+// Ingest uses dedicated writer threads so blocking RocksDB writes do not occupy Tokio workers.
+// The writer folds already-queued requests into one commit group while preserving a contiguous
 // sequence number and replay-log row for each request.
 impl Ingest for RocksStore {
     async fn put_batch(&self, kvs: Vec<(Bytes, Bytes)>) -> Result<u64, String> {

--- a/examples/simulator/src/rocks.rs
+++ b/examples/simulator/src/rocks.rs
@@ -40,7 +40,6 @@ use exoware_server::{
     Ingest, Log, LogBatch, Prune, Query, QueryExtra, RangeScan, RangeScanBatch, Sequence,
 };
 use parking_lot::Mutex;
-use rayon::slice::ParallelSliceMut;
 use regex::bytes::Regex;
 use rocksdb::{
     ColumnFamily, ColumnFamilyDescriptor, DBCompressionType, DBIterator, Direction,
@@ -374,7 +373,6 @@ impl Writer {
     fn start(
         db: Arc<DB>,
         ingest_dir: PathBuf,
-        staging_pool: rayon::ThreadPool,
         frontiers: Arc<Frontiers>,
         next: u64,
         write_pipeline: RocksWritePipelineConfig,
@@ -395,7 +393,6 @@ impl Writer {
             .spawn(move || {
                 run_prepare(
                     ingest_dir,
-                    staging_pool,
                     next,
                     request_receiver,
                     group_sender,
@@ -447,21 +444,14 @@ impl Drop for Writer {
 /// (store drop); panics if `commit` died, since that only happens on a fatal write error.
 fn run_prepare(
     ingest_dir: PathBuf,
-    staging_pool: rayon::ThreadPool,
     mut next: u64,
     receiver: mpsc::Receiver<WriteRequest>,
     sender: mpsc::SyncSender<PreparedWrite>,
     max_commit_batch_bytes: usize,
 ) {
     while let Ok(first) = receiver.recv() {
-        let (group, disconnected) = prepare_queued_write(
-            &ingest_dir,
-            &staging_pool,
-            &receiver,
-            first,
-            next,
-            max_commit_batch_bytes,
-        );
+        let (group, disconnected) =
+            prepare_queued_write(&ingest_dir, &receiver, first, next, max_commit_batch_bytes);
         next = group
             .writes
             .last()
@@ -482,7 +472,6 @@ fn run_prepare(
 /// crosses the cap stays in the wave so a single large request can still make progress.
 fn prepare_queued_write(
     ingest_dir: &Path,
-    staging_pool: &rayon::ThreadPool,
     receiver: &mpsc::Receiver<WriteRequest>,
     first: WriteRequest,
     from: u64,
@@ -522,26 +511,33 @@ fn prepare_queued_write(
         }
     }
 
-    let staged = staging_pool.install(|| stage_group_files(ingest_dir, &writes));
+    let staged = stage_group_files(ingest_dir, &writes);
     (PreparedWrite { writes, staged }, disconnected)
 }
 
 /// Writes and syncs one commit group's two SST files: the replay-log rows (already in ascending
-/// sequence order) and the current-state rows (sorted by key in parallel, keeping the last write
-/// per key). The two files are built concurrently on the caller's rayon pool (the store's
-/// staging pool, sized by [`RocksWritePipelineConfig::staging_threads`]); ingestion later links
-/// them into their column families, so each payload byte reaches the disk exactly once, in its
-/// final resting place. A staging failure is fatal; leftover files are removed by the next open.
+/// sequence order) and the current-state rows (sorted by key, keeping the last write per key).
+/// The two files are built concurrently — the state file on a scoped thread while this thread
+/// writes the log file. Ingestion later links them into their column families, so each payload
+/// byte reaches the disk exactly once, in its final resting place. A staging failure is fatal;
+/// leftover files are removed by the next open.
 fn stage_group_files(ingest_dir: &Path, writes: &[AssignedWrite]) -> StagedFiles {
     let first = writes.first().expect("groups are never empty").sequence;
     let last = writes.last().expect("groups are never empty").sequence;
     let log_path = ingest_dir.join(format!("log-{first:020}-{last:020}.sst"));
     let state_path = ingest_dir.join(format!("state-{first:020}-{last:020}.sst"));
 
-    let (log_result, state_result) = rayon::join(
-        || stage_log_file(&log_path, writes),
-        || stage_state_file(&state_path, writes),
-    );
+    let (log_result, state_result) = thread::scope(|scope| {
+        let state = thread::Builder::new()
+            .name("simulator-rocks-stage".to_string())
+            .spawn_scoped(scope, || stage_state_file(&state_path, writes))
+            .expect("failed to spawn SST staging thread");
+        let log_result = stage_log_file(&log_path, writes);
+        (
+            log_result,
+            state.join().expect("state staging thread panicked"),
+        )
+    });
     let log_bytes = log_result.unwrap_or_else(|error| panic!("failed to stage log SST: {error}"));
     let state_bytes =
         state_result.unwrap_or_else(|error| panic!("failed to stage state SST: {error}"));
@@ -588,8 +584,8 @@ fn stage_state_file(path: &Path, writes: &[AssignedWrite]) -> Result<usize, Stri
             rows.push((key, value));
         }
     }
-    // Stable parallel sort: equal keys keep arrival order, so the last occurrence is the newest.
-    rows.par_sort_by(|a, b| a.0.cmp(b.0));
+    // Stable sort: equal keys keep arrival order, so the last occurrence is the newest.
+    rows.sort_by(|a, b| a.0.cmp(b.0));
 
     let options = staging_options();
     let mut writer = SstFileWriter::create(&options);
@@ -625,7 +621,7 @@ fn run_commit(db: Arc<DB>, frontiers: Arc<Frontiers>, receiver: mpsc::Receiver<P
 /// callers observe an error even though the group may resurface after the restart repair — an
 /// accepted at-least-once ambiguity of this severe error path.
 fn commit_group(db: &DB, frontiers: &Frontiers, group: PreparedWrite) {
-    debug_assert!(!group.writes.is_empty(), "groups are never empty");
+    assert!(!group.writes.is_empty(), "groups are never empty");
     let PreparedWrite { writes, staged } = group;
     let requests = writes.len();
     let last_sequence = writes
@@ -792,9 +788,6 @@ pub struct RocksWritePipelineConfig {
     /// Soft maximum combined size (state rows plus encoded log rows) before cutting a prepared
     /// commit group.
     pub max_commit_batch_bytes: NonZeroUsize,
-    /// Threads in the pool that sorts and stages each commit group's SST files — CPU work on
-    /// the ack path. Defaults to the machine's available parallelism.
-    pub staging_threads: NonZeroUsize,
 }
 
 impl Default for RocksWritePipelineConfig {
@@ -802,7 +795,6 @@ impl Default for RocksWritePipelineConfig {
         Self {
             max_commit_batch_bytes: NonZeroUsize::new(DEFAULT_COMMIT_COALESCE_MAX_BATCH_BYTES)
                 .expect("default commit batch byte limit must be nonzero"),
-            staging_threads: available_parallelism(),
         }
     }
 }
@@ -874,11 +866,6 @@ impl RocksStore {
         db_options.create_if_missing(true);
         db_options.create_missing_column_families(true);
         db_options.increase_parallelism(background_jobs.get() as i32);
-        let staging_pool = rayon::ThreadPoolBuilder::new()
-            .num_threads(write_pipeline.staging_threads.get())
-            .thread_name(|i| format!("simulator-rocks-stage-{i}"))
-            .build()
-            .map_err(|e| format!("failed to build SST staging thread pool: {e}"))?;
 
         let cf_default =
             ColumnFamilyDescriptor::new(rocksdb::DEFAULT_COLUMN_FAMILY_NAME, default_cf_options);
@@ -899,7 +886,6 @@ impl RocksStore {
         let writer = Arc::new(Writer::start(
             db.clone(),
             ingest_dir,
-            staging_pool,
             frontiers.clone(),
             seq,
             write_pipeline,
@@ -1268,7 +1254,7 @@ fn encode_log_value(sequence: u64, kvs: &[(Bytes, Bytes)]) -> Vec<u8> {
             buf.extend_from_slice(value);
         }
     }
-    debug_assert_eq!(buf.len(), total);
+    assert_eq!(buf.len(), total);
     buf
 }
 
@@ -1350,13 +1336,6 @@ mod tests {
         PreparedWrite { writes, staged }
     }
 
-    fn staging_pool() -> rayon::ThreadPool {
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(1)
-            .build()
-            .expect("build staging pool")
-    }
-
     #[test]
     fn log_value_matches_generated_encoder() {
         let cases: Vec<(u64, Vec<(Bytes, Bytes)>)> = vec![
@@ -1421,7 +1400,6 @@ mod tests {
         let first = receiver.recv().expect("first request");
         let (group, disconnected) = prepare_queued_write(
             dir.path(),
-            &staging_pool(),
             &receiver,
             first,
             0,
@@ -1444,8 +1422,7 @@ mod tests {
         drop(sender);
 
         let first = receiver.recv().expect("first request");
-        let (group, disconnected) =
-            prepare_queued_write(dir.path(), &staging_pool(), &receiver, first, 0, 1);
+        let (group, disconnected) = prepare_queued_write(dir.path(), &receiver, first, 0, 1);
 
         assert_eq!(group.writes.len(), 1);
         assert_eq!(group.writes[0].request.kvs[0].0.as_ref(), b"a");
@@ -1639,7 +1616,6 @@ mod tests {
                 background_jobs: NonZeroUsize::new(1).expect("nonzero"),
                 write_pipeline: RocksWritePipelineConfig {
                     max_commit_batch_bytes: NonZeroUsize::new(1).expect("nonzero"),
-                    staging_threads: NonZeroUsize::new(1).expect("nonzero"),
                 },
                 ..Default::default()
             }),

--- a/examples/simulator/src/rocks.rs
+++ b/examples/simulator/src/rocks.rs
@@ -13,8 +13,8 @@
 //! ack. Ingestion is atomic and strictly ordered, so a crash never leaves a partial batch and
 //! at most the newest group can be missing its state ingestion; `open` repairs that by
 //! re-applying the newest retained log row (idempotent: its rows are the newest writes for
-//! their keys). The floor meta row is written only by pruning, synced, atomically with its
-//! deletes: it marks state the replay must never touch (re-applying key-pruned rows would
+//! their keys). The floor meta row is written only by pruning and is durable by the time a
+//! prune acks: it marks state the replay must never touch (re-applying key-pruned rows would
 //! resurrect them) and keeps a fully-pruned log from regressing the frontier.
 //!
 //! Any write failure in the pipeline is fatal: once a group's log row is durable it cannot be
@@ -337,10 +337,11 @@ struct Frontiers {
     /// while a group's state ingestion is in flight, and is re-derived at open from the
     /// retained log rows and the state-floor meta row.
     published: AtomicU64,
-    /// Serializes prunes (so the persisted state floor never moves backward) and orders state
-    /// visibility against floor reads: `commit` ingests and publishes each group's state under
-    /// this lock, so a prune that loads `published` under it sees a frontier covering every row
-    /// its scan could have observed.
+    /// Serializes floor persists (so the persisted state floor never moves backward even
+    /// though whole prunes run concurrently) and orders state visibility against floor reads:
+    /// `commit` ingests and publishes each group's state under this lock, so a prune that
+    /// loads `published` under it sees a frontier covering every row its scan could have
+    /// observed.
     persist: Mutex<()>,
 }
 
@@ -687,8 +688,12 @@ fn write_synced_batch(db: &DB, batch: rocksdb::WriteBatch) -> Result<(), String>
         .map_err(|e| e.to_string())
 }
 
-/// Creates the SST staging directory and deletes files a crashed writer left behind. Staged
-/// files are only ever consumed by `commit`, so anything still here was never visible.
+/// Creates the SST staging directory and deletes files a crashed writer left behind. A
+/// leftover can exist even for an ingested group: move-ingestion hard-links the staged file
+/// into the database and unlinks the original afterward, so a crash in between leaves the
+/// original behind while its rows are already visible. Deleting leftovers is safe either way
+/// because the database owns its own link to every ingested file. Nothing here decides
+/// whether a group committed: the retained log rows alone do.
 fn prepare_ingest_dir(store_path: &Path) -> Result<PathBuf, String> {
     let ingest_dir = store_path.join(LOG_INGEST_DIR);
     std::fs::create_dir_all(&ingest_dir)
@@ -718,23 +723,6 @@ fn sequence_from_log_key(key: &[u8]) -> Result<u64, String> {
     Ok(u64::from_be_bytes(raw))
 }
 
-/// Returns the sequence of the highest retained log row, or zero when the log is empty. Rows
-/// are only ever ingested by sequential, atomic commits, so the highest retained row is a lower
-/// bound on the durable frontier (pruning persists the state floor atomically with its deletes,
-/// so the floor covers whatever was pruned).
-fn highest_log_row(db: &DB) -> Result<u64, String> {
-    let log_cf = db
-        .cf_handle(LOG_CF)
-        .expect("log CF must exist (created on open)");
-    match db.iterator_cf(log_cf, IteratorMode::End).next() {
-        None => Ok(0),
-        Some(item) => {
-            let (key, _) = item.map_err(|e| e.to_string())?;
-            sequence_from_log_key(key.as_ref())
-        }
-    }
-}
-
 /// Reads the state-floor meta row, defaulting to zero when no prune has written it yet. A
 /// malformed row is corruption and fails the open: silently treating it as zero would let the
 /// replay resurrect key-pruned rows.
@@ -756,25 +744,27 @@ fn read_state_floor(db: &DB) -> Result<u64, String> {
     }
 }
 
-/// Re-applies the newest retained log row to the state column family. `commit` ingests
-/// strictly in order (a group's log row lands before its state, and the next group's row only
-/// after that state), so every older group's state is already durably ingested and at most the
+/// Re-applies the newest retained log row to the state column family and returns its sequence
+/// (zero when the log is empty). Rows are only ever ingested by sequential, atomic commits, so
+/// the returned sequence is a lower bound on the durable frontier. `commit` ingests strictly
+/// in order (a group's log row lands before its state, and the next group's row only after
+/// that state), so every older group's state is already durably ingested and at most the
 /// newest group can be missing it; re-applying is idempotent because the row's entries are the
 /// newest writes for their keys. A row at or below `floor` is never replayed: its state is
 /// authoritative, and key pruning may have deleted rows a replay would resurrect. Ingestion is
 /// atomic, so no partial row can exist; a row that fails to decode is real corruption and
 /// fails the open.
-fn replay_newest_log_row(db: &DB, floor: u64) -> Result<(), String> {
+fn replay_newest_log_row(db: &DB, floor: u64) -> Result<u64, String> {
     let log_cf = db
         .cf_handle(LOG_CF)
         .expect("log CF must exist (created on open)");
     let Some(item) = db.iterator_cf(log_cf, IteratorMode::End).next() else {
-        return Ok(());
+        return Ok(0);
     };
     let (key, value) = item.map_err(|e| e.to_string())?;
     let sequence = sequence_from_log_key(key.as_ref())?;
     if sequence <= floor {
-        return Ok(());
+        return Ok(sequence);
     }
     let response = StreamGetResponseView::decode_view(value.as_ref())
         .map_err(|e| format!("corrupt log row for sequence {sequence}: {e}"))?;
@@ -785,7 +775,8 @@ fn replay_newest_log_row(db: &DB, floor: u64) -> Result<(), String> {
 
     // Synced: once a later commit moves the newest row past this group, a repair lost to power
     // loss would never be re-run.
-    write_synced_batch(db, batch)
+    write_synced_batch(db, batch)?;
+    Ok(sequence)
 }
 
 /// Application-level write pipeline options used by [`RocksStore::open`].
@@ -828,9 +819,13 @@ pub struct RocksConfig {
 /// plus a per-sequence log.
 #[derive(Clone)]
 pub struct RocksStore {
+    /// Declared before `db` so the last store drop joins the writer threads before releasing
+    /// its database handle: the prepare thread stages files inside the data directory without
+    /// holding [`Database`], so it must never outlive the handles that keep the directory
+    /// alive.
+    writer: Arc<Writer>,
     db: Arc<Database>,
     frontiers: Arc<Frontiers>,
-    writer: Arc<Writer>,
 }
 
 impl RocksStore {
@@ -889,8 +884,7 @@ impl RocksStore {
 
         // Commits do not write the state-floor meta row; the log rows are the durable record.
         let floor = read_state_floor(&db)?;
-        let seq = floor.max(highest_log_row(&db)?);
-        replay_newest_log_row(&db, floor)?;
+        let seq = floor.max(replay_newest_log_row(&db, floor)?);
 
         let frontiers = Arc::new(Frontiers::new(seq));
         let writer = Arc::new(Writer::start(
@@ -925,32 +919,33 @@ impl RocksStore {
         self.db.get(key)
     }
 
-    /// Deletes key-pruned current rows. The state floor is raised to the published frontier
-    /// first (synced, under the publish lock), so every deleted row's log entry sits at or
-    /// below a durable floor and the replay at the next open cannot resurrect it. The deletes
-    /// themselves are applied in bounded chunks outside the lock (all covered by the
-    /// just-persisted floor), so a large prune never stalls commit acks; the final chunk is
-    /// synced, which flushes the whole run and makes an acked prune durable. A crash between
-    /// chunks leaves rows the next prune pass re-deletes.
+    /// Raises the durable state floor to the published frontier, marking every published row
+    /// as state the open-time replay must never re-apply. Loaded and written under the
+    /// publish lock, so the floor covers every row a prune's scan could have observed (a
+    /// group's state becomes scan-visible only under the same lock hold that publishes it)
+    /// and concurrent raises never regress it. Unsynced: the floor only has to be durable by
+    /// the time the prune acks, and the caller's final synced write flushes it.
+    fn raise_state_floor(&self) -> Result<(), String> {
+        let _guard = self.frontiers.persist.lock();
+        let mut batch = rocksdb::WriteBatch::default();
+        batch.put_cf(
+            self.meta_cf(),
+            SEQ_META_KEY,
+            self.frontiers
+                .published
+                .load(Ordering::Acquire)
+                .to_le_bytes(),
+        );
+        self.db.write(batch).map_err(|e| e.to_string())
+    }
+
+    /// Deletes current rows in bounded chunks, entirely off the publish lock: keys are
+    /// write-once, so a concurrent commit only ever adds new keys, never a row this delete
+    /// targets. Chunking keeps any single batch from monopolizing the RocksDB write path
+    /// that `commit`'s ingestions briefly pause and wait behind. The final chunk is synced,
+    /// which flushes the whole run; a crash between chunks loses whole batches atomically,
+    /// leaving rows the next prune pass re-deletes.
     fn delete_keys(&self, keys: &[Bytes]) -> Result<(), String> {
-        if keys.is_empty() {
-            return Ok(());
-        }
-
-        {
-            let _guard = self.frontiers.persist.lock();
-            let mut batch = rocksdb::WriteBatch::default();
-            batch.put_cf(
-                self.meta_cf(),
-                SEQ_META_KEY,
-                self.frontiers
-                    .published
-                    .load(Ordering::Acquire)
-                    .to_le_bytes(),
-            );
-            write_synced_batch(&self.db, batch)?;
-        }
-
         let mut chunks = keys.chunks(PRUNE_DELETE_CHUNK_KEYS).peekable();
         while let Some(chunk) = chunks.next() {
             let mut batch = rocksdb::WriteBatch::default();
@@ -976,8 +971,8 @@ impl RocksStore {
         // One synced, atomic batch: the range tombstone that deletes the rows, and the state
         // floor that keeps `open` from re-deriving a regressed frontier once they are gone.
         // The published frontier covers every pruned row (the cutoff is capped at
-        // published + 1), and everything at or below it is durable and applied to the state —
-        // which also makes this safe against the writer's concurrent, lock-free log ingestion:
+        // published + 1), and everything at or below it is durable and applied to the state.
+        // That also makes this safe against the writer's concurrent, lock-free log ingestion:
         // an in-flight group's row sits above every published frontier this prune could have
         // loaded. Space is reclaimed by ordinary compaction; nothing assumes which SST files
         // hold the rows.
@@ -1057,6 +1052,13 @@ impl RocksStore {
         for (_group_key, entries) in groups {
             all_deletes.extend(keys_to_delete(entries, scope, retain)?);
         }
+        if all_deletes.is_empty() {
+            return Ok(());
+        }
+
+        // The floor is raised before the deletes so the final synced chunk makes it durable
+        // by ack: an acked prune must never be undone by the newest-log-row replay at reopen.
+        self.raise_state_floor()?;
         self.delete_keys(&all_deletes)
     }
 

--- a/examples/simulator/src/server.rs
+++ b/examples/simulator/src/server.rs
@@ -9,7 +9,8 @@ use axum::{routing::get, Router};
 use bytes::Bytes;
 use exoware_sdk::prune_policy::PrunePolicyDocument;
 use exoware_server::{
-    connect_stack, AppState, Ingest, Log, LogBatch, Prune, Query, QueryExtra, Sequence,
+    connect_stack, AppState, Ingest, Log, LogBatch, Prune, Query, QueryExtra, RangeScan,
+    RangeScanBatch, Sequence,
 };
 use tower_http::cors::CorsLayer;
 use tracing::info;
@@ -45,15 +46,29 @@ pub async fn run(
     Ok(())
 }
 
-/// Store engine that keeps `guard` (the test's tempdir) alive until the engine itself is
-/// dropped. Server and connection tasks all hold engine clones and are torn down in arbitrary
-/// order when a test runtime shuts down; owning the guard here — declared after the store, so it
-/// drops last — guarantees the data directory outlives every store handle. Deleting the
-/// directory under a live store cannot corrupt anything, but it makes the final close stall on
-/// RocksDB's background-error recovery loop.
+/// Store engine that keeps `guard` (the test's tempdir) alive until the engine — and every
+/// range-scan cursor it hands out, which pins the DB independently — is dropped. Server and
+/// connection tasks all hold engine clones and are torn down in arbitrary order when a test
+/// runtime shuts down; owning the guard here (declared after the store, so it drops last, and
+/// cloned into each cursor) keeps the data directory alive for as long as any store handle or
+/// open cursor. Deleting the directory under a live store cannot corrupt anything, but it makes
+/// the final close stall on RocksDB's background-error recovery loop.
 struct GuardedStore<G> {
     store: RocksStore,
-    _guard: G,
+    _guard: Arc<G>,
+}
+
+/// Range-scan cursor that carries the tempdir guard: connection tasks hold the cursor (not the
+/// engine) in their response streams, and the cursor's iterator pins the DB.
+struct GuardedRangeScan<G> {
+    inner: RocksRangeScanCursor,
+    _guard: Arc<G>,
+}
+
+impl<G: Send + Sync + 'static> RangeScan for GuardedRangeScan<G> {
+    async fn next_batch(&mut self, max_items: usize) -> Result<RangeScanBatch, String> {
+        self.inner.next_batch(max_items).await
+    }
 }
 
 impl<G: Send + Sync + 'static> Sequence for GuardedStore<G> {
@@ -69,7 +84,7 @@ impl<G: Send + Sync + 'static> Ingest for GuardedStore<G> {
 }
 
 impl<G: Send + Sync + 'static> Query for GuardedStore<G> {
-    type RangeScan = RocksRangeScanCursor;
+    type RangeScan = GuardedRangeScan<G>;
 
     async fn get(&self, key: Bytes) -> Result<(Option<Bytes>, QueryExtra), String> {
         self.store.get(key).await
@@ -82,7 +97,10 @@ impl<G: Send + Sync + 'static> Query for GuardedStore<G> {
         limit: usize,
         forward: bool,
     ) -> Result<Self::RangeScan, String> {
-        self.store.range_scan(start, end, limit, forward).await
+        Ok(GuardedRangeScan {
+            inner: self.store.range_scan(start, end, limit, forward).await?,
+            _guard: self._guard.clone(),
+        })
     }
 
     async fn get_many(
@@ -120,7 +138,7 @@ pub async fn spawn_for_test(
 ) -> Result<(tokio::task::JoinHandle<()>, String), Box<dyn std::error::Error + Send + Sync>> {
     let engine = Arc::new(GuardedStore {
         store: RocksStore::open(data_dir, None)?,
-        _guard: guard,
+        _guard: Arc::new(guard),
     });
     let state = AppState::new(engine);
     let connect = connect_stack(state);

--- a/examples/simulator/src/server.rs
+++ b/examples/simulator/src/server.rs
@@ -6,11 +6,15 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use axum::{routing::get, Router};
+use bytes::Bytes;
+use exoware_sdk::prune_policy::PrunePolicyDocument;
+use exoware_server::{
+    connect_stack, AppState, Ingest, Log, LogBatch, Prune, Query, QueryExtra, Sequence,
+};
 use tower_http::cors::CorsLayer;
 use tracing::info;
 
-use exoware_server::{connect_stack, AppState};
-
+use crate::rocks::RocksRangeScanCursor;
 use crate::RocksStore;
 
 pub const CMD: &str = "server";
@@ -41,11 +45,83 @@ pub async fn run(
     Ok(())
 }
 
+/// Store engine that keeps `guard` (the test's tempdir) alive until the engine itself is
+/// dropped. Server and connection tasks all hold engine clones and are torn down in arbitrary
+/// order when a test runtime shuts down; owning the guard here — declared after the store, so it
+/// drops last — guarantees the data directory outlives every store handle. Deleting the
+/// directory under a live store cannot corrupt anything, but it makes the final close stall on
+/// RocksDB's background-error recovery loop.
+struct GuardedStore<G> {
+    store: RocksStore,
+    _guard: G,
+}
+
+impl<G: Send + Sync + 'static> Sequence for GuardedStore<G> {
+    fn current_sequence(&self) -> u64 {
+        self.store.current_sequence()
+    }
+}
+
+impl<G: Send + Sync + 'static> Ingest for GuardedStore<G> {
+    async fn put_batch(&self, kvs: Vec<(Bytes, Bytes)>) -> Result<u64, String> {
+        self.store.put_batch(kvs).await
+    }
+}
+
+impl<G: Send + Sync + 'static> Query for GuardedStore<G> {
+    type RangeScan = RocksRangeScanCursor;
+
+    async fn get(&self, key: Bytes) -> Result<(Option<Bytes>, QueryExtra), String> {
+        self.store.get(key).await
+    }
+
+    async fn range_scan(
+        &self,
+        start: Bytes,
+        end: Bytes,
+        limit: usize,
+        forward: bool,
+    ) -> Result<Self::RangeScan, String> {
+        self.store.range_scan(start, end, limit, forward).await
+    }
+
+    async fn get_many(
+        &self,
+        keys: Vec<Bytes>,
+    ) -> Result<(Vec<(Bytes, Option<Bytes>)>, QueryExtra), String> {
+        self.store.get_many(keys).await
+    }
+}
+
+impl<G: Send + Sync + 'static> Prune for GuardedStore<G> {
+    async fn apply_prune_policies(&self, document: PrunePolicyDocument) -> Result<(), String> {
+        self.store.apply_prune_policies(document).await
+    }
+}
+
+impl<G: Send + Sync + 'static> Log for GuardedStore<G> {
+    async fn get_batch(&self, sequence_number: u64) -> Result<Option<LogBatch>, String> {
+        self.store.get_batch(sequence_number).await
+    }
+
+    async fn oldest_retained_batch(&self) -> Result<Option<u64>, String> {
+        self.store.oldest_retained_batch().await
+    }
+}
+
 /// Used by integration tests: bind an ephemeral port and return the base URL.
+///
+/// `guard` (typically the `TempDir` owning `data_dir`) lives inside the engine and is dropped
+/// after the store closes, so the data directory stays alive for as long as any engine handle
+/// does — however the test runtime tears its tasks down.
 pub async fn spawn_for_test(
     data_dir: &Path,
+    guard: impl Send + Sync + 'static,
 ) -> Result<(tokio::task::JoinHandle<()>, String), Box<dyn std::error::Error + Send + Sync>> {
-    let engine = Arc::new(RocksStore::open(data_dir, None)?);
+    let engine = Arc::new(GuardedStore {
+        store: RocksStore::open(data_dir, None)?,
+        _guard: guard,
+    });
     let state = AppState::new(engine);
     let connect = connect_stack(state);
     let app = Router::new()

--- a/examples/simulator/src/server.rs
+++ b/examples/simulator/src/server.rs
@@ -44,7 +44,7 @@ pub async fn run(
 ///
 /// The server runs on a temporary data directory owned by the store
 /// ([`RocksStore::open_owned`]), deleted only after the database has fully closed.
-pub async fn test_spawn(
+pub async fn open_temp(
 ) -> Result<(tokio::task::JoinHandle<()>, String), Box<dyn std::error::Error + Send + Sync>> {
     let data_dir = tempfile::tempdir()?;
     let engine = Arc::new(RocksStore::open_owned(data_dir, None)?);

--- a/examples/simulator/src/server.rs
+++ b/examples/simulator/src/server.rs
@@ -6,16 +6,10 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use axum::{routing::get, Router};
-use bytes::Bytes;
-use exoware_sdk::prune_policy::PrunePolicyDocument;
-use exoware_server::{
-    connect_stack, AppState, Ingest, Log, LogBatch, Prune, Query, QueryExtra, RangeScan,
-    RangeScanBatch, Sequence,
-};
+use exoware_server::{connect_stack, AppState};
 use tower_http::cors::CorsLayer;
 use tracing::info;
 
-use crate::rocks::RocksRangeScanCursor;
 use crate::RocksStore;
 
 pub const CMD: &str = "server";
@@ -27,7 +21,7 @@ async fn health() -> &'static str {
 
 /// Run the store simulator until the process is interrupted.
 pub async fn run(
-    directory: &std::path::Path,
+    directory: &Path,
     port: u16,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let engine = Arc::new(RocksStore::open(directory, None)?);
@@ -46,100 +40,14 @@ pub async fn run(
     Ok(())
 }
 
-/// Store engine that keeps `guard` (the test's tempdir) alive until the engine — and every
-/// range-scan cursor it hands out, which pins the DB independently — is dropped. Server and
-/// connection tasks all hold engine clones and are torn down in arbitrary order when a test
-/// runtime shuts down; owning the guard here (declared after the store, so it drops last, and
-/// cloned into each cursor) keeps the data directory alive for as long as any store handle or
-/// open cursor. Deleting the directory under a live store cannot corrupt anything, but it makes
-/// the final close stall on RocksDB's background-error recovery loop.
-struct GuardedStore<G> {
-    store: RocksStore,
-    _guard: Arc<G>,
-}
-
-/// Range-scan cursor that carries the tempdir guard: connection tasks hold the cursor (not the
-/// engine) in their response streams, and the cursor's iterator pins the DB.
-struct GuardedRangeScan<G> {
-    inner: RocksRangeScanCursor,
-    _guard: Arc<G>,
-}
-
-impl<G: Send + Sync + 'static> RangeScan for GuardedRangeScan<G> {
-    async fn next_batch(&mut self, max_items: usize) -> Result<RangeScanBatch, String> {
-        self.inner.next_batch(max_items).await
-    }
-}
-
-impl<G: Send + Sync + 'static> Sequence for GuardedStore<G> {
-    fn current_sequence(&self) -> u64 {
-        self.store.current_sequence()
-    }
-}
-
-impl<G: Send + Sync + 'static> Ingest for GuardedStore<G> {
-    async fn put_batch(&self, kvs: Vec<(Bytes, Bytes)>) -> Result<u64, String> {
-        self.store.put_batch(kvs).await
-    }
-}
-
-impl<G: Send + Sync + 'static> Query for GuardedStore<G> {
-    type RangeScan = GuardedRangeScan<G>;
-
-    async fn get(&self, key: Bytes) -> Result<(Option<Bytes>, QueryExtra), String> {
-        self.store.get(key).await
-    }
-
-    async fn range_scan(
-        &self,
-        start: Bytes,
-        end: Bytes,
-        limit: usize,
-        forward: bool,
-    ) -> Result<Self::RangeScan, String> {
-        Ok(GuardedRangeScan {
-            inner: self.store.range_scan(start, end, limit, forward).await?,
-            _guard: self._guard.clone(),
-        })
-    }
-
-    async fn get_many(
-        &self,
-        keys: Vec<Bytes>,
-    ) -> Result<(Vec<(Bytes, Option<Bytes>)>, QueryExtra), String> {
-        self.store.get_many(keys).await
-    }
-}
-
-impl<G: Send + Sync + 'static> Prune for GuardedStore<G> {
-    async fn apply_prune_policies(&self, document: PrunePolicyDocument) -> Result<(), String> {
-        self.store.apply_prune_policies(document).await
-    }
-}
-
-impl<G: Send + Sync + 'static> Log for GuardedStore<G> {
-    async fn get_batch(&self, sequence_number: u64) -> Result<Option<LogBatch>, String> {
-        self.store.get_batch(sequence_number).await
-    }
-
-    async fn oldest_retained_batch(&self) -> Result<Option<u64>, String> {
-        self.store.oldest_retained_batch().await
-    }
-}
-
 /// Used by integration tests: bind an ephemeral port and return the base URL.
 ///
-/// `guard` (typically the `TempDir` owning `data_dir`) lives inside the engine and is dropped
-/// after the store closes, so the data directory stays alive for as long as any engine handle
-/// does — however the test runtime tears its tasks down.
-pub async fn spawn_for_test(
-    data_dir: &Path,
-    guard: impl Send + Sync + 'static,
+/// The server runs on a temporary data directory owned by the store
+/// ([`RocksStore::open_owned`]), deleted only after the database has fully closed.
+pub async fn test_spawn(
 ) -> Result<(tokio::task::JoinHandle<()>, String), Box<dyn std::error::Error + Send + Sync>> {
-    let engine = Arc::new(GuardedStore {
-        store: RocksStore::open(data_dir, None)?,
-        _guard: Arc::new(guard),
-    });
+    let data_dir = tempfile::tempdir()?;
+    let engine = Arc::new(RocksStore::open_owned(data_dir, None)?);
     let state = AppState::new(engine);
     let connect = connect_stack(state);
     let app = Router::new()

--- a/examples/simulator/tests/e2e_connect.rs
+++ b/examples/simulator/tests/e2e_connect.rs
@@ -17,22 +17,16 @@ use exoware_sdk::{
     connect_compression_registry, PreferZstdHttpClient, PrefixedStoreClient, RangeMode,
     RangeReduceOp, RangeReduceRequest, RangeReducerSpec, RetryConfig, StoreClient,
 };
-use tempfile::tempdir;
 
-/// The tempdir guard moves into the store engine, which every server and connection task
-/// holds, so the data directory is never deleted under the store however tasks are torn down.
-async fn spawn_client() -> (tokio::task::JoinHandle<()>, PrefixedStoreClient, String) {
-    let dir = tempdir().expect("tempdir");
-    let path = dir.path().to_path_buf();
-    let (handle, url) = exoware_simulator::spawn_for_test(&path, dir)
-        .await
-        .expect("spawn_for_test");
+/// Spawns a local simulator and returns a client for it plus the base URL.
+async fn spawn_client() -> (PrefixedStoreClient, String) {
+    let (_task, url) = exoware_simulator::test_spawn().await.expect("test_spawn");
     let client = StoreClient::builder()
         .url(&url)
         .retry_config(RetryConfig::disabled())
         .build()
         .expect("build client");
-    (handle, PrefixedStoreClient::empty(client), url)
+    (PrefixedStoreClient::empty(client), url)
 }
 
 fn key(b: &[u8]) -> Key {
@@ -43,7 +37,7 @@ fn key(b: &[u8]) -> Key {
 
 #[tokio::test]
 async fn put_and_get_round_trip() {
-    let (_h, client, _url) = spawn_client().await;
+    let (client, _url) = spawn_client().await;
     let k = key(b"hello");
     let v = b"world";
     let seq = client.ingest().put(&[(&k, v)]).await.expect("put");
@@ -55,14 +49,14 @@ async fn put_and_get_round_trip() {
 
 #[tokio::test]
 async fn get_missing_key_returns_none() {
-    let (_h, client, _url) = spawn_client().await;
+    let (client, _url) = spawn_client().await;
     let got = client.query().get(&key(b"nope")).await.expect("get");
     assert!(got.is_none());
 }
 
 #[tokio::test]
 async fn put_overwrites_value() {
-    let (_h, client, _url) = spawn_client().await;
+    let (client, _url) = spawn_client().await;
     let k = key(b"k");
     client.ingest().put(&[(&k, b"v1")]).await.expect("put1");
     let seq2 = client.ingest().put(&[(&k, b"v2")]).await.expect("put2");
@@ -78,7 +72,7 @@ async fn put_overwrites_value() {
 
 #[tokio::test]
 async fn get_many_returns_found_and_missing() {
-    let (_h, client, _url) = spawn_client().await;
+    let (client, _url) = spawn_client().await;
     let ka = key(b"a");
     let kb = key(b"b");
     let kc = key(b"c");
@@ -103,7 +97,7 @@ async fn get_many_returns_found_and_missing() {
 
 #[tokio::test]
 async fn range_forward() {
-    let (_h, client, _url) = spawn_client().await;
+    let (client, _url) = spawn_client().await;
     let ka = key(b"ra");
     let kb = key(b"rb");
     let kc = key(b"rc");
@@ -124,7 +118,7 @@ async fn range_forward() {
 
 #[tokio::test]
 async fn range_reverse() {
-    let (_h, client, _url) = spawn_client().await;
+    let (client, _url) = spawn_client().await;
     let ka = key(b"sa");
     let kb = key(b"sb");
     let kc = key(b"sc");
@@ -145,7 +139,7 @@ async fn range_reverse() {
 
 #[tokio::test]
 async fn range_with_limit() {
-    let (_h, client, _url) = spawn_client().await;
+    let (client, _url) = spawn_client().await;
     let ka = key(b"la");
     let kb = key(b"lb");
     let kc = key(b"lc");
@@ -167,7 +161,7 @@ async fn range_with_limit() {
 
 #[tokio::test]
 async fn range_empty_result() {
-    let (_h, client, _url) = spawn_client().await;
+    let (client, _url) = spawn_client().await;
     let rows = client
         .query()
         .range(&key(b"zzz_no"), &key(b"zzz_nz"), 100)
@@ -180,7 +174,7 @@ async fn range_empty_result() {
 
 #[tokio::test]
 async fn reduce_count_all() {
-    let (_h, client, _url) = spawn_client().await;
+    let (client, _url) = spawn_client().await;
     let ka = key(b"ca");
     let kb = key(b"cb");
     let kc = key(b"cc");
@@ -211,7 +205,7 @@ async fn reduce_count_all() {
 
 #[tokio::test]
 async fn reduce_sum_int64() {
-    let (_h, client, _url) = spawn_client().await;
+    let (client, _url) = spawn_client().await;
     let ka = key(b"ua");
     let kb = key(b"ub");
     let kc = key(b"uc");
@@ -257,7 +251,7 @@ async fn reduce_sum_int64() {
 
 #[tokio::test]
 async fn prune_drop_all_removes_keys() {
-    let (_h, client, url) = spawn_client().await;
+    let (client, url) = spawn_client().await;
 
     let codec = KeyCodec::new(4, 1);
     let ka = codec.encode(b"aaa").expect("encode key a");
@@ -317,7 +311,7 @@ async fn prune_drop_all_removes_keys() {
 
 #[tokio::test]
 async fn create_session_with_sequence_reads_at_or_above_floor() {
-    let (_h, client, _url) = spawn_client().await;
+    let (client, _url) = spawn_client().await;
     let k1 = key(b"s1");
     let k2 = key(b"s2");
     let seq1 = client.ingest().put(&[(&k1, b"v1")]).await.expect("put1");
@@ -333,7 +327,7 @@ async fn create_session_with_sequence_reads_at_or_above_floor() {
 
 #[tokio::test]
 async fn health_endpoint() {
-    let (_h, client, _url) = spawn_client().await;
+    let (client, _url) = spawn_client().await;
     assert!(client.client().health().await.expect("health"));
 }
 
@@ -341,7 +335,7 @@ async fn health_endpoint() {
 
 #[tokio::test]
 async fn put_batch_multiple_keys() {
-    let (_h, client, _url) = spawn_client().await;
+    let (client, _url) = spawn_client().await;
     let ka = key(b"ba");
     let kb = key(b"bb");
     let kc = key(b"bc");
@@ -369,7 +363,7 @@ async fn put_batch_multiple_keys() {
 
 #[tokio::test]
 async fn range_stream_collects_all() {
-    let (_h, client, _url) = spawn_client().await;
+    let (client, _url) = spawn_client().await;
     let ka = key(b"xa");
     let kb = key(b"xb");
     let kc = key(b"xc");
@@ -395,7 +389,7 @@ async fn range_stream_collects_all() {
 
 #[tokio::test]
 async fn get_with_min_sequence_number() {
-    let (_h, client, _url) = spawn_client().await;
+    let (client, _url) = spawn_client().await;
     let k = key(b"msn");
     let seq = client.ingest().put(&[(&k, b"val")]).await.expect("put");
     let got = client
@@ -410,7 +404,7 @@ async fn get_with_min_sequence_number() {
 
 #[tokio::test]
 async fn prune_keep_latest_retains_newest() {
-    let (_h, client, url) = spawn_client().await;
+    let (client, url) = spawn_client().await;
 
     let codec = KeyCodec::new(4, 2);
     // Keys: prefix(4bits,family=2) + logical(3 bytes) + \x00\x00 + version(8 bytes big-endian u64)
@@ -503,7 +497,7 @@ async fn prune_keep_latest_retains_newest() {
 
 #[tokio::test]
 async fn reduce_count_min_max_field() {
-    let (_h, client, _url) = spawn_client().await;
+    let (client, _url) = spawn_client().await;
     let encode_row = |v: i64| -> Vec<u8> {
         StoredRow {
             values: vec![Some(StoredValue::Int64(v))],
@@ -559,7 +553,7 @@ async fn reduce_count_min_max_field() {
 
 #[tokio::test]
 async fn reduce_grouped_count() {
-    let (_h, client, _url) = spawn_client().await;
+    let (client, _url) = spawn_client().await;
     let codec = KeyCodec::new(4, 1);
     let encode_row = |v: i64| -> Vec<u8> {
         StoredRow {
@@ -605,7 +599,7 @@ async fn reduce_grouped_count() {
 
 #[tokio::test]
 async fn store_client_prune_drop_all() {
-    let (_h, client, _url) = spawn_client().await;
+    let (client, _url) = spawn_client().await;
 
     let codec = KeyCodec::new(4, 5);
     let ka = codec.encode(b"pa").expect("encode");
@@ -642,7 +636,7 @@ async fn store_client_prune_drop_all() {
 
 #[tokio::test]
 async fn prune_greater_than_retains_above_threshold() {
-    let (_h, client, url) = spawn_client().await;
+    let (client, url) = spawn_client().await;
 
     let codec = KeyCodec::new(4, 3);
     let make_key = |logical: &[u8; 2], version: u64| -> Key {

--- a/examples/simulator/tests/e2e_connect.rs
+++ b/examples/simulator/tests/e2e_connect.rs
@@ -20,7 +20,7 @@ use exoware_sdk::{
 
 /// Spawns a local simulator and returns a client for it plus the base URL.
 async fn spawn_client() -> (PrefixedStoreClient, String) {
-    let (_task, url) = exoware_simulator::test_spawn().await.expect("test_spawn");
+    let (_task, url) = exoware_simulator::open_temp().await.expect("open_temp");
     let client = StoreClient::builder()
         .url(&url)
         .retry_config(RetryConfig::disabled())

--- a/examples/simulator/tests/e2e_connect.rs
+++ b/examples/simulator/tests/e2e_connect.rs
@@ -19,15 +19,12 @@ use exoware_sdk::{
 };
 use tempfile::tempdir;
 
-/// The tempdir guard rides along with the join handle so the store's data
-/// directory outlives the test instead of being deleted under the server.
-async fn spawn_client() -> (
-    (tokio::task::JoinHandle<()>, tempfile::TempDir),
-    PrefixedStoreClient,
-    String,
-) {
+/// The tempdir guard moves into the server task, which holds the store until
+/// runtime teardown, so the data directory is never deleted under the store.
+async fn spawn_client() -> (tokio::task::JoinHandle<()>, PrefixedStoreClient, String) {
     let dir = tempdir().expect("tempdir");
-    let (handle, url) = exoware_simulator::spawn_for_test(dir.path())
+    let path = dir.path().to_path_buf();
+    let (handle, url) = exoware_simulator::spawn_for_test(&path, dir)
         .await
         .expect("spawn_for_test");
     let client = StoreClient::builder()
@@ -35,7 +32,7 @@ async fn spawn_client() -> (
         .retry_config(RetryConfig::disabled())
         .build()
         .expect("build client");
-    ((handle, dir), PrefixedStoreClient::empty(client), url)
+    (handle, PrefixedStoreClient::empty(client), url)
 }
 
 fn key(b: &[u8]) -> Key {

--- a/examples/simulator/tests/e2e_connect.rs
+++ b/examples/simulator/tests/e2e_connect.rs
@@ -19,8 +19,8 @@ use exoware_sdk::{
 };
 use tempfile::tempdir;
 
-/// The tempdir guard moves into the server task, which holds the store until
-/// runtime teardown, so the data directory is never deleted under the store.
+/// The tempdir guard moves into the store engine, which every server and connection task
+/// holds, so the data directory is never deleted under the store however tasks are torn down.
 async fn spawn_client() -> (tokio::task::JoinHandle<()>, PrefixedStoreClient, String) {
     let dir = tempdir().expect("tempdir");
     let path = dir.path().to_path_buf();

--- a/examples/simulator/tests/e2e_connect.rs
+++ b/examples/simulator/tests/e2e_connect.rs
@@ -19,11 +19,15 @@ use exoware_sdk::{
 };
 use tempfile::tempdir;
 
-async fn spawn_client() -> (tokio::task::JoinHandle<()>, PrefixedStoreClient, String) {
+/// The tempdir guard rides along with the join handle so the store's data
+/// directory outlives the test instead of being deleted under the server.
+async fn spawn_client() -> (
+    (tokio::task::JoinHandle<()>, tempfile::TempDir),
+    PrefixedStoreClient,
+    String,
+) {
     let dir = tempdir().expect("tempdir");
-    let dir_path = dir.path().to_owned();
-    let _dir = dir;
-    let (handle, url) = exoware_simulator::spawn_for_test(&dir_path)
+    let (handle, url) = exoware_simulator::spawn_for_test(dir.path())
         .await
         .expect("spawn_for_test");
     let client = StoreClient::builder()
@@ -31,7 +35,7 @@ async fn spawn_client() -> (tokio::task::JoinHandle<()>, PrefixedStoreClient, St
         .retry_config(RetryConfig::disabled())
         .build()
         .expect("build client");
-    (handle, PrefixedStoreClient::empty(client), url)
+    ((handle, dir), PrefixedStoreClient::empty(client), url)
 }
 
 fn key(b: &[u8]) -> Key {

--- a/examples/simulator/tests/e2e_stream.rs
+++ b/examples/simulator/tests/e2e_stream.rs
@@ -9,8 +9,8 @@ use exoware_sdk::stream_filter::StreamFilter;
 use exoware_sdk::{PrefixedStoreClient, RetryConfig, StoreClient};
 use tempfile::tempdir;
 
-/// The tempdir guard moves into the server task, which holds the store until
-/// runtime teardown, so the data directory is never deleted under the store.
+/// The tempdir guard moves into the store engine, which every server and connection task
+/// holds, so the data directory is never deleted under the store however tasks are torn down.
 async fn spawn_client() -> (tokio::task::JoinHandle<()>, PrefixedStoreClient) {
     let dir = tempdir().expect("tempdir");
     let path = dir.path().to_path_buf();

--- a/examples/simulator/tests/e2e_stream.rs
+++ b/examples/simulator/tests/e2e_stream.rs
@@ -9,11 +9,14 @@ use exoware_sdk::stream_filter::StreamFilter;
 use exoware_sdk::{PrefixedStoreClient, RetryConfig, StoreClient};
 use tempfile::tempdir;
 
-async fn spawn_client() -> (tokio::task::JoinHandle<()>, PrefixedStoreClient) {
+/// The tempdir guard rides along with the join handle so the store's data
+/// directory outlives the test instead of being deleted under the server.
+async fn spawn_client() -> (
+    (tokio::task::JoinHandle<()>, tempfile::TempDir),
+    PrefixedStoreClient,
+) {
     let dir = tempdir().expect("tempdir");
-    let dir_path = dir.path().to_owned();
-    let _dir = dir;
-    let (handle, url) = exoware_simulator::spawn_for_test(&dir_path)
+    let (handle, url) = exoware_simulator::spawn_for_test(dir.path())
         .await
         .expect("spawn_for_test");
     let client = StoreClient::builder()
@@ -21,7 +24,7 @@ async fn spawn_client() -> (tokio::task::JoinHandle<()>, PrefixedStoreClient) {
         .retry_config(RetryConfig::disabled())
         .build()
         .expect("build client");
-    (handle, PrefixedStoreClient::empty(client))
+    ((handle, dir), PrefixedStoreClient::empty(client))
 }
 
 fn key(family: u16, payload: &[u8]) -> Key {

--- a/examples/simulator/tests/e2e_stream.rs
+++ b/examples/simulator/tests/e2e_stream.rs
@@ -9,14 +9,12 @@ use exoware_sdk::stream_filter::StreamFilter;
 use exoware_sdk::{PrefixedStoreClient, RetryConfig, StoreClient};
 use tempfile::tempdir;
 
-/// The tempdir guard rides along with the join handle so the store's data
-/// directory outlives the test instead of being deleted under the server.
-async fn spawn_client() -> (
-    (tokio::task::JoinHandle<()>, tempfile::TempDir),
-    PrefixedStoreClient,
-) {
+/// The tempdir guard moves into the server task, which holds the store until
+/// runtime teardown, so the data directory is never deleted under the store.
+async fn spawn_client() -> (tokio::task::JoinHandle<()>, PrefixedStoreClient) {
     let dir = tempdir().expect("tempdir");
-    let (handle, url) = exoware_simulator::spawn_for_test(dir.path())
+    let path = dir.path().to_path_buf();
+    let (handle, url) = exoware_simulator::spawn_for_test(&path, dir)
         .await
         .expect("spawn_for_test");
     let client = StoreClient::builder()
@@ -24,7 +22,7 @@ async fn spawn_client() -> (
         .retry_config(RetryConfig::disabled())
         .build()
         .expect("build client");
-    ((handle, dir), PrefixedStoreClient::empty(client))
+    (handle, PrefixedStoreClient::empty(client))
 }
 
 fn key(family: u16, payload: &[u8]) -> Key {

--- a/examples/simulator/tests/e2e_stream.rs
+++ b/examples/simulator/tests/e2e_stream.rs
@@ -7,22 +7,16 @@ use exoware_sdk::prune_policy::{PolicyScope, PrunePolicy, RetainPolicy};
 use exoware_sdk::selector::Selector;
 use exoware_sdk::stream_filter::StreamFilter;
 use exoware_sdk::{PrefixedStoreClient, RetryConfig, StoreClient};
-use tempfile::tempdir;
 
-/// The tempdir guard moves into the store engine, which every server and connection task
-/// holds, so the data directory is never deleted under the store however tasks are torn down.
-async fn spawn_client() -> (tokio::task::JoinHandle<()>, PrefixedStoreClient) {
-    let dir = tempdir().expect("tempdir");
-    let path = dir.path().to_path_buf();
-    let (handle, url) = exoware_simulator::spawn_for_test(&path, dir)
-        .await
-        .expect("spawn_for_test");
+/// Spawns a local simulator and returns a client for it.
+async fn spawn_client() -> PrefixedStoreClient {
+    let (_task, url) = exoware_simulator::test_spawn().await.expect("test_spawn");
     let client = StoreClient::builder()
         .url(&url)
         .retry_config(RetryConfig::disabled())
         .build()
         .expect("build client");
-    (handle, PrefixedStoreClient::empty(client))
+    PrefixedStoreClient::empty(client)
 }
 
 fn key(family: u16, payload: &[u8]) -> Key {
@@ -68,7 +62,7 @@ async fn next_with_timeout(
 
 #[tokio::test]
 async fn live_subscribe_delivers_matching_entries() {
-    let (_h, client) = spawn_client().await;
+    let client = spawn_client().await;
     let mut sub = client
         .stream()
         .subscribe(filter(1), None)
@@ -92,7 +86,7 @@ async fn live_subscribe_delivers_matching_entries() {
 
 #[tokio::test]
 async fn non_matching_put_yields_no_frame() {
-    let (_h, client) = spawn_client().await;
+    let client = spawn_client().await;
     let mut sub = client
         .stream()
         .subscribe(filter(1), None)
@@ -114,7 +108,7 @@ async fn non_matching_put_yields_no_frame() {
 
 #[tokio::test]
 async fn multiple_selectors_delivered_once_per_put() {
-    let (_h, client) = spawn_client().await;
+    let client = spawn_client().await;
     let f = StreamFilter {
         selectors: vec![
             Selector {
@@ -153,7 +147,7 @@ async fn multiple_selectors_delivered_once_per_put() {
 
 #[tokio::test]
 async fn two_puts_yield_two_distinct_frames() {
-    let (_h, client) = spawn_client().await;
+    let client = spawn_client().await;
     let mut sub = client
         .stream()
         .subscribe(filter(1), None)
@@ -183,7 +177,7 @@ async fn two_puts_yield_two_distinct_frames() {
 
 #[tokio::test]
 async fn replay_since_delivers_retained_batches_then_live() {
-    let (_h, client) = spawn_client().await;
+    let client = spawn_client().await;
     let mut seen_seqs = Vec::new();
     for i in 0..5u8 {
         let seq = client
@@ -227,7 +221,7 @@ async fn replay_since_delivers_retained_batches_then_live() {
 
 #[tokio::test]
 async fn replay_past_end_delivers_only_live() {
-    let (_h, client) = spawn_client().await;
+    let client = spawn_client().await;
     let current = client
         .ingest()
         .put(&[(&key(1, b"seed"), b"v")])
@@ -258,7 +252,7 @@ async fn replay_past_end_delivers_only_live() {
 
 #[tokio::test]
 async fn replay_miss_after_prune_returns_batch_evicted() {
-    let (_h, client) = spawn_client().await;
+    let client = spawn_client().await;
     for i in 0..20u8 {
         client
             .ingest()
@@ -294,7 +288,7 @@ async fn replay_miss_after_prune_returns_batch_evicted() {
 
 #[tokio::test]
 async fn get_batch_returns_whole_batch_unfiltered() {
-    let (_h, client) = spawn_client().await;
+    let client = spawn_client().await;
     let ka = key(1, b"a");
     let kb = key(2, b"b");
     let seq = client
@@ -319,7 +313,7 @@ async fn get_batch_returns_whole_batch_unfiltered() {
 
 #[tokio::test]
 async fn get_batch_missing_seq_returns_none() {
-    let (_h, client) = spawn_client().await;
+    let client = spawn_client().await;
     client
         .ingest()
         .put(&[(&key(1, b"a"), b"1")])
@@ -335,7 +329,7 @@ async fn get_batch_missing_seq_returns_none() {
 
 #[tokio::test]
 async fn get_batch_after_drop_all_returns_none() {
-    let (_h, client) = spawn_client().await;
+    let client = spawn_client().await;
     let seq = client
         .ingest()
         .put(&[(&key(1, b"a"), b"1")])
@@ -353,7 +347,7 @@ async fn get_batch_after_drop_all_returns_none() {
 
 #[tokio::test]
 async fn get_batch_after_keep_latest_evicts_old_but_keeps_new() {
-    let (_h, client) = spawn_client().await;
+    let client = spawn_client().await;
     let mut seqs = Vec::new();
     for i in 0..20u8 {
         let s = client
@@ -386,7 +380,7 @@ async fn get_batch_after_keep_latest_evicts_old_but_keeps_new() {
 
 #[tokio::test]
 async fn slow_subscriber_drops_without_blocking_ingest() {
-    let (_h, client) = spawn_client().await;
+    let client = spawn_client().await;
     // Open subscription but never drain it. Internal cap = 256 frames.
     let _sub = client
         .stream()
@@ -424,7 +418,7 @@ async fn slow_subscriber_drops_without_blocking_ingest() {
 #[tokio::test]
 async fn value_filter_restricts_to_matching_values() {
     use exoware_sdk::stream_filter::Filter;
-    let (_h, client) = spawn_client().await;
+    let client = spawn_client().await;
     let f = StreamFilter {
         selectors: vec![Selector {
             reserved_bits: 4,

--- a/examples/simulator/tests/e2e_stream.rs
+++ b/examples/simulator/tests/e2e_stream.rs
@@ -10,7 +10,7 @@ use exoware_sdk::{PrefixedStoreClient, RetryConfig, StoreClient};
 
 /// Spawns a local simulator and returns a client for it.
 async fn spawn_client() -> PrefixedStoreClient {
-    let (_task, url) = exoware_simulator::test_spawn().await.expect("test_spawn");
+    let (_task, url) = exoware_simulator::open_temp().await.expect("open_temp");
     let client = StoreClient::builder()
         .url(&url)
         .retry_config(RetryConfig::disabled())

--- a/examples/simulator/tests/prune_contract.rs
+++ b/examples/simulator/tests/prune_contract.rs
@@ -331,6 +331,7 @@ fn key_pruned_state_survives_reopen_when_versions_share_a_batch() {
         let v1 = versioned_key(b"row", 1);
         let v2 = versioned_key(b"row", 2);
         let v3 = versioned_key(b"row", 3);
+
         // All versions land in one batch, so one retained log row holds the pruned keys.
         put_batch(
             &store,

--- a/examples/simulator/tests/prune_contract.rs
+++ b/examples/simulator/tests/prune_contract.rs
@@ -277,7 +277,7 @@ fn pruned_state_survives_reopen() {
         (v1, v2, v3, retained_sequence)
     };
 
-    // Reopening (which replays retained log rows above the flushed watermark) must not
+    // Reopening (which replays retained log rows above the state floor) must not
     // resurrect pruned current keys or pruned log rows.
     let store = RocksStore::open(dir.path(), None).expect("reopen db");
     assert_eq!(store.current_sequence(), retained_sequence);
@@ -290,6 +290,41 @@ fn pruned_state_survives_reopen() {
     assert!(block_on(store.get_batch(retained_sequence))
         .expect("get batch")
         .is_some());
+}
+
+#[test]
+fn key_pruned_state_survives_reopen_when_versions_share_a_batch() {
+    let dir = tempdir().expect("tempdir");
+    let (v1, v2, v3) = {
+        let store = RocksStore::open(dir.path(), None).expect("open db");
+        let v1 = versioned_key(b"row", 1);
+        let v2 = versioned_key(b"row", 2);
+        let v3 = versioned_key(b"row", 3);
+        // All versions land in one batch, so one retained log row holds the pruned keys.
+        put_batch(
+            &store,
+            vec![
+                (v1.clone(), Bytes::from_static(b"v1")),
+                (v2.clone(), Bytes::from_static(b"v2")),
+                (v3.clone(), Bytes::from_static(b"v3")),
+            ],
+        );
+
+        apply_prune(
+            &store,
+            &[version_policy(RetainPolicy::KeepLatest { count: 1 })],
+        );
+        assert!(get_value(&store, &v1).is_none());
+        assert!(get_value(&store, &v2).is_none());
+        (v1, v2, v3)
+    };
+
+    // Reopening replays retained log rows; that replay must not resurrect key-pruned rows
+    // whose log entries are still retained.
+    let store = RocksStore::open(dir.path(), None).expect("reopen db");
+    assert!(get_value(&store, &v1).is_none());
+    assert!(get_value(&store, &v2).is_none());
+    assert_eq!(get_value(&store, &v3).as_deref(), Some(b"v3".as_slice()));
 }
 
 #[test]

--- a/examples/simulator/tests/prune_contract.rs
+++ b/examples/simulator/tests/prune_contract.rs
@@ -293,6 +293,37 @@ fn pruned_state_survives_reopen() {
 }
 
 #[test]
+fn sequence_survives_reopen_after_drop_all_prune() {
+    let dir = tempdir().expect("tempdir");
+    let last = {
+        let store = RocksStore::open(dir.path(), None).expect("open db");
+        put_batch(
+            &store,
+            vec![(versioned_key(b"row", 1), Bytes::from_static(b"v1"))],
+        );
+        let last = put_batch(
+            &store,
+            vec![(versioned_key(b"row", 2), Bytes::from_static(b"v2"))],
+        );
+        apply_prune(&store, &[sequence_policy(RetainPolicy::DropAll)]);
+        assert!(block_on(store.oldest_retained_batch())
+            .expect("oldest")
+            .is_none());
+        last
+    };
+
+    // Every log row is gone, so the floor written atomically with the tombstone is the only
+    // record of the frontier; without it a reopen would re-issue acked sequence numbers.
+    let store = RocksStore::open(dir.path(), None).expect("reopen db");
+    assert_eq!(store.current_sequence(), last);
+    let next = put_batch(
+        &store,
+        vec![(versioned_key(b"row", 3), Bytes::from_static(b"v3"))],
+    );
+    assert_eq!(next, last + 1);
+}
+
+#[test]
 fn key_pruned_state_survives_reopen_when_versions_share_a_batch() {
     let dir = tempdir().expect("tempdir");
     let (v1, v2, v3) = {

--- a/examples/simulator/tests/prune_contract.rs
+++ b/examples/simulator/tests/prune_contract.rs
@@ -256,6 +256,43 @@ fn sequence_scope_prunes_log_without_advancing_sequence() {
 }
 
 #[test]
+fn pruned_state_survives_reopen() {
+    let dir = tempdir().expect("tempdir");
+    let (v1, v2, v3, retained_sequence) = {
+        let store = RocksStore::open(dir.path(), None).expect("open db");
+        let v1 = versioned_key(b"row", 1);
+        let v2 = versioned_key(b"row", 2);
+        let v3 = versioned_key(b"row", 3);
+        put_batch(&store, vec![(v1.clone(), Bytes::from_static(b"v1"))]);
+        put_batch(&store, vec![(v2.clone(), Bytes::from_static(b"v2"))]);
+        let retained_sequence = put_batch(&store, vec![(v3.clone(), Bytes::from_static(b"v3"))]);
+
+        apply_prune(
+            &store,
+            &[
+                version_policy(RetainPolicy::KeepLatest { count: 1 }),
+                sequence_policy(RetainPolicy::KeepLatest { count: 1 }),
+            ],
+        );
+        (v1, v2, v3, retained_sequence)
+    };
+
+    // Reopening (which replays retained log rows above the flushed watermark) must not
+    // resurrect pruned current keys or pruned log rows.
+    let store = RocksStore::open(dir.path(), None).expect("reopen db");
+    assert_eq!(store.current_sequence(), retained_sequence);
+    assert!(get_value(&store, &v1).is_none());
+    assert!(get_value(&store, &v2).is_none());
+    assert_eq!(get_value(&store, &v3).as_deref(), Some(b"v3".as_slice()));
+    assert!(block_on(store.get_batch(retained_sequence - 1))
+        .expect("get batch")
+        .is_none());
+    assert!(block_on(store.get_batch(retained_sequence))
+        .expect("get batch")
+        .is_some());
+}
+
+#[test]
 fn overlapping_prune_policies_apply_in_input_order() {
     let sequence_then_keys_dir = tempdir().expect("tempdir");
     let sequence_then_keys =

--- a/integration/Cargo.toml
+++ b/integration/Cargo.toml
@@ -20,5 +20,4 @@ exoware-simulator = { path = "../examples/simulator" }
 exoware-sql = { workspace = true }
 futures = { workspace = true }
 reqwest = { workspace = true }
-tempfile = { workspace = true }
 tokio = { workspace = true, features = ["full"] }

--- a/integration/tests/multi_instance.rs
+++ b/integration/tests/multi_instance.rs
@@ -39,8 +39,8 @@ type QmdbReader = KeylessClient<QmdbFamily, Sha256, Vec<u8>>;
 type QmdbWriter = KeylessWriter<QmdbFamily, Sha256, Vec<u8>>;
 type QmdbConnectClient = OperationLogClient<PreferZstdHttpClient, QmdbFamily, Sha256, QmdbOp>;
 
-/// The store's tempdir lives inside the server task so it cannot be deleted while the store is
-/// still running.
+/// The store's tempdir lives inside the store engine so it cannot be deleted while the store
+/// is still running, however the runtime tears its tasks down.
 async fn local_store_client() -> (tokio::task::JoinHandle<()>, StoreClient) {
     let dir = tempfile::tempdir().expect("tempdir");
     let path = dir.path().to_path_buf();

--- a/integration/tests/multi_instance.rs
+++ b/integration/tests/multi_instance.rs
@@ -39,20 +39,16 @@ type QmdbReader = KeylessClient<QmdbFamily, Sha256, Vec<u8>>;
 type QmdbWriter = KeylessWriter<QmdbFamily, Sha256, Vec<u8>>;
 type QmdbConnectClient = OperationLogClient<PreferZstdHttpClient, QmdbFamily, Sha256, QmdbOp>;
 
-/// The store's tempdir lives inside the store engine so it cannot be deleted while the store
-/// is still running, however the runtime tears its tasks down.
-async fn local_store_client() -> (tokio::task::JoinHandle<()>, StoreClient) {
-    let dir = tempfile::tempdir().expect("tempdir");
-    let path = dir.path().to_path_buf();
-    let (handle, url) = exoware_simulator::spawn_for_test(&path, dir)
+/// Spawns a local simulator and returns a client for it.
+async fn local_store_client() -> StoreClient {
+    let (_task, url) = exoware_simulator::test_spawn()
         .await
         .expect("spawn simulator");
-    let client = StoreClient::builder()
+    StoreClient::builder()
         .url(&url)
         .retry_config(RetryConfig::disabled())
         .build()
-        .expect("build store client");
-    (handle, client)
+        .expect("build store client")
 }
 
 async fn health() -> &'static str {
@@ -258,7 +254,7 @@ fn collect_int64_column(
 
 #[tokio::test]
 async fn raw_prefixes_support_atomic_batch_fetch_range_and_stream() {
-    let (_server, base) = local_store_client().await;
+    let base = local_store_client().await;
     let a = base.prefixed(store_prefix(1));
     let b = base.prefixed(store_prefix(2));
     let unprefixed = PrefixedStoreClient::empty(base.clone());
@@ -346,7 +342,7 @@ async fn raw_prefixes_support_atomic_batch_fetch_range_and_stream() {
 
 #[tokio::test]
 async fn sql_schemas_are_isolated_by_store_prefix() {
-    let (_server, base) = local_store_client().await;
+    let base = local_store_client().await;
     let schema_a = make_sql_schema(base.prefixed(StoreKeyPrefix::new(4, 0).unwrap()));
     let schema_b = make_sql_schema(base.prefixed(StoreKeyPrefix::new(4, 1).unwrap()));
 
@@ -379,7 +375,7 @@ async fn sql_schemas_are_isolated_by_store_prefix() {
 
 #[tokio::test]
 async fn sql_streaming_is_isolated_by_store_prefix() {
-    let (_server, base) = local_store_client().await;
+    let base = local_store_client().await;
     let client_a = base.prefixed(StoreKeyPrefix::new(4, 0).unwrap());
     let client_b = base.prefixed(StoreKeyPrefix::new(4, 1).unwrap());
     let (_sql_server_a, sql_url_a) = spawn_sql_service(make_sql_schema(client_a.clone())).await;
@@ -482,7 +478,7 @@ async fn query_sql_items(client: PrefixedStoreClient) -> (Vec<i64>, Vec<i64>) {
 
 #[tokio::test]
 async fn prefixed_qmdb_writers_handle_concurrent_inflight_batches_per_instance() {
-    let (_server, base) = local_store_client().await;
+    let base = local_store_client().await;
     let client_a = base.prefixed(StoreKeyPrefix::new(4, 4).unwrap());
     let client_b = base.prefixed(StoreKeyPrefix::new(4, 5).unwrap());
     let writer_a = Arc::new(keyless_writer(client_a.clone()));
@@ -566,7 +562,7 @@ async fn prefixed_qmdb_writers_handle_concurrent_inflight_batches_per_instance()
 
 #[tokio::test]
 async fn prepared_sql_and_qmdb_batches_commit_atomically_with_sequence_receipts() {
-    let (_server, base) = local_store_client().await;
+    let base = local_store_client().await;
     let sql_client = base.prefixed(StoreKeyPrefix::new(4, 0).unwrap());
     let qmdb_client = base.prefixed(StoreKeyPrefix::new(4, 4).unwrap());
     let mut sql_writer = make_sql_schema(sql_client.clone()).batch_writer();
@@ -678,7 +674,7 @@ async fn prepared_sql_and_qmdb_batches_commit_atomically_with_sequence_receipts(
 
 #[tokio::test]
 async fn qmdb_streaming_is_isolated_by_store_prefix() {
-    let (_server, base) = local_store_client().await;
+    let base = local_store_client().await;
     let client_a = base.prefixed(StoreKeyPrefix::new(4, 4).unwrap());
     let client_b = base.prefixed(StoreKeyPrefix::new(4, 5).unwrap());
     let (_qmdb_server_a, qmdb_url_a) = spawn_qmdb_service(client_a.clone()).await;

--- a/integration/tests/multi_instance.rs
+++ b/integration/tests/multi_instance.rs
@@ -41,7 +41,7 @@ type QmdbConnectClient = OperationLogClient<PreferZstdHttpClient, QmdbFamily, Sh
 
 /// Spawns a local simulator and returns a client for it.
 async fn local_store_client() -> StoreClient {
-    let (_task, url) = exoware_simulator::test_spawn()
+    let (_task, url) = exoware_simulator::open_temp()
         .await
         .expect("spawn simulator");
     StoreClient::builder()

--- a/integration/tests/multi_instance.rs
+++ b/integration/tests/multi_instance.rs
@@ -39,9 +39,12 @@ type QmdbReader = KeylessClient<QmdbFamily, Sha256, Vec<u8>>;
 type QmdbWriter = KeylessWriter<QmdbFamily, Sha256, Vec<u8>>;
 type QmdbConnectClient = OperationLogClient<PreferZstdHttpClient, QmdbFamily, Sha256, QmdbOp>;
 
-async fn local_store_client() -> (tempfile::TempDir, tokio::task::JoinHandle<()>, StoreClient) {
+/// The store's tempdir lives inside the server task so it cannot be deleted while the store is
+/// still running.
+async fn local_store_client() -> (tokio::task::JoinHandle<()>, StoreClient) {
     let dir = tempfile::tempdir().expect("tempdir");
-    let (handle, url) = exoware_simulator::spawn_for_test(dir.path())
+    let path = dir.path().to_path_buf();
+    let (handle, url) = exoware_simulator::spawn_for_test(&path, dir)
         .await
         .expect("spawn simulator");
     let client = StoreClient::builder()
@@ -49,7 +52,7 @@ async fn local_store_client() -> (tempfile::TempDir, tokio::task::JoinHandle<()>
         .retry_config(RetryConfig::disabled())
         .build()
         .expect("build store client");
-    (dir, handle, client)
+    (handle, client)
 }
 
 async fn health() -> &'static str {
@@ -255,7 +258,7 @@ fn collect_int64_column(
 
 #[tokio::test]
 async fn raw_prefixes_support_atomic_batch_fetch_range_and_stream() {
-    let (_dir, _server, base) = local_store_client().await;
+    let (_server, base) = local_store_client().await;
     let a = base.prefixed(store_prefix(1));
     let b = base.prefixed(store_prefix(2));
     let unprefixed = PrefixedStoreClient::empty(base.clone());
@@ -343,7 +346,7 @@ async fn raw_prefixes_support_atomic_batch_fetch_range_and_stream() {
 
 #[tokio::test]
 async fn sql_schemas_are_isolated_by_store_prefix() {
-    let (_dir, _server, base) = local_store_client().await;
+    let (_server, base) = local_store_client().await;
     let schema_a = make_sql_schema(base.prefixed(StoreKeyPrefix::new(4, 0).unwrap()));
     let schema_b = make_sql_schema(base.prefixed(StoreKeyPrefix::new(4, 1).unwrap()));
 
@@ -376,7 +379,7 @@ async fn sql_schemas_are_isolated_by_store_prefix() {
 
 #[tokio::test]
 async fn sql_streaming_is_isolated_by_store_prefix() {
-    let (_dir, _server, base) = local_store_client().await;
+    let (_server, base) = local_store_client().await;
     let client_a = base.prefixed(StoreKeyPrefix::new(4, 0).unwrap());
     let client_b = base.prefixed(StoreKeyPrefix::new(4, 1).unwrap());
     let (_sql_server_a, sql_url_a) = spawn_sql_service(make_sql_schema(client_a.clone())).await;
@@ -479,7 +482,7 @@ async fn query_sql_items(client: PrefixedStoreClient) -> (Vec<i64>, Vec<i64>) {
 
 #[tokio::test]
 async fn prefixed_qmdb_writers_handle_concurrent_inflight_batches_per_instance() {
-    let (_dir, _server, base) = local_store_client().await;
+    let (_server, base) = local_store_client().await;
     let client_a = base.prefixed(StoreKeyPrefix::new(4, 4).unwrap());
     let client_b = base.prefixed(StoreKeyPrefix::new(4, 5).unwrap());
     let writer_a = Arc::new(keyless_writer(client_a.clone()));
@@ -563,7 +566,7 @@ async fn prefixed_qmdb_writers_handle_concurrent_inflight_batches_per_instance()
 
 #[tokio::test]
 async fn prepared_sql_and_qmdb_batches_commit_atomically_with_sequence_receipts() {
-    let (_dir, _server, base) = local_store_client().await;
+    let (_server, base) = local_store_client().await;
     let sql_client = base.prefixed(StoreKeyPrefix::new(4, 0).unwrap());
     let qmdb_client = base.prefixed(StoreKeyPrefix::new(4, 4).unwrap());
     let mut sql_writer = make_sql_schema(sql_client.clone()).batch_writer();
@@ -675,7 +678,7 @@ async fn prepared_sql_and_qmdb_batches_commit_atomically_with_sequence_receipts(
 
 #[tokio::test]
 async fn qmdb_streaming_is_isolated_by_store_prefix() {
-    let (_dir, _server, base) = local_store_client().await;
+    let (_server, base) = local_store_client().await;
     let client_a = base.prefixed(StoreKeyPrefix::new(4, 4).unwrap());
     let client_b = base.prefixed(StoreKeyPrefix::new(4, 5).unwrap());
     let (_qmdb_server_a, qmdb_url_a) = spawn_qmdb_service(client_a.clone()).await;

--- a/qmdb/rs/tests/common/mod.rs
+++ b/qmdb/rs/tests/common/mod.rs
@@ -144,8 +144,8 @@ pub fn immutable_variable_config<C>(
     }
 }
 
-/// Keep `_server` alive for the whole test; the store's tempdir lives inside the server task so
-/// it cannot be deleted while the store is still running.
+/// Keep `_server` alive for the whole test; the store's tempdir lives inside the store engine
+/// so it cannot be deleted while the store is still running.
 pub async fn local_store_client() -> (tokio::task::JoinHandle<()>, StoreClient) {
     let dir = tempfile::tempdir().expect("tempdir");
     let path = dir.path().to_path_buf();

--- a/qmdb/rs/tests/common/mod.rs
+++ b/qmdb/rs/tests/common/mod.rs
@@ -144,14 +144,16 @@ pub fn immutable_variable_config<C>(
     }
 }
 
-/// Keep `_dir` and `_server` alive for the whole test.
-pub async fn local_store_client() -> (tempfile::TempDir, tokio::task::JoinHandle<()>, StoreClient) {
+/// Keep `_server` alive for the whole test; the store's tempdir lives inside the server task so
+/// it cannot be deleted while the store is still running.
+pub async fn local_store_client() -> (tokio::task::JoinHandle<()>, StoreClient) {
     let dir = tempfile::tempdir().expect("tempdir");
-    let (jh, url) = exoware_simulator::spawn_for_test(dir.path())
+    let path = dir.path().to_path_buf();
+    let (jh, url) = exoware_simulator::spawn_for_test(&path, dir)
         .await
         .expect("spawn simulator");
     let client = StoreClient::new(&url);
-    (dir, jh, client)
+    (jh, client)
 }
 
 #[allow(dead_code)]

--- a/qmdb/rs/tests/common/mod.rs
+++ b/qmdb/rs/tests/common/mod.rs
@@ -146,7 +146,7 @@ pub fn immutable_variable_config<C>(
 
 /// Spawns a local simulator and returns a client for it.
 pub async fn local_store_client() -> StoreClient {
-    let (_task, url) = exoware_simulator::test_spawn()
+    let (_task, url) = exoware_simulator::open_temp()
         .await
         .expect("spawn simulator");
     StoreClient::new(&url)

--- a/qmdb/rs/tests/common/mod.rs
+++ b/qmdb/rs/tests/common/mod.rs
@@ -144,16 +144,12 @@ pub fn immutable_variable_config<C>(
     }
 }
 
-/// Keep `_server` alive for the whole test; the store's tempdir lives inside the store engine
-/// so it cannot be deleted while the store is still running.
-pub async fn local_store_client() -> (tokio::task::JoinHandle<()>, StoreClient) {
-    let dir = tempfile::tempdir().expect("tempdir");
-    let path = dir.path().to_path_buf();
-    let (jh, url) = exoware_simulator::spawn_for_test(&path, dir)
+/// Spawns a local simulator and returns a client for it.
+pub async fn local_store_client() -> StoreClient {
+    let (_task, url) = exoware_simulator::test_spawn()
         .await
         .expect("spawn simulator");
-    let client = StoreClient::new(&url);
-    (jh, client)
+    StoreClient::new(&url)
 }
 
 #[allow(dead_code)]

--- a/qmdb/rs/tests/e2e_immutable.rs
+++ b/qmdb/rs/tests/e2e_immutable.rs
@@ -201,7 +201,7 @@ async fn build_fixed_local_db() -> FixedLocalReference {
 
 #[tokio::test]
 async fn immutable_round_trip() {
-    let (_server, client) = common::local_store_client().await;
+    let client = common::local_store_client().await;
     let local = build_local_db().await;
 
     let writer = fresh_writer(client.clone());
@@ -243,7 +243,7 @@ async fn immutable_round_trip() {
 
 #[tokio::test]
 async fn immutable_fixed_round_trip() {
-    let (_server, client) = common::local_store_client().await;
+    let client = common::local_store_client().await;
     let local = build_fixed_local_db().await;
 
     let writer = fresh_fixed_writer(client.clone());

--- a/qmdb/rs/tests/e2e_immutable.rs
+++ b/qmdb/rs/tests/e2e_immutable.rs
@@ -201,7 +201,7 @@ async fn build_fixed_local_db() -> FixedLocalReference {
 
 #[tokio::test]
 async fn immutable_round_trip() {
-    let (_dir, _server, client) = common::local_store_client().await;
+    let (_server, client) = common::local_store_client().await;
     let local = build_local_db().await;
 
     let writer = fresh_writer(client.clone());
@@ -243,7 +243,7 @@ async fn immutable_round_trip() {
 
 #[tokio::test]
 async fn immutable_fixed_round_trip() {
-    let (_dir, _server, client) = common::local_store_client().await;
+    let (_server, client) = common::local_store_client().await;
     let local = build_fixed_local_db().await;
 
     let writer = fresh_fixed_writer(client.clone());

--- a/qmdb/rs/tests/e2e_immutable_connect.rs
+++ b/qmdb/rs/tests/e2e_immutable_connect.rs
@@ -134,7 +134,7 @@ async fn commit_upload(client: &StoreClient, batch: &LocalBatch) {
 
 #[tokio::test]
 async fn immutable_connect_subscribe_emits_verifiable_multi_proof() {
-    let (_dir, _store_server, store_client) = common::local_store_client().await;
+    let (_store_server, store_client) = common::local_store_client().await;
     let local = build_local_batch().await;
     assert!(
         *local.inactivity_floor > 0,
@@ -178,7 +178,7 @@ async fn immutable_connect_subscribe_emits_verifiable_multi_proof() {
 
 #[tokio::test]
 async fn immutable_connect_get_operation_range_returns_verifiable_proof() {
-    let (_dir, _store_server, store_client) = common::local_store_client().await;
+    let (_store_server, store_client) = common::local_store_client().await;
     let local = build_local_batch().await;
     assert!(
         *local.inactivity_floor > 0,
@@ -216,7 +216,7 @@ async fn immutable_connect_get_operation_range_returns_verifiable_proof() {
 
 #[tokio::test]
 async fn immutable_connect_client_rejects_invalid_streamed_proof() {
-    let (_dir, _store_server, store_client) = common::local_store_client().await;
+    let (_store_server, store_client) = common::local_store_client().await;
     let local = build_local_batch().await;
     assert!(
         *local.inactivity_floor > 0,

--- a/qmdb/rs/tests/e2e_immutable_connect.rs
+++ b/qmdb/rs/tests/e2e_immutable_connect.rs
@@ -134,7 +134,7 @@ async fn commit_upload(client: &StoreClient, batch: &LocalBatch) {
 
 #[tokio::test]
 async fn immutable_connect_subscribe_emits_verifiable_multi_proof() {
-    let (_store_server, store_client) = common::local_store_client().await;
+    let store_client = common::local_store_client().await;
     let local = build_local_batch().await;
     assert!(
         *local.inactivity_floor > 0,
@@ -178,7 +178,7 @@ async fn immutable_connect_subscribe_emits_verifiable_multi_proof() {
 
 #[tokio::test]
 async fn immutable_connect_get_operation_range_returns_verifiable_proof() {
-    let (_store_server, store_client) = common::local_store_client().await;
+    let store_client = common::local_store_client().await;
     let local = build_local_batch().await;
     assert!(
         *local.inactivity_floor > 0,
@@ -216,7 +216,7 @@ async fn immutable_connect_get_operation_range_returns_verifiable_proof() {
 
 #[tokio::test]
 async fn immutable_connect_client_rejects_invalid_streamed_proof() {
-    let (_store_server, store_client) = common::local_store_client().await;
+    let store_client = common::local_store_client().await;
     let local = build_local_batch().await;
     assert!(
         *local.inactivity_floor > 0,

--- a/qmdb/rs/tests/e2e_immutable_writer.rs
+++ b/qmdb/rs/tests/e2e_immutable_writer.rs
@@ -131,7 +131,7 @@ fn split_upload_batches(
 
 #[tokio::test]
 async fn sequential_upload_matches_local_root() {
-    let (_dir, _server, client) = common::local_store_client().await;
+    let (_server, client) = common::local_store_client().await;
     let local = build_local_reference(vec![
         vec![(FixedBytes::new([0x11; 32]), b"alpha".to_vec())],
         vec![(FixedBytes::new([0x22; 32]), b"beta".to_vec())],
@@ -168,7 +168,7 @@ async fn sequential_upload_matches_local_root() {
 
 #[tokio::test]
 async fn pipelined_batches_require_flush_to_catch_up_watermark() {
-    let (_dir, _server, client) = common::local_store_client().await;
+    let (_server, client) = common::local_store_client().await;
     let local = build_local_reference(vec![
         vec![(FixedBytes::new([0x01; 32]), b"a".to_vec())],
         vec![(FixedBytes::new([0x02; 32]), b"b".to_vec())],

--- a/qmdb/rs/tests/e2e_immutable_writer.rs
+++ b/qmdb/rs/tests/e2e_immutable_writer.rs
@@ -131,7 +131,7 @@ fn split_upload_batches(
 
 #[tokio::test]
 async fn sequential_upload_matches_local_root() {
-    let (_server, client) = common::local_store_client().await;
+    let client = common::local_store_client().await;
     let local = build_local_reference(vec![
         vec![(FixedBytes::new([0x11; 32]), b"alpha".to_vec())],
         vec![(FixedBytes::new([0x22; 32]), b"beta".to_vec())],
@@ -168,7 +168,7 @@ async fn sequential_upload_matches_local_root() {
 
 #[tokio::test]
 async fn pipelined_batches_require_flush_to_catch_up_watermark() {
-    let (_server, client) = common::local_store_client().await;
+    let client = common::local_store_client().await;
     let local = build_local_reference(vec![
         vec![(FixedBytes::new([0x01; 32]), b"a".to_vec())],
         vec![(FixedBytes::new([0x02; 32]), b"b".to_vec())],

--- a/qmdb/rs/tests/e2e_keyless.rs
+++ b/qmdb/rs/tests/e2e_keyless.rs
@@ -192,7 +192,7 @@ where
     KeylessOperation<F, Vec<u8>>:
         commonware_codec::Codec<Cfg = <Vec<u8> as commonware_codec::Read>::Cfg> + Clone + PartialEq,
 {
-    let (_dir, _server, client) = common::local_store_client().await;
+    let (_server, client) = common::local_store_client().await;
     let local = build_local_db::<F>().await;
 
     let writer = fresh_writer::<F>(client.clone());
@@ -263,7 +263,7 @@ where
 
 #[tokio::test]
 async fn keyless_fixed_round_trip() {
-    let (_dir, _server, client) = common::local_store_client().await;
+    let (_server, client) = common::local_store_client().await;
     let local = build_fixed_local_db::<mmr::Family>().await;
 
     let writer = fresh_fixed_writer::<mmr::Family>(client.clone());

--- a/qmdb/rs/tests/e2e_keyless.rs
+++ b/qmdb/rs/tests/e2e_keyless.rs
@@ -192,7 +192,7 @@ where
     KeylessOperation<F, Vec<u8>>:
         commonware_codec::Codec<Cfg = <Vec<u8> as commonware_codec::Read>::Cfg> + Clone + PartialEq,
 {
-    let (_server, client) = common::local_store_client().await;
+    let client = common::local_store_client().await;
     let local = build_local_db::<F>().await;
 
     let writer = fresh_writer::<F>(client.clone());
@@ -263,7 +263,7 @@ where
 
 #[tokio::test]
 async fn keyless_fixed_round_trip() {
-    let (_server, client) = common::local_store_client().await;
+    let client = common::local_store_client().await;
     let local = build_fixed_local_db::<mmr::Family>().await;
 
     let writer = fresh_fixed_writer::<mmr::Family>(client.clone());

--- a/qmdb/rs/tests/e2e_keyless_connect.rs
+++ b/qmdb/rs/tests/e2e_keyless_connect.rs
@@ -130,7 +130,7 @@ async fn commit_upload(client: &StoreClient, batch: &LocalBatch) {
 
 #[tokio::test]
 async fn keyless_connect_subscribe_emits_verifiable_multi_proof() {
-    let (_store_server, store_client) = common::local_store_client().await;
+    let store_client = common::local_store_client().await;
     let local = build_local_batch().await;
     assert!(
         *local.inactivity_floor > 0,
@@ -174,7 +174,7 @@ async fn keyless_connect_subscribe_emits_verifiable_multi_proof() {
 
 #[tokio::test]
 async fn keyless_connect_get_operation_range_returns_verifiable_proof() {
-    let (_store_server, store_client) = common::local_store_client().await;
+    let store_client = common::local_store_client().await;
     let local = build_local_batch().await;
     assert!(
         *local.inactivity_floor > 0,
@@ -212,7 +212,7 @@ async fn keyless_connect_get_operation_range_returns_verifiable_proof() {
 
 #[tokio::test]
 async fn keyless_operation_log_sync_resolver_fetches_api_batches() {
-    let (_store_server, store_client) = common::local_store_client().await;
+    let store_client = common::local_store_client().await;
     let local = build_local_batch().await;
     commit_upload(&store_client, &local).await;
 
@@ -258,7 +258,7 @@ async fn keyless_operation_log_sync_resolver_fetches_api_batches() {
 
 #[tokio::test]
 async fn keyless_commonware_glue_state_sync_uses_operation_log_resolver() {
-    let (_store_server, store_client) = common::local_store_client().await;
+    let store_client = common::local_store_client().await;
     let local = build_local_batch().await;
     assert!(
         *local.inactivity_floor > 0,
@@ -380,7 +380,7 @@ async fn keyless_operation_log_sync_resolver_observes_cancelled_fetch() {
 
 #[tokio::test]
 async fn keyless_connect_client_rejects_invalid_streamed_proof() {
-    let (_store_server, store_client) = common::local_store_client().await;
+    let store_client = common::local_store_client().await;
     let local = build_local_batch().await;
     assert!(
         *local.inactivity_floor > 0,
@@ -447,7 +447,7 @@ fn match_regex(regex: &str) -> ProtoFilter {
 
 #[tokio::test]
 async fn keyless_connect_subscribe_filters_by_value_regex() {
-    let (_store_server, store_client) = common::local_store_client().await;
+    let store_client = common::local_store_client().await;
     let local = build_local_batch().await;
     assert!(
         *local.inactivity_floor > 0,
@@ -500,7 +500,7 @@ async fn keyless_connect_subscribe_filters_by_value_regex() {
 
 #[tokio::test]
 async fn keyless_connect_subscribe_rejects_key_filters() {
-    let (_store_server, store_client) = common::local_store_client().await;
+    let store_client = common::local_store_client().await;
     let local = build_local_batch().await;
     assert!(
         *local.inactivity_floor > 0,

--- a/qmdb/rs/tests/e2e_keyless_connect.rs
+++ b/qmdb/rs/tests/e2e_keyless_connect.rs
@@ -130,7 +130,7 @@ async fn commit_upload(client: &StoreClient, batch: &LocalBatch) {
 
 #[tokio::test]
 async fn keyless_connect_subscribe_emits_verifiable_multi_proof() {
-    let (_dir, _store_server, store_client) = common::local_store_client().await;
+    let (_store_server, store_client) = common::local_store_client().await;
     let local = build_local_batch().await;
     assert!(
         *local.inactivity_floor > 0,
@@ -174,7 +174,7 @@ async fn keyless_connect_subscribe_emits_verifiable_multi_proof() {
 
 #[tokio::test]
 async fn keyless_connect_get_operation_range_returns_verifiable_proof() {
-    let (_dir, _store_server, store_client) = common::local_store_client().await;
+    let (_store_server, store_client) = common::local_store_client().await;
     let local = build_local_batch().await;
     assert!(
         *local.inactivity_floor > 0,
@@ -212,7 +212,7 @@ async fn keyless_connect_get_operation_range_returns_verifiable_proof() {
 
 #[tokio::test]
 async fn keyless_operation_log_sync_resolver_fetches_api_batches() {
-    let (_dir, _store_server, store_client) = common::local_store_client().await;
+    let (_store_server, store_client) = common::local_store_client().await;
     let local = build_local_batch().await;
     commit_upload(&store_client, &local).await;
 
@@ -258,7 +258,7 @@ async fn keyless_operation_log_sync_resolver_fetches_api_batches() {
 
 #[tokio::test]
 async fn keyless_commonware_glue_state_sync_uses_operation_log_resolver() {
-    let (_dir, _store_server, store_client) = common::local_store_client().await;
+    let (_store_server, store_client) = common::local_store_client().await;
     let local = build_local_batch().await;
     assert!(
         *local.inactivity_floor > 0,
@@ -380,7 +380,7 @@ async fn keyless_operation_log_sync_resolver_observes_cancelled_fetch() {
 
 #[tokio::test]
 async fn keyless_connect_client_rejects_invalid_streamed_proof() {
-    let (_dir, _store_server, store_client) = common::local_store_client().await;
+    let (_store_server, store_client) = common::local_store_client().await;
     let local = build_local_batch().await;
     assert!(
         *local.inactivity_floor > 0,
@@ -447,7 +447,7 @@ fn match_regex(regex: &str) -> ProtoFilter {
 
 #[tokio::test]
 async fn keyless_connect_subscribe_filters_by_value_regex() {
-    let (_dir, _store_server, store_client) = common::local_store_client().await;
+    let (_store_server, store_client) = common::local_store_client().await;
     let local = build_local_batch().await;
     assert!(
         *local.inactivity_floor > 0,
@@ -500,7 +500,7 @@ async fn keyless_connect_subscribe_filters_by_value_regex() {
 
 #[tokio::test]
 async fn keyless_connect_subscribe_rejects_key_filters() {
-    let (_dir, _store_server, store_client) = common::local_store_client().await;
+    let (_store_server, store_client) = common::local_store_client().await;
     let local = build_local_batch().await;
     assert!(
         *local.inactivity_floor > 0,

--- a/qmdb/rs/tests/e2e_keyless_writer.rs
+++ b/qmdb/rs/tests/e2e_keyless_writer.rs
@@ -133,7 +133,7 @@ fn split_upload_batches(
 // a no-op.
 #[tokio::test]
 async fn sequential_upload_matches_local_root() {
-    let (_server, client) = common::local_store_client().await;
+    let client = common::local_store_client().await;
     let batches = vec![
         vec![b"alpha".to_vec(), b"beta".to_vec()],
         vec![b"gamma".to_vec()],
@@ -191,7 +191,7 @@ async fn sequential_upload_matches_local_root() {
 // Every batch's watermark lands in-band (pipeline always empty on entry).
 #[tokio::test]
 async fn multiple_sequential_batches_each_publish_watermarks_in_band() {
-    let (_server, client) = common::local_store_client().await;
+    let client = common::local_store_client().await;
     let (local_root, _proof, local_ops, latest) = build_local_reference(vec![
         vec![b"a".to_vec(), b"b".to_vec()],
         vec![b"c".to_vec()],
@@ -248,7 +248,7 @@ async fn multiple_sequential_batches_each_publish_watermarks_in_band() {
 // the tail so readers see the full prefix.
 #[tokio::test]
 async fn pipelined_batches_require_flush_to_catch_up_watermark() {
-    let (_server, client) = common::local_store_client().await;
+    let client = common::local_store_client().await;
     // Local DB adds a Commit op per batch, so 3 batches of 2 Appends produce
     // 9 total ops (indices 0..=8). Split the writer's view into the same
     // batch boundaries.
@@ -325,7 +325,7 @@ async fn bounded_pipeline_advances_watermark_via_contiguous_acks() {
     const MAX_INFLIGHT: usize = 4;
     const BATCHES: usize = 20;
 
-    let (_server, client) = common::local_store_client().await;
+    let client = common::local_store_client().await;
     let batch_values: Vec<Vec<Vec<u8>>> = (0..BATCHES)
         .map(|i| vec![format!("v{i}").into_bytes()])
         .collect();
@@ -397,7 +397,7 @@ async fn bounded_pipeline_advances_watermark_via_contiguous_acks() {
 // wrote some batches).
 #[tokio::test]
 async fn local_proof_resumes_from_existing_store_state() {
-    let (_server, client) = common::local_store_client().await;
+    let client = common::local_store_client().await;
     let (local_root_after_two, proof_two, local_ops_two, latest_two) =
         build_local_reference(vec![vec![b"g".to_vec(), b"h".to_vec()]]).await;
     let (local_root_final, _proof_final, local_ops_final, latest_final) =

--- a/qmdb/rs/tests/e2e_keyless_writer.rs
+++ b/qmdb/rs/tests/e2e_keyless_writer.rs
@@ -133,7 +133,7 @@ fn split_upload_batches(
 // a no-op.
 #[tokio::test]
 async fn sequential_upload_matches_local_root() {
-    let (_dir, _server, client) = common::local_store_client().await;
+    let (_server, client) = common::local_store_client().await;
     let batches = vec![
         vec![b"alpha".to_vec(), b"beta".to_vec()],
         vec![b"gamma".to_vec()],
@@ -191,7 +191,7 @@ async fn sequential_upload_matches_local_root() {
 // Every batch's watermark lands in-band (pipeline always empty on entry).
 #[tokio::test]
 async fn multiple_sequential_batches_each_publish_watermarks_in_band() {
-    let (_dir, _server, client) = common::local_store_client().await;
+    let (_server, client) = common::local_store_client().await;
     let (local_root, _proof, local_ops, latest) = build_local_reference(vec![
         vec![b"a".to_vec(), b"b".to_vec()],
         vec![b"c".to_vec()],
@@ -248,7 +248,7 @@ async fn multiple_sequential_batches_each_publish_watermarks_in_band() {
 // the tail so readers see the full prefix.
 #[tokio::test]
 async fn pipelined_batches_require_flush_to_catch_up_watermark() {
-    let (_dir, _server, client) = common::local_store_client().await;
+    let (_server, client) = common::local_store_client().await;
     // Local DB adds a Commit op per batch, so 3 batches of 2 Appends produce
     // 9 total ops (indices 0..=8). Split the writer's view into the same
     // batch boundaries.
@@ -325,7 +325,7 @@ async fn bounded_pipeline_advances_watermark_via_contiguous_acks() {
     const MAX_INFLIGHT: usize = 4;
     const BATCHES: usize = 20;
 
-    let (_dir, _server, client) = common::local_store_client().await;
+    let (_server, client) = common::local_store_client().await;
     let batch_values: Vec<Vec<Vec<u8>>> = (0..BATCHES)
         .map(|i| vec![format!("v{i}").into_bytes()])
         .collect();
@@ -397,7 +397,7 @@ async fn bounded_pipeline_advances_watermark_via_contiguous_acks() {
 // wrote some batches).
 #[tokio::test]
 async fn local_proof_resumes_from_existing_store_state() {
-    let (_dir, _server, client) = common::local_store_client().await;
+    let (_server, client) = common::local_store_client().await;
     let (local_root_after_two, proof_two, local_ops_two, latest_two) =
         build_local_reference(vec![vec![b"g".to_vec(), b"h".to_vec()]]).await;
     let (local_root_final, _proof_final, local_ops_final, latest_final) =

--- a/qmdb/rs/tests/e2e_mirror_from_local.rs
+++ b/qmdb/rs/tests/e2e_mirror_from_local.rs
@@ -40,7 +40,7 @@ type Digest = commonware_cryptography::sha256::Digest;
 
 #[tokio::test]
 async fn mirror_keyless_from_local() {
-    let (_dir, _server, client) = common::local_store_client().await;
+    let (_server, client) = common::local_store_client().await;
 
     // Session 1: apply one batch locally, mirror.
     let (ops1, proof1, latest1, root1) = run_keyless_local(vec![vec![
@@ -146,7 +146,7 @@ type UnorderedOp =
 
 #[tokio::test]
 async fn mirror_unordered_from_local() {
-    let (_dir, _server, client) = common::local_store_client().await;
+    let (_server, client) = common::local_store_client().await;
 
     let (ops1, proof1, latest1, root1) = run_unordered_local(vec![vec![
         (b"alpha".to_vec(), Some(b"one".to_vec())),
@@ -266,7 +266,7 @@ type ImmK = FixedBytes<32>;
 
 #[tokio::test]
 async fn mirror_immutable_from_local() {
-    let (_dir, _server, client) = common::local_store_client().await;
+    let (_server, client) = common::local_store_client().await;
 
     let (ops1, proof1, latest1, root1) = run_immutable_local(vec![vec![
         (FixedBytes::new([0x11; 32]), b"one".to_vec()),
@@ -422,7 +422,7 @@ async fn ordered_boundary_from_local_db(
 
 #[tokio::test]
 async fn mirror_ordered_from_local() {
-    let (_dir, _server, client) = common::local_store_client().await;
+    let (_server, client) = common::local_store_client().await;
 
     let (ops1, proof1, latest1, root1, boundary1) = run_ordered_local(
         vec![vec![

--- a/qmdb/rs/tests/e2e_mirror_from_local.rs
+++ b/qmdb/rs/tests/e2e_mirror_from_local.rs
@@ -40,7 +40,7 @@ type Digest = commonware_cryptography::sha256::Digest;
 
 #[tokio::test]
 async fn mirror_keyless_from_local() {
-    let (_server, client) = common::local_store_client().await;
+    let client = common::local_store_client().await;
 
     // Session 1: apply one batch locally, mirror.
     let (ops1, proof1, latest1, root1) = run_keyless_local(vec![vec![
@@ -146,7 +146,7 @@ type UnorderedOp =
 
 #[tokio::test]
 async fn mirror_unordered_from_local() {
-    let (_server, client) = common::local_store_client().await;
+    let client = common::local_store_client().await;
 
     let (ops1, proof1, latest1, root1) = run_unordered_local(vec![vec![
         (b"alpha".to_vec(), Some(b"one".to_vec())),
@@ -266,7 +266,7 @@ type ImmK = FixedBytes<32>;
 
 #[tokio::test]
 async fn mirror_immutable_from_local() {
-    let (_server, client) = common::local_store_client().await;
+    let client = common::local_store_client().await;
 
     let (ops1, proof1, latest1, root1) = run_immutable_local(vec![vec![
         (FixedBytes::new([0x11; 32]), b"one".to_vec()),
@@ -422,7 +422,7 @@ async fn ordered_boundary_from_local_db(
 
 #[tokio::test]
 async fn mirror_ordered_from_local() {
-    let (_server, client) = common::local_store_client().await;
+    let client = common::local_store_client().await;
 
     let (ops1, proof1, latest1, root1, boundary1) = run_ordered_local(
         vec![vec![

--- a/qmdb/rs/tests/e2e_ordered.rs
+++ b/qmdb/rs/tests/e2e_ordered.rs
@@ -442,7 +442,7 @@ where
 
 #[tokio::test]
 async fn ordered_round_trip() {
-    let (_dir, _server, client) = common::local_store_client().await;
+    let (_server, client) = common::local_store_client().await;
     let local = build_local_db::<mmr::Family>().await;
 
     mirror_local(&client, &local).await;
@@ -484,7 +484,7 @@ async fn ordered_round_trip() {
 
 #[tokio::test]
 async fn ordered_mmb_round_trip() {
-    let (_dir, _server, client) = common::local_store_client().await;
+    let (_server, client) = common::local_store_client().await;
     let local = build_local_db::<mmb::Family>().await;
 
     mirror_local(&client, &local).await;
@@ -532,7 +532,7 @@ async fn ordered_mmb_round_trip() {
 
 #[tokio::test]
 async fn ordered_mmb_multi_peak_grafted_chunk_round_trip() {
-    let (_dir, _server, client) = common::local_store_client().await;
+    let (_server, client) = common::local_store_client().await;
     let local = build_local_db_with_write_count::<mmb::Family, N>("ordered_mmb_grafted", 767).await;
     assert!(
         local.current_boundary.grafted_nodes.len() >= 2,
@@ -582,7 +582,7 @@ async fn assert_incremental_seed_batches_keep_current_proofs_verifiable<F>(
     BatchOperation<F>:
         commonware_codec::Codec + commonware_codec::Encode + commonware_codec::Decode + Clone,
 {
-    let (_dir, _server, client) = common::local_store_client().await;
+    let (_server, client) = common::local_store_client().await;
     let (uploads, latest_location, latest_key, expected_root, expected_active) =
         tokio::task::spawn_blocking(move || {
             cw_tokio::Runner::default().start(|context| async move {
@@ -743,7 +743,7 @@ async fn ordered_mmb_incremental_seed_batches_keep_current_proofs_verifiable() {
 
 #[tokio::test]
 async fn ordered_mmb_persistent_interleaved_seed_batches_keep_current_proofs_verifiable() {
-    let (_dir, _server, client) = common::local_store_client().await;
+    let (_server, client) = common::local_store_client().await;
     let storage_dir = tempfile::tempdir().expect("tempdir");
     let storage_path = storage_dir.path().to_owned();
     let store = client.clone();
@@ -863,7 +863,7 @@ async fn ordered_mmr_incremental_seed_batches_keep_current_proofs_verifiable() {
 
 #[tokio::test]
 async fn ordered_fixed_round_trip() {
-    let (_dir, _server, client) = common::local_store_client().await;
+    let (_server, client) = common::local_store_client().await;
     let local = build_fixed_local_db::<mmr::Family>().await;
 
     let writer: FixedTestOrderedWriter<mmr::Family> =
@@ -929,7 +929,7 @@ async fn ordered_fixed_round_trip() {
 
 #[tokio::test]
 async fn current_root_at() {
-    let (_dir, _server, client) = common::local_store_client().await;
+    let (_server, client) = common::local_store_client().await;
     let local = build_local_db::<mmr::Family>().await;
 
     mirror_local(&client, &local).await;
@@ -948,7 +948,7 @@ async fn current_root_at() {
 
 #[tokio::test]
 async fn current_operation_range_proof() {
-    let (_dir, _server, client) = common::local_store_client().await;
+    let (_server, client) = common::local_store_client().await;
     let local = build_local_db::<mmr::Family>().await;
 
     mirror_local(&client, &local).await;
@@ -971,7 +971,7 @@ async fn current_operation_range_proof() {
 
 #[tokio::test]
 async fn key_value_proof() {
-    let (_dir, _server, client) = common::local_store_client().await;
+    let (_server, client) = common::local_store_client().await;
     let local = build_local_db::<mmr::Family>().await;
 
     mirror_local(&client, &local).await;
@@ -996,7 +996,7 @@ async fn key_value_proof() {
 
 #[tokio::test]
 async fn multi_proof() {
-    let (_dir, _server, client) = common::local_store_client().await;
+    let (_server, client) = common::local_store_client().await;
     let local = build_local_db::<mmr::Family>().await;
 
     mirror_local(&client, &local).await;

--- a/qmdb/rs/tests/e2e_ordered.rs
+++ b/qmdb/rs/tests/e2e_ordered.rs
@@ -442,7 +442,7 @@ where
 
 #[tokio::test]
 async fn ordered_round_trip() {
-    let (_server, client) = common::local_store_client().await;
+    let client = common::local_store_client().await;
     let local = build_local_db::<mmr::Family>().await;
 
     mirror_local(&client, &local).await;
@@ -484,7 +484,7 @@ async fn ordered_round_trip() {
 
 #[tokio::test]
 async fn ordered_mmb_round_trip() {
-    let (_server, client) = common::local_store_client().await;
+    let client = common::local_store_client().await;
     let local = build_local_db::<mmb::Family>().await;
 
     mirror_local(&client, &local).await;
@@ -532,7 +532,7 @@ async fn ordered_mmb_round_trip() {
 
 #[tokio::test]
 async fn ordered_mmb_multi_peak_grafted_chunk_round_trip() {
-    let (_server, client) = common::local_store_client().await;
+    let client = common::local_store_client().await;
     let local = build_local_db_with_write_count::<mmb::Family, N>("ordered_mmb_grafted", 767).await;
     assert!(
         local.current_boundary.grafted_nodes.len() >= 2,
@@ -582,7 +582,7 @@ async fn assert_incremental_seed_batches_keep_current_proofs_verifiable<F>(
     BatchOperation<F>:
         commonware_codec::Codec + commonware_codec::Encode + commonware_codec::Decode + Clone,
 {
-    let (_server, client) = common::local_store_client().await;
+    let client = common::local_store_client().await;
     let (uploads, latest_location, latest_key, expected_root, expected_active) =
         tokio::task::spawn_blocking(move || {
             cw_tokio::Runner::default().start(|context| async move {
@@ -743,7 +743,7 @@ async fn ordered_mmb_incremental_seed_batches_keep_current_proofs_verifiable() {
 
 #[tokio::test]
 async fn ordered_mmb_persistent_interleaved_seed_batches_keep_current_proofs_verifiable() {
-    let (_server, client) = common::local_store_client().await;
+    let client = common::local_store_client().await;
     let storage_dir = tempfile::tempdir().expect("tempdir");
     let storage_path = storage_dir.path().to_owned();
     let store = client.clone();
@@ -863,7 +863,7 @@ async fn ordered_mmr_incremental_seed_batches_keep_current_proofs_verifiable() {
 
 #[tokio::test]
 async fn ordered_fixed_round_trip() {
-    let (_server, client) = common::local_store_client().await;
+    let client = common::local_store_client().await;
     let local = build_fixed_local_db::<mmr::Family>().await;
 
     let writer: FixedTestOrderedWriter<mmr::Family> =
@@ -929,7 +929,7 @@ async fn ordered_fixed_round_trip() {
 
 #[tokio::test]
 async fn current_root_at() {
-    let (_server, client) = common::local_store_client().await;
+    let client = common::local_store_client().await;
     let local = build_local_db::<mmr::Family>().await;
 
     mirror_local(&client, &local).await;
@@ -948,7 +948,7 @@ async fn current_root_at() {
 
 #[tokio::test]
 async fn current_operation_range_proof() {
-    let (_server, client) = common::local_store_client().await;
+    let client = common::local_store_client().await;
     let local = build_local_db::<mmr::Family>().await;
 
     mirror_local(&client, &local).await;
@@ -971,7 +971,7 @@ async fn current_operation_range_proof() {
 
 #[tokio::test]
 async fn key_value_proof() {
-    let (_server, client) = common::local_store_client().await;
+    let client = common::local_store_client().await;
     let local = build_local_db::<mmr::Family>().await;
 
     mirror_local(&client, &local).await;
@@ -996,7 +996,7 @@ async fn key_value_proof() {
 
 #[tokio::test]
 async fn multi_proof() {
-    let (_server, client) = common::local_store_client().await;
+    let client = common::local_store_client().await;
     let local = build_local_db::<mmr::Family>().await;
 
     mirror_local(&client, &local).await;

--- a/qmdb/rs/tests/e2e_ordered_connect.rs
+++ b/qmdb/rs/tests/e2e_ordered_connect.rs
@@ -377,7 +377,7 @@ fn tamper_get_many_response(mut response: ProtoGetManyResponse) -> ProtoGetManyR
 
 #[tokio::test]
 async fn ordered_connect_get_returns_current_key_value_proof() {
-    let (_dir, _store_server, store_client) = common::local_store_client().await;
+    let (_store_server, store_client) = common::local_store_client().await;
     let local = build_local_batch().await;
     let ordered_client = Arc::new(TestOrderedClient::new(
         PrefixedStoreClient::empty(store_client.clone()),
@@ -408,7 +408,7 @@ async fn ordered_connect_get_returns_current_key_value_proof() {
 
 #[tokio::test]
 async fn ordered_get_after_grafted_boundary_returns_current_key_value_proof() {
-    let (_dir, _store_server, store_client) = common::local_store_client().await;
+    let (_store_server, store_client) = common::local_store_client().await;
     let local = build_grafted_boundary_local_batch().await;
     let ordered_client = TestOrderedClient::new(
         PrefixedStoreClient::empty(store_client.clone()),
@@ -434,7 +434,7 @@ async fn ordered_get_after_grafted_boundary_returns_current_key_value_proof() {
 
 #[tokio::test]
 async fn ordered_connect_get_many_returns_current_key_lookup_proofs() {
-    let (_dir, _store_server, store_client) = common::local_store_client().await;
+    let (_store_server, store_client) = common::local_store_client().await;
     let local = build_local_batch().await;
     let ordered_client = Arc::new(TestOrderedClient::new(
         PrefixedStoreClient::empty(store_client.clone()),
@@ -480,7 +480,7 @@ async fn ordered_connect_get_many_returns_current_key_lookup_proofs() {
 
 #[tokio::test]
 async fn ordered_connect_get_many_returns_miss_proofs_and_rejects_duplicates() {
-    let (_dir, _store_server, store_client) = common::local_store_client().await;
+    let (_store_server, store_client) = common::local_store_client().await;
     let local = build_local_batch().await;
     let ordered_client = Arc::new(TestOrderedClient::new(
         PrefixedStoreClient::empty(store_client.clone()),
@@ -526,7 +526,7 @@ async fn ordered_connect_get_many_returns_miss_proofs_and_rejects_duplicates() {
 
 #[tokio::test]
 async fn ordered_connect_get_range_verifies_complete_empty_and_partial_pages() {
-    let (_dir, _store_server, store_client) = common::local_store_client().await;
+    let (_store_server, store_client) = common::local_store_client().await;
     let local = build_local_batch().await;
     let ordered_client = Arc::new(TestOrderedClient::new(
         PrefixedStoreClient::empty(store_client.clone()),
@@ -597,7 +597,7 @@ async fn ordered_connect_get_range_verifies_complete_empty_and_partial_pages() {
 
 #[tokio::test]
 async fn ordered_connect_client_rejects_get_range_boundary_omission() {
-    let (_dir, _store_server, store_client) = common::local_store_client().await;
+    let (_store_server, store_client) = common::local_store_client().await;
     let local = build_local_batch().await;
     commit_upload(&store_client, &local).await;
 
@@ -670,7 +670,7 @@ async fn ordered_connect_client_rejects_get_range_boundary_omission() {
 
 #[tokio::test]
 async fn ordered_connect_client_rejects_empty_unbounded_get_range_before_next_key() {
-    let (_dir, _store_server, store_client) = common::local_store_client().await;
+    let (_store_server, store_client) = common::local_store_client().await;
     let local = build_local_batch().await;
     commit_upload(&store_client, &local).await;
 
@@ -747,7 +747,7 @@ async fn ordered_connect_client_rejects_empty_unbounded_get_range_before_next_ke
 
 #[tokio::test]
 async fn ordered_connect_client_rejects_invalid_get_proof() {
-    let (_dir, _store_server, store_client) = common::local_store_client().await;
+    let (_store_server, store_client) = common::local_store_client().await;
     let local = build_local_batch().await;
     commit_upload(&store_client, &local).await;
 
@@ -809,7 +809,7 @@ async fn ordered_connect_client_rejects_invalid_get_proof() {
 
 #[tokio::test]
 async fn ordered_connect_client_rejects_invalid_get_many_proof() {
-    let (_dir, _store_server, store_client) = common::local_store_client().await;
+    let (_store_server, store_client) = common::local_store_client().await;
     let local = build_local_batch().await;
     commit_upload(&store_client, &local).await;
 
@@ -871,7 +871,7 @@ async fn ordered_connect_client_rejects_invalid_get_many_proof() {
 
 #[tokio::test]
 async fn ordered_connect_client_rejects_get_many_proof_for_different_key() {
-    let (_dir, _store_server, store_client) = common::local_store_client().await;
+    let (_store_server, store_client) = common::local_store_client().await;
     let local = build_local_batch().await;
     commit_upload(&store_client, &local).await;
 

--- a/qmdb/rs/tests/e2e_ordered_connect.rs
+++ b/qmdb/rs/tests/e2e_ordered_connect.rs
@@ -377,7 +377,7 @@ fn tamper_get_many_response(mut response: ProtoGetManyResponse) -> ProtoGetManyR
 
 #[tokio::test]
 async fn ordered_connect_get_returns_current_key_value_proof() {
-    let (_store_server, store_client) = common::local_store_client().await;
+    let store_client = common::local_store_client().await;
     let local = build_local_batch().await;
     let ordered_client = Arc::new(TestOrderedClient::new(
         PrefixedStoreClient::empty(store_client.clone()),
@@ -408,7 +408,7 @@ async fn ordered_connect_get_returns_current_key_value_proof() {
 
 #[tokio::test]
 async fn ordered_get_after_grafted_boundary_returns_current_key_value_proof() {
-    let (_store_server, store_client) = common::local_store_client().await;
+    let store_client = common::local_store_client().await;
     let local = build_grafted_boundary_local_batch().await;
     let ordered_client = TestOrderedClient::new(
         PrefixedStoreClient::empty(store_client.clone()),
@@ -434,7 +434,7 @@ async fn ordered_get_after_grafted_boundary_returns_current_key_value_proof() {
 
 #[tokio::test]
 async fn ordered_connect_get_many_returns_current_key_lookup_proofs() {
-    let (_store_server, store_client) = common::local_store_client().await;
+    let store_client = common::local_store_client().await;
     let local = build_local_batch().await;
     let ordered_client = Arc::new(TestOrderedClient::new(
         PrefixedStoreClient::empty(store_client.clone()),
@@ -480,7 +480,7 @@ async fn ordered_connect_get_many_returns_current_key_lookup_proofs() {
 
 #[tokio::test]
 async fn ordered_connect_get_many_returns_miss_proofs_and_rejects_duplicates() {
-    let (_store_server, store_client) = common::local_store_client().await;
+    let store_client = common::local_store_client().await;
     let local = build_local_batch().await;
     let ordered_client = Arc::new(TestOrderedClient::new(
         PrefixedStoreClient::empty(store_client.clone()),
@@ -526,7 +526,7 @@ async fn ordered_connect_get_many_returns_miss_proofs_and_rejects_duplicates() {
 
 #[tokio::test]
 async fn ordered_connect_get_range_verifies_complete_empty_and_partial_pages() {
-    let (_store_server, store_client) = common::local_store_client().await;
+    let store_client = common::local_store_client().await;
     let local = build_local_batch().await;
     let ordered_client = Arc::new(TestOrderedClient::new(
         PrefixedStoreClient::empty(store_client.clone()),
@@ -597,7 +597,7 @@ async fn ordered_connect_get_range_verifies_complete_empty_and_partial_pages() {
 
 #[tokio::test]
 async fn ordered_connect_client_rejects_get_range_boundary_omission() {
-    let (_store_server, store_client) = common::local_store_client().await;
+    let store_client = common::local_store_client().await;
     let local = build_local_batch().await;
     commit_upload(&store_client, &local).await;
 
@@ -670,7 +670,7 @@ async fn ordered_connect_client_rejects_get_range_boundary_omission() {
 
 #[tokio::test]
 async fn ordered_connect_client_rejects_empty_unbounded_get_range_before_next_key() {
-    let (_store_server, store_client) = common::local_store_client().await;
+    let store_client = common::local_store_client().await;
     let local = build_local_batch().await;
     commit_upload(&store_client, &local).await;
 
@@ -747,7 +747,7 @@ async fn ordered_connect_client_rejects_empty_unbounded_get_range_before_next_ke
 
 #[tokio::test]
 async fn ordered_connect_client_rejects_invalid_get_proof() {
-    let (_store_server, store_client) = common::local_store_client().await;
+    let store_client = common::local_store_client().await;
     let local = build_local_batch().await;
     commit_upload(&store_client, &local).await;
 
@@ -809,7 +809,7 @@ async fn ordered_connect_client_rejects_invalid_get_proof() {
 
 #[tokio::test]
 async fn ordered_connect_client_rejects_invalid_get_many_proof() {
-    let (_store_server, store_client) = common::local_store_client().await;
+    let store_client = common::local_store_client().await;
     let local = build_local_batch().await;
     commit_upload(&store_client, &local).await;
 
@@ -871,7 +871,7 @@ async fn ordered_connect_client_rejects_invalid_get_many_proof() {
 
 #[tokio::test]
 async fn ordered_connect_client_rejects_get_many_proof_for_different_key() {
-    let (_store_server, store_client) = common::local_store_client().await;
+    let store_client = common::local_store_client().await;
     let local = build_local_batch().await;
     commit_upload(&store_client, &local).await;
 

--- a/qmdb/rs/tests/e2e_ordered_prune.rs
+++ b/qmdb/rs/tests/e2e_ordered_prune.rs
@@ -103,7 +103,7 @@ async fn boundary_from_db(
 
 #[tokio::test]
 async fn mirror_ordered_prune_past_chunk_zero() {
-    let (_server, client) = common::local_store_client().await;
+    let client = common::local_store_client().await;
 
     // Phase 1 (blocking tokio runtime): drive the local QMDB through BATCHES
     // batches, capturing each batch's delta, root, and boundary delta. The

--- a/qmdb/rs/tests/e2e_ordered_prune.rs
+++ b/qmdb/rs/tests/e2e_ordered_prune.rs
@@ -103,7 +103,7 @@ async fn boundary_from_db(
 
 #[tokio::test]
 async fn mirror_ordered_prune_past_chunk_zero() {
-    let (_dir, _server, client) = common::local_store_client().await;
+    let (_server, client) = common::local_store_client().await;
 
     // Phase 1 (blocking tokio runtime): drive the local QMDB through BATCHES
     // batches, capturing each batch's delta, root, and boundary delta. The

--- a/qmdb/rs/tests/e2e_ordered_range_connect.rs
+++ b/qmdb/rs/tests/e2e_ordered_range_connect.rs
@@ -480,7 +480,7 @@ async fn commit_mmb_upload(client: &StoreClient, batch: &MmbLocalBatch) {
 
 #[tokio::test]
 async fn ordered_current_operation_range_connect_emits_verifiable_proof() {
-    let (_dir, _store_server, store_client) = common::local_store_client().await;
+    let (_store_server, store_client) = common::local_store_client().await;
     let local = build_local_batch().await;
     commit_upload(&store_client, &local).await;
 
@@ -518,7 +518,7 @@ async fn ordered_current_operation_range_connect_emits_verifiable_proof() {
 
 #[tokio::test]
 async fn ordered_current_state_sync_from_connect_api_reconstructs_current_db() {
-    let (_dir, _store_server, store_client) = common::local_store_client().await;
+    let (_store_server, store_client) = common::local_store_client().await;
     let local = build_local_batch().await;
     commit_upload(&store_client, &local).await;
 
@@ -585,7 +585,7 @@ async fn ordered_current_state_sync_from_connect_api_reconstructs_current_db() {
 async fn ordered_mmb_current_state_sync_from_nonzero_connect_api_reconstructs_current_db() {
     const FETCH_BATCH_SIZE: u64 = 3;
 
-    let (_dir, _store_server, store_client) = common::local_store_client().await;
+    let (_store_server, store_client) = common::local_store_client().await;
     let local = build_mmb_local_batch().await;
     let start = Location::<mmb::Family>::new(1);
     let start_index = usize::try_from(*start).expect("start fits usize");
@@ -668,7 +668,7 @@ async fn ordered_mmb_current_state_sync_from_nonzero_connect_api_reconstructs_cu
 
 #[tokio::test]
 async fn ordered_mmb_sync_resolvers_return_pinned_nodes_for_nonzero_fetches() {
-    let (_dir, _store_server, store_client) = common::local_store_client().await;
+    let (_store_server, store_client) = common::local_store_client().await;
     let local = build_mmb_local_batch().await;
     let start = Location::<mmb::Family>::new(3);
     assert!(*start > 0, "regression must exercise a nonzero lower bound");
@@ -755,7 +755,7 @@ async fn ordered_mmb_sync_resolvers_return_pinned_nodes_for_nonzero_fetches() {
 
 #[tokio::test]
 async fn ordered_mmb_operation_range_client_rejects_missing_nonzero_pinned_nodes() {
-    let (_dir, _store_server, store_client) = common::local_store_client().await;
+    let (_store_server, store_client) = common::local_store_client().await;
     let local = build_mmb_local_batch().await;
     let start = Location::<mmb::Family>::new(3);
     assert!(
@@ -823,7 +823,7 @@ async fn ordered_mmb_operation_range_client_rejects_missing_nonzero_pinned_nodes
 
 #[tokio::test]
 async fn ordered_mmb_operation_range_client_rejects_extra_nonzero_pinned_node() {
-    let (_dir, _store_server, store_client) = common::local_store_client().await;
+    let (_store_server, store_client) = common::local_store_client().await;
     let local = build_mmb_local_batch().await;
     let start = Location::<mmb::Family>::new(3);
     assert!(
@@ -879,7 +879,7 @@ async fn ordered_mmb_operation_range_client_rejects_extra_nonzero_pinned_node() 
 
 #[tokio::test]
 async fn ordered_mmb_operation_range_client_rejects_zero_start_pinned_nodes() {
-    let (_dir, _store_server, store_client) = common::local_store_client().await;
+    let (_store_server, store_client) = common::local_store_client().await;
     let local = build_mmb_local_batch().await;
     commit_mmb_upload(&store_client, &local).await;
 
@@ -932,7 +932,7 @@ async fn ordered_mmb_operation_range_client_rejects_zero_start_pinned_nodes() {
 
 #[tokio::test]
 async fn ordered_operation_range_connect_uses_current_root_witness() {
-    let (_dir, _store_server, store_client) = common::local_store_client().await;
+    let (_store_server, store_client) = common::local_store_client().await;
     let local = build_local_batch().await;
     commit_upload(&store_client, &local).await;
 
@@ -1059,7 +1059,7 @@ fn latest_mmb_value_for_key(operations: &[MmbBatchOperation], key: &[u8]) -> Opt
 
 #[tokio::test]
 async fn ordered_range_connect_subscribe_emits_verifiable_range_proof() {
-    let (_dir, _store_server, store_client) = common::local_store_client().await;
+    let (_store_server, store_client) = common::local_store_client().await;
     let local = build_local_batch().await;
     assert!(
         *local.inactivity_floor > 0,
@@ -1103,7 +1103,7 @@ async fn ordered_range_connect_subscribe_emits_verifiable_range_proof() {
 
 #[tokio::test]
 async fn ordered_range_connect_client_rejects_invalid_streamed_proof() {
-    let (_dir, _store_server, store_client) = common::local_store_client().await;
+    let (_store_server, store_client) = common::local_store_client().await;
     let local = build_local_batch().await;
     commit_upload(&store_client, &local).await;
 
@@ -1153,7 +1153,7 @@ async fn ordered_range_connect_client_rejects_invalid_streamed_proof() {
 
 #[tokio::test]
 async fn ordered_range_connect_subscribe_emits_multi_proof_for_matching_keys() {
-    let (_dir, _store_server, store_client) = common::local_store_client().await;
+    let (_store_server, store_client) = common::local_store_client().await;
     let local = build_local_batch().await;
     let ordered_client = Arc::new(TestOrderedClient::new(
         PrefixedStoreClient::empty(store_client.clone()),
@@ -1192,7 +1192,7 @@ async fn ordered_range_connect_subscribe_emits_multi_proof_for_matching_keys() {
 
 #[tokio::test]
 async fn ordered_mmb_range_connect_subscribe_verifies_range_and_multi_proofs() {
-    let (_dir, _store_server, store_client) = common::local_store_client().await;
+    let (_store_server, store_client) = common::local_store_client().await;
     let local = build_mmb_local_batch().await;
     assert!(
         *local.inactivity_floor > 0,
@@ -1260,7 +1260,7 @@ async fn ordered_mmb_range_connect_subscribe_verifies_range_and_multi_proofs() {
 async fn ordered_mmb_operation_log_any_sync_from_connect_api_reconstructs_any_db() {
     const FETCH_BATCH_SIZE: u64 = 3;
 
-    let (_dir, _store_server, store_client) = common::local_store_client().await;
+    let (_store_server, store_client) = common::local_store_client().await;
     let local = build_mmb_local_batch().await;
     assert!(
         local.operations.len() as u64 > FETCH_BATCH_SIZE * 2,
@@ -1326,7 +1326,7 @@ async fn ordered_mmb_operation_log_any_sync_from_connect_api_reconstructs_any_db
 async fn ordered_mmb_operation_log_any_sync_from_nonzero_connect_api_reconstructs_any_db() {
     const FETCH_BATCH_SIZE: u64 = 3;
 
-    let (_dir, _store_server, store_client) = common::local_store_client().await;
+    let (_store_server, store_client) = common::local_store_client().await;
     let local = build_mmb_local_batch().await;
     let start = Location::<mmb::Family>::new(3);
     let start_index = usize::try_from(*start).expect("start fits usize");
@@ -1405,7 +1405,7 @@ async fn ordered_mmb_operation_log_any_sync_from_nonzero_connect_api_reconstruct
 async fn ordered_mmb_operation_log_any_sync_accepts_target_update_from_growing_backend() {
     const FETCH_BATCH_SIZE: u64 = 3;
 
-    let (_dir, _store_server, store_client) = common::local_store_client().await;
+    let (_store_server, store_client) = common::local_store_client().await;
     let local = build_mmb_growing_local_batch().await;
     let start = Location::<mmb::Family>::new(1);
     let start_index = usize::try_from(*start).expect("start fits usize");
@@ -1523,7 +1523,7 @@ async fn ordered_mmb_operation_log_any_sync_accepts_target_update_from_growing_b
 
 #[tokio::test]
 async fn ordered_range_connect_subscribe_replays_since_cursor() {
-    let (_dir, _store_server, store_client) = common::local_store_client().await;
+    let (_store_server, store_client) = common::local_store_client().await;
     let local = build_local_batch().await;
     let ordered_client = Arc::new(TestOrderedClient::new(
         PrefixedStoreClient::empty(store_client.clone()),
@@ -1560,7 +1560,7 @@ async fn ordered_range_connect_subscribe_replays_since_cursor() {
 
 #[tokio::test]
 async fn ordered_range_connect_subscribe_matches_prefix_and_regex_filters() {
-    let (_dir, _store_server, store_client) = common::local_store_client().await;
+    let (_store_server, store_client) = common::local_store_client().await;
     let local = build_local_batch().await;
     let ordered_client = Arc::new(TestOrderedClient::new(
         PrefixedStoreClient::empty(store_client.clone()),
@@ -1616,7 +1616,7 @@ async fn ordered_range_connect_subscribe_matches_prefix_and_regex_filters() {
 
 #[tokio::test]
 async fn ordered_range_connect_subscribe_filters_by_value_regex_without_key() {
-    let (_dir, _store_server, store_client) = common::local_store_client().await;
+    let (_store_server, store_client) = common::local_store_client().await;
     let local = build_local_batch().await;
     let ordered_client = Arc::new(TestOrderedClient::new(
         PrefixedStoreClient::empty(store_client.clone()),
@@ -1656,7 +1656,7 @@ async fn ordered_range_connect_subscribe_filters_by_value_regex_without_key() {
 
 #[tokio::test]
 async fn ordered_range_connect_subscribe_intersects_key_and_value_filters() {
-    let (_dir, _store_server, store_client) = common::local_store_client().await;
+    let (_store_server, store_client) = common::local_store_client().await;
     let local = build_local_batch().await;
     let ordered_client = Arc::new(TestOrderedClient::new(
         PrefixedStoreClient::empty(store_client.clone()),

--- a/qmdb/rs/tests/e2e_ordered_range_connect.rs
+++ b/qmdb/rs/tests/e2e_ordered_range_connect.rs
@@ -480,7 +480,7 @@ async fn commit_mmb_upload(client: &StoreClient, batch: &MmbLocalBatch) {
 
 #[tokio::test]
 async fn ordered_current_operation_range_connect_emits_verifiable_proof() {
-    let (_store_server, store_client) = common::local_store_client().await;
+    let store_client = common::local_store_client().await;
     let local = build_local_batch().await;
     commit_upload(&store_client, &local).await;
 
@@ -518,7 +518,7 @@ async fn ordered_current_operation_range_connect_emits_verifiable_proof() {
 
 #[tokio::test]
 async fn ordered_current_state_sync_from_connect_api_reconstructs_current_db() {
-    let (_store_server, store_client) = common::local_store_client().await;
+    let store_client = common::local_store_client().await;
     let local = build_local_batch().await;
     commit_upload(&store_client, &local).await;
 
@@ -585,7 +585,7 @@ async fn ordered_current_state_sync_from_connect_api_reconstructs_current_db() {
 async fn ordered_mmb_current_state_sync_from_nonzero_connect_api_reconstructs_current_db() {
     const FETCH_BATCH_SIZE: u64 = 3;
 
-    let (_store_server, store_client) = common::local_store_client().await;
+    let store_client = common::local_store_client().await;
     let local = build_mmb_local_batch().await;
     let start = Location::<mmb::Family>::new(1);
     let start_index = usize::try_from(*start).expect("start fits usize");
@@ -668,7 +668,7 @@ async fn ordered_mmb_current_state_sync_from_nonzero_connect_api_reconstructs_cu
 
 #[tokio::test]
 async fn ordered_mmb_sync_resolvers_return_pinned_nodes_for_nonzero_fetches() {
-    let (_store_server, store_client) = common::local_store_client().await;
+    let store_client = common::local_store_client().await;
     let local = build_mmb_local_batch().await;
     let start = Location::<mmb::Family>::new(3);
     assert!(*start > 0, "regression must exercise a nonzero lower bound");
@@ -755,7 +755,7 @@ async fn ordered_mmb_sync_resolvers_return_pinned_nodes_for_nonzero_fetches() {
 
 #[tokio::test]
 async fn ordered_mmb_operation_range_client_rejects_missing_nonzero_pinned_nodes() {
-    let (_store_server, store_client) = common::local_store_client().await;
+    let store_client = common::local_store_client().await;
     let local = build_mmb_local_batch().await;
     let start = Location::<mmb::Family>::new(3);
     assert!(
@@ -823,7 +823,7 @@ async fn ordered_mmb_operation_range_client_rejects_missing_nonzero_pinned_nodes
 
 #[tokio::test]
 async fn ordered_mmb_operation_range_client_rejects_extra_nonzero_pinned_node() {
-    let (_store_server, store_client) = common::local_store_client().await;
+    let store_client = common::local_store_client().await;
     let local = build_mmb_local_batch().await;
     let start = Location::<mmb::Family>::new(3);
     assert!(
@@ -879,7 +879,7 @@ async fn ordered_mmb_operation_range_client_rejects_extra_nonzero_pinned_node() 
 
 #[tokio::test]
 async fn ordered_mmb_operation_range_client_rejects_zero_start_pinned_nodes() {
-    let (_store_server, store_client) = common::local_store_client().await;
+    let store_client = common::local_store_client().await;
     let local = build_mmb_local_batch().await;
     commit_mmb_upload(&store_client, &local).await;
 
@@ -932,7 +932,7 @@ async fn ordered_mmb_operation_range_client_rejects_zero_start_pinned_nodes() {
 
 #[tokio::test]
 async fn ordered_operation_range_connect_uses_current_root_witness() {
-    let (_store_server, store_client) = common::local_store_client().await;
+    let store_client = common::local_store_client().await;
     let local = build_local_batch().await;
     commit_upload(&store_client, &local).await;
 
@@ -1059,7 +1059,7 @@ fn latest_mmb_value_for_key(operations: &[MmbBatchOperation], key: &[u8]) -> Opt
 
 #[tokio::test]
 async fn ordered_range_connect_subscribe_emits_verifiable_range_proof() {
-    let (_store_server, store_client) = common::local_store_client().await;
+    let store_client = common::local_store_client().await;
     let local = build_local_batch().await;
     assert!(
         *local.inactivity_floor > 0,
@@ -1103,7 +1103,7 @@ async fn ordered_range_connect_subscribe_emits_verifiable_range_proof() {
 
 #[tokio::test]
 async fn ordered_range_connect_client_rejects_invalid_streamed_proof() {
-    let (_store_server, store_client) = common::local_store_client().await;
+    let store_client = common::local_store_client().await;
     let local = build_local_batch().await;
     commit_upload(&store_client, &local).await;
 
@@ -1153,7 +1153,7 @@ async fn ordered_range_connect_client_rejects_invalid_streamed_proof() {
 
 #[tokio::test]
 async fn ordered_range_connect_subscribe_emits_multi_proof_for_matching_keys() {
-    let (_store_server, store_client) = common::local_store_client().await;
+    let store_client = common::local_store_client().await;
     let local = build_local_batch().await;
     let ordered_client = Arc::new(TestOrderedClient::new(
         PrefixedStoreClient::empty(store_client.clone()),
@@ -1192,7 +1192,7 @@ async fn ordered_range_connect_subscribe_emits_multi_proof_for_matching_keys() {
 
 #[tokio::test]
 async fn ordered_mmb_range_connect_subscribe_verifies_range_and_multi_proofs() {
-    let (_store_server, store_client) = common::local_store_client().await;
+    let store_client = common::local_store_client().await;
     let local = build_mmb_local_batch().await;
     assert!(
         *local.inactivity_floor > 0,
@@ -1260,7 +1260,7 @@ async fn ordered_mmb_range_connect_subscribe_verifies_range_and_multi_proofs() {
 async fn ordered_mmb_operation_log_any_sync_from_connect_api_reconstructs_any_db() {
     const FETCH_BATCH_SIZE: u64 = 3;
 
-    let (_store_server, store_client) = common::local_store_client().await;
+    let store_client = common::local_store_client().await;
     let local = build_mmb_local_batch().await;
     assert!(
         local.operations.len() as u64 > FETCH_BATCH_SIZE * 2,
@@ -1326,7 +1326,7 @@ async fn ordered_mmb_operation_log_any_sync_from_connect_api_reconstructs_any_db
 async fn ordered_mmb_operation_log_any_sync_from_nonzero_connect_api_reconstructs_any_db() {
     const FETCH_BATCH_SIZE: u64 = 3;
 
-    let (_store_server, store_client) = common::local_store_client().await;
+    let store_client = common::local_store_client().await;
     let local = build_mmb_local_batch().await;
     let start = Location::<mmb::Family>::new(3);
     let start_index = usize::try_from(*start).expect("start fits usize");
@@ -1405,7 +1405,7 @@ async fn ordered_mmb_operation_log_any_sync_from_nonzero_connect_api_reconstruct
 async fn ordered_mmb_operation_log_any_sync_accepts_target_update_from_growing_backend() {
     const FETCH_BATCH_SIZE: u64 = 3;
 
-    let (_store_server, store_client) = common::local_store_client().await;
+    let store_client = common::local_store_client().await;
     let local = build_mmb_growing_local_batch().await;
     let start = Location::<mmb::Family>::new(1);
     let start_index = usize::try_from(*start).expect("start fits usize");
@@ -1523,7 +1523,7 @@ async fn ordered_mmb_operation_log_any_sync_accepts_target_update_from_growing_b
 
 #[tokio::test]
 async fn ordered_range_connect_subscribe_replays_since_cursor() {
-    let (_store_server, store_client) = common::local_store_client().await;
+    let store_client = common::local_store_client().await;
     let local = build_local_batch().await;
     let ordered_client = Arc::new(TestOrderedClient::new(
         PrefixedStoreClient::empty(store_client.clone()),
@@ -1560,7 +1560,7 @@ async fn ordered_range_connect_subscribe_replays_since_cursor() {
 
 #[tokio::test]
 async fn ordered_range_connect_subscribe_matches_prefix_and_regex_filters() {
-    let (_store_server, store_client) = common::local_store_client().await;
+    let store_client = common::local_store_client().await;
     let local = build_local_batch().await;
     let ordered_client = Arc::new(TestOrderedClient::new(
         PrefixedStoreClient::empty(store_client.clone()),
@@ -1616,7 +1616,7 @@ async fn ordered_range_connect_subscribe_matches_prefix_and_regex_filters() {
 
 #[tokio::test]
 async fn ordered_range_connect_subscribe_filters_by_value_regex_without_key() {
-    let (_store_server, store_client) = common::local_store_client().await;
+    let store_client = common::local_store_client().await;
     let local = build_local_batch().await;
     let ordered_client = Arc::new(TestOrderedClient::new(
         PrefixedStoreClient::empty(store_client.clone()),
@@ -1656,7 +1656,7 @@ async fn ordered_range_connect_subscribe_filters_by_value_regex_without_key() {
 
 #[tokio::test]
 async fn ordered_range_connect_subscribe_intersects_key_and_value_filters() {
-    let (_store_server, store_client) = common::local_store_client().await;
+    let store_client = common::local_store_client().await;
     let local = build_local_batch().await;
     let ordered_client = Arc::new(TestOrderedClient::new(
         PrefixedStoreClient::empty(store_client.clone()),

--- a/qmdb/rs/tests/e2e_ordered_writer.rs
+++ b/qmdb/rs/tests/e2e_ordered_writer.rs
@@ -166,7 +166,7 @@ async fn build_local_reference(
 
 #[tokio::test]
 async fn sequential_upload_matches_local_root() {
-    let (_server, client) = common::local_store_client().await;
+    let client = common::local_store_client().await;
     let local = build_local_reference(
         vec![vec![
             (b"alpha".to_vec(), Some(b"one".to_vec())),
@@ -206,7 +206,7 @@ async fn sequential_upload_matches_local_root() {
 // local DBs side-by-side to extract the per-batch CurrentBoundaryState.
 #[tokio::test]
 async fn pipelined_batches_require_flush_to_catch_up_watermark() {
-    let (_server, client) = common::local_store_client().await;
+    let client = common::local_store_client().await;
 
     // Build three cumulative reference snapshots so we can pull a
     // current-boundary delta at each batch boundary from the local current DB.

--- a/qmdb/rs/tests/e2e_ordered_writer.rs
+++ b/qmdb/rs/tests/e2e_ordered_writer.rs
@@ -166,7 +166,7 @@ async fn build_local_reference(
 
 #[tokio::test]
 async fn sequential_upload_matches_local_root() {
-    let (_dir, _server, client) = common::local_store_client().await;
+    let (_server, client) = common::local_store_client().await;
     let local = build_local_reference(
         vec![vec![
             (b"alpha".to_vec(), Some(b"one".to_vec())),
@@ -206,7 +206,7 @@ async fn sequential_upload_matches_local_root() {
 // local DBs side-by-side to extract the per-batch CurrentBoundaryState.
 #[tokio::test]
 async fn pipelined_batches_require_flush_to_catch_up_watermark() {
-    let (_dir, _server, client) = common::local_store_client().await;
+    let (_server, client) = common::local_store_client().await;
 
     // Build three cumulative reference snapshots so we can pull a
     // current-boundary delta at each batch boundary from the local current DB.

--- a/qmdb/rs/tests/e2e_unordered.rs
+++ b/qmdb/rs/tests/e2e_unordered.rs
@@ -196,7 +196,7 @@ async fn build_fixed_local_db() -> FixedLocalReference {
 
 #[tokio::test]
 async fn unordered_round_trip() {
-    let (_server, client) = common::local_store_client().await;
+    let client = common::local_store_client().await;
     let local = build_local_db().await;
 
     let writer: UnorderedWriter<mmr::Family, Sha256, Vec<u8>, Vec<u8>> =
@@ -238,7 +238,7 @@ async fn unordered_round_trip() {
 
 #[tokio::test]
 async fn unordered_fixed_round_trip() {
-    let (_server, client) = common::local_store_client().await;
+    let client = common::local_store_client().await;
     let local = build_fixed_local_db().await;
 
     let writer: UnorderedWriter<mmr::Family, Sha256, Digest, Digest, FixedEncoding<Digest>> =

--- a/qmdb/rs/tests/e2e_unordered.rs
+++ b/qmdb/rs/tests/e2e_unordered.rs
@@ -196,7 +196,7 @@ async fn build_fixed_local_db() -> FixedLocalReference {
 
 #[tokio::test]
 async fn unordered_round_trip() {
-    let (_dir, _server, client) = common::local_store_client().await;
+    let (_server, client) = common::local_store_client().await;
     let local = build_local_db().await;
 
     let writer: UnorderedWriter<mmr::Family, Sha256, Vec<u8>, Vec<u8>> =
@@ -238,7 +238,7 @@ async fn unordered_round_trip() {
 
 #[tokio::test]
 async fn unordered_fixed_round_trip() {
-    let (_dir, _server, client) = common::local_store_client().await;
+    let (_server, client) = common::local_store_client().await;
     let local = build_fixed_local_db().await;
 
     let writer: UnorderedWriter<mmr::Family, Sha256, Digest, Digest, FixedEncoding<Digest>> =

--- a/qmdb/rs/tests/e2e_unordered_connect.rs
+++ b/qmdb/rs/tests/e2e_unordered_connect.rs
@@ -472,7 +472,7 @@ fn latest_fixed_operation_for_key(
 
 #[tokio::test]
 async fn unordered_range_stack_does_not_expose_key_lookup_or_ordered_range_services() {
-    let (_dir, _store_server, store_client) = common::local_store_client().await;
+    let (_store_server, store_client) = common::local_store_client().await;
     let unordered_client = Arc::new(TestUnorderedClient::new(
         PrefixedStoreClient::empty(store_client),
         op_cfg(),
@@ -503,7 +503,7 @@ async fn unordered_range_stack_does_not_expose_key_lookup_or_ordered_range_servi
 
 #[tokio::test]
 async fn unordered_connect_get_operation_range_returns_verifiable_proof() {
-    let (_dir, _store_server, store_client) = common::local_store_client().await;
+    let (_store_server, store_client) = common::local_store_client().await;
     let local = build_local_batch().await;
     commit_upload(&store_client, &local).await;
 
@@ -537,7 +537,7 @@ async fn unordered_connect_get_operation_range_returns_verifiable_proof() {
 
 #[tokio::test]
 async fn unordered_connect_get_many_returns_present_key_proofs() {
-    let (_dir, _store_server, store_client) = common::local_store_client().await;
+    let (_store_server, store_client) = common::local_store_client().await;
     let local = build_fixed_local_batch().await;
     commit_fixed_upload(&store_client, &local).await;
 
@@ -587,7 +587,7 @@ async fn unordered_connect_get_many_returns_present_key_proofs() {
 
 #[tokio::test]
 async fn unordered_current_operation_range_connect_returns_verifiable_proof() {
-    let (_dir, _store_server, store_client) = common::local_store_client().await;
+    let (_store_server, store_client) = common::local_store_client().await;
     let local = build_fixed_local_batch().await;
     commit_fixed_upload(&store_client, &local).await;
 
@@ -625,7 +625,7 @@ async fn unordered_current_operation_range_connect_returns_verifiable_proof() {
 
 #[tokio::test]
 async fn unordered_connect_omits_missing_and_rejects_duplicate_range_and_stale_root() {
-    let (_dir, _store_server, store_client) = common::local_store_client().await;
+    let (_store_server, store_client) = common::local_store_client().await;
     let local = build_fixed_local_batch().await;
     commit_fixed_upload(&store_client, &local).await;
 
@@ -696,7 +696,7 @@ async fn unordered_connect_omits_missing_and_rejects_duplicate_range_and_stale_r
 
 #[tokio::test]
 async fn unordered_connect_subscribe_emits_verifiable_range_proof() {
-    let (_dir, _store_server, store_client) = common::local_store_client().await;
+    let (_store_server, store_client) = common::local_store_client().await;
     let local = build_local_batch().await;
     assert!(
         *local.inactivity_floor > 0,
@@ -739,7 +739,7 @@ async fn unordered_connect_subscribe_emits_verifiable_range_proof() {
 
 #[tokio::test]
 async fn unordered_mmb_connect_subscribe_emits_verifiable_range_proof() {
-    let (_dir, _store_server, store_client) = common::local_store_client().await;
+    let (_store_server, store_client) = common::local_store_client().await;
     let local = build_mmb_local_batch().await;
     assert!(
         *local.inactivity_floor > 0,
@@ -782,7 +782,7 @@ async fn unordered_mmb_connect_subscribe_emits_verifiable_range_proof() {
 
 #[tokio::test]
 async fn unordered_connect_client_rejects_invalid_streamed_proof() {
-    let (_dir, _store_server, store_client) = common::local_store_client().await;
+    let (_store_server, store_client) = common::local_store_client().await;
     let local = build_local_batch().await;
     commit_upload(&store_client, &local).await;
 

--- a/qmdb/rs/tests/e2e_unordered_connect.rs
+++ b/qmdb/rs/tests/e2e_unordered_connect.rs
@@ -472,7 +472,7 @@ fn latest_fixed_operation_for_key(
 
 #[tokio::test]
 async fn unordered_range_stack_does_not_expose_key_lookup_or_ordered_range_services() {
-    let (_store_server, store_client) = common::local_store_client().await;
+    let store_client = common::local_store_client().await;
     let unordered_client = Arc::new(TestUnorderedClient::new(
         PrefixedStoreClient::empty(store_client),
         op_cfg(),
@@ -503,7 +503,7 @@ async fn unordered_range_stack_does_not_expose_key_lookup_or_ordered_range_servi
 
 #[tokio::test]
 async fn unordered_connect_get_operation_range_returns_verifiable_proof() {
-    let (_store_server, store_client) = common::local_store_client().await;
+    let store_client = common::local_store_client().await;
     let local = build_local_batch().await;
     commit_upload(&store_client, &local).await;
 
@@ -537,7 +537,7 @@ async fn unordered_connect_get_operation_range_returns_verifiable_proof() {
 
 #[tokio::test]
 async fn unordered_connect_get_many_returns_present_key_proofs() {
-    let (_store_server, store_client) = common::local_store_client().await;
+    let store_client = common::local_store_client().await;
     let local = build_fixed_local_batch().await;
     commit_fixed_upload(&store_client, &local).await;
 
@@ -587,7 +587,7 @@ async fn unordered_connect_get_many_returns_present_key_proofs() {
 
 #[tokio::test]
 async fn unordered_current_operation_range_connect_returns_verifiable_proof() {
-    let (_store_server, store_client) = common::local_store_client().await;
+    let store_client = common::local_store_client().await;
     let local = build_fixed_local_batch().await;
     commit_fixed_upload(&store_client, &local).await;
 
@@ -625,7 +625,7 @@ async fn unordered_current_operation_range_connect_returns_verifiable_proof() {
 
 #[tokio::test]
 async fn unordered_connect_omits_missing_and_rejects_duplicate_range_and_stale_root() {
-    let (_store_server, store_client) = common::local_store_client().await;
+    let store_client = common::local_store_client().await;
     let local = build_fixed_local_batch().await;
     commit_fixed_upload(&store_client, &local).await;
 
@@ -696,7 +696,7 @@ async fn unordered_connect_omits_missing_and_rejects_duplicate_range_and_stale_r
 
 #[tokio::test]
 async fn unordered_connect_subscribe_emits_verifiable_range_proof() {
-    let (_store_server, store_client) = common::local_store_client().await;
+    let store_client = common::local_store_client().await;
     let local = build_local_batch().await;
     assert!(
         *local.inactivity_floor > 0,
@@ -739,7 +739,7 @@ async fn unordered_connect_subscribe_emits_verifiable_range_proof() {
 
 #[tokio::test]
 async fn unordered_mmb_connect_subscribe_emits_verifiable_range_proof() {
-    let (_store_server, store_client) = common::local_store_client().await;
+    let store_client = common::local_store_client().await;
     let local = build_mmb_local_batch().await;
     assert!(
         *local.inactivity_floor > 0,
@@ -782,7 +782,7 @@ async fn unordered_mmb_connect_subscribe_emits_verifiable_range_proof() {
 
 #[tokio::test]
 async fn unordered_connect_client_rejects_invalid_streamed_proof() {
-    let (_store_server, store_client) = common::local_store_client().await;
+    let store_client = common::local_store_client().await;
     let local = build_local_batch().await;
     commit_upload(&store_client, &local).await;
 

--- a/qmdb/rs/tests/e2e_unordered_writer.rs
+++ b/qmdb/rs/tests/e2e_unordered_writer.rs
@@ -109,7 +109,7 @@ async fn build_local_reference(batches: Vec<WriteBatch>) -> LocalReference {
 
 #[tokio::test]
 async fn sequential_upload_matches_local_root() {
-    let (_server, client) = common::local_store_client().await;
+    let client = common::local_store_client().await;
     let local = build_local_reference(vec![vec![
         (b"alpha".to_vec(), Some(b"one".to_vec())),
         (b"beta".to_vec(), Some(b"two".to_vec())),
@@ -142,7 +142,7 @@ async fn sequential_upload_matches_local_root() {
 
 #[tokio::test]
 async fn pipelined_batches_require_flush_to_catch_up_watermark() {
-    let (_server, client) = common::local_store_client().await;
+    let client = common::local_store_client().await;
     let b1 = vec![(b"a".to_vec(), Some(b"1".to_vec()))];
     let b2 = vec![(b"b".to_vec(), Some(b"2".to_vec()))];
     let b3 = vec![(b"c".to_vec(), Some(b"3".to_vec()))];

--- a/qmdb/rs/tests/e2e_unordered_writer.rs
+++ b/qmdb/rs/tests/e2e_unordered_writer.rs
@@ -109,7 +109,7 @@ async fn build_local_reference(batches: Vec<WriteBatch>) -> LocalReference {
 
 #[tokio::test]
 async fn sequential_upload_matches_local_root() {
-    let (_dir, _server, client) = common::local_store_client().await;
+    let (_server, client) = common::local_store_client().await;
     let local = build_local_reference(vec![vec![
         (b"alpha".to_vec(), Some(b"one".to_vec())),
         (b"beta".to_vec(), Some(b"two".to_vec())),
@@ -142,7 +142,7 @@ async fn sequential_upload_matches_local_root() {
 
 #[tokio::test]
 async fn pipelined_batches_require_flush_to_catch_up_watermark() {
-    let (_dir, _server, client) = common::local_store_client().await;
+    let (_server, client) = common::local_store_client().await;
     let b1 = vec![(b"a".to_vec(), Some(b"1".to_vec()))];
     let b2 = vec![(b"b".to_vec(), Some(b"2".to_vec()))];
     let b3 = vec![(b"c".to_vec(), Some(b"3".to_vec()))];

--- a/simplex/rs/Cargo.toml
+++ b/simplex/rs/Cargo.toml
@@ -40,4 +40,3 @@ commonware-cryptography = { workspace = true, features = ["mocks"] }
 commonware-p2p = { workspace = true }
 commonware-storage = { workspace = true }
 exoware-simulator = { path = "../../examples/simulator" }
-tempfile = { workspace = true }

--- a/simplex/rs/tests/e2e.rs
+++ b/simplex/rs/tests/e2e.rs
@@ -180,9 +180,12 @@ impl CertifiableBlock for TestBlock {
     }
 }
 
-async fn local_store_client() -> (tempfile::TempDir, tokio::task::JoinHandle<()>, StoreClient) {
+/// Keep `_server` alive for the whole test; the store's tempdir lives inside the server task so
+/// it cannot be deleted while the store is still running.
+async fn local_store_client() -> (tokio::task::JoinHandle<()>, StoreClient) {
     let dir = tempfile::tempdir().expect("tempdir");
-    let (handle, url) = exoware_simulator::spawn_for_test(dir.path())
+    let path = dir.path().to_path_buf();
+    let (handle, url) = exoware_simulator::spawn_for_test(&path, dir)
         .await
         .expect("spawn simulator");
     let client = StoreClient::builder()
@@ -190,7 +193,7 @@ async fn local_store_client() -> (tempfile::TempDir, tokio::task::JoinHandle<()>
         .retry_config(RetryConfig::disabled())
         .build()
         .expect("store client");
-    (dir, handle, client)
+    (handle, client)
 }
 
 fn schemes() -> Vec<Scheme> {
@@ -228,7 +231,7 @@ fn finalized(block: TestBlock, schemes: &[Scheme]) -> Finalized<TestBlock, Schem
 
 #[tokio::test]
 async fn uploads_and_reads_notarized_and_finalized_blocks() {
-    let (_dir, _handle, store) = local_store_client().await;
+    let (_handle, store) = local_store_client().await;
     let simplex = SimplexClient::new(PrefixedStoreClient::empty(store));
     let schemes = schemes();
 
@@ -304,7 +307,7 @@ async fn uploads_and_reads_notarized_and_finalized_blocks() {
 
 #[tokio::test]
 async fn prepared_uploads_can_share_one_store_batch() {
-    let (_dir, _handle, store) = local_store_client().await;
+    let (_handle, store) = local_store_client().await;
     let simplex = SimplexClient::new(PrefixedStoreClient::empty(store.clone()));
     let schemes = schemes();
 
@@ -336,7 +339,7 @@ async fn prepared_uploads_can_share_one_store_batch() {
 async fn marshal_resolver_sinks_finalized_chain_from_simplex_api() {
     const BLOCKS_TO_PROCESS: u64 = 5;
 
-    let (_dir, _handle, store) = local_store_client().await;
+    let (_handle, store) = local_store_client().await;
     let simplex = SimplexClient::new(PrefixedStoreClient::empty(store));
     let schemes = schemes();
 

--- a/simplex/rs/tests/e2e.rs
+++ b/simplex/rs/tests/e2e.rs
@@ -182,7 +182,7 @@ impl CertifiableBlock for TestBlock {
 
 /// Spawns a local simulator and returns a client for it.
 async fn local_store_client() -> StoreClient {
-    let (_task, url) = exoware_simulator::test_spawn()
+    let (_task, url) = exoware_simulator::open_temp()
         .await
         .expect("spawn simulator");
     StoreClient::builder()

--- a/simplex/rs/tests/e2e.rs
+++ b/simplex/rs/tests/e2e.rs
@@ -180,8 +180,8 @@ impl CertifiableBlock for TestBlock {
     }
 }
 
-/// Keep `_server` alive for the whole test; the store's tempdir lives inside the server task so
-/// it cannot be deleted while the store is still running.
+/// Keep `_server` alive for the whole test; the store's tempdir lives inside the store engine
+/// so it cannot be deleted while the store is still running.
 async fn local_store_client() -> (tokio::task::JoinHandle<()>, StoreClient) {
     let dir = tempfile::tempdir().expect("tempdir");
     let path = dir.path().to_path_buf();

--- a/simplex/rs/tests/e2e.rs
+++ b/simplex/rs/tests/e2e.rs
@@ -180,20 +180,16 @@ impl CertifiableBlock for TestBlock {
     }
 }
 
-/// Keep `_server` alive for the whole test; the store's tempdir lives inside the store engine
-/// so it cannot be deleted while the store is still running.
-async fn local_store_client() -> (tokio::task::JoinHandle<()>, StoreClient) {
-    let dir = tempfile::tempdir().expect("tempdir");
-    let path = dir.path().to_path_buf();
-    let (handle, url) = exoware_simulator::spawn_for_test(&path, dir)
+/// Spawns a local simulator and returns a client for it.
+async fn local_store_client() -> StoreClient {
+    let (_task, url) = exoware_simulator::test_spawn()
         .await
         .expect("spawn simulator");
-    let client = StoreClient::builder()
+    StoreClient::builder()
         .url(&url)
         .retry_config(RetryConfig::disabled())
         .build()
-        .expect("store client");
-    (handle, client)
+        .expect("store client")
 }
 
 fn schemes() -> Vec<Scheme> {
@@ -231,7 +227,7 @@ fn finalized(block: TestBlock, schemes: &[Scheme]) -> Finalized<TestBlock, Schem
 
 #[tokio::test]
 async fn uploads_and_reads_notarized_and_finalized_blocks() {
-    let (_handle, store) = local_store_client().await;
+    let store = local_store_client().await;
     let simplex = SimplexClient::new(PrefixedStoreClient::empty(store));
     let schemes = schemes();
 
@@ -307,7 +303,7 @@ async fn uploads_and_reads_notarized_and_finalized_blocks() {
 
 #[tokio::test]
 async fn prepared_uploads_can_share_one_store_batch() {
-    let (_handle, store) = local_store_client().await;
+    let store = local_store_client().await;
     let simplex = SimplexClient::new(PrefixedStoreClient::empty(store.clone()));
     let schemes = schemes();
 
@@ -339,7 +335,7 @@ async fn prepared_uploads_can_share_one_store_batch() {
 async fn marshal_resolver_sinks_finalized_chain_from_simplex_api() {
     const BLOCKS_TO_PROCESS: u64 = 5;
 
-    let (_handle, store) = local_store_client().await;
+    let store = local_store_client().await;
     let simplex = SimplexClient::new(PrefixedStoreClient::empty(store));
     let schemes = schemes();
 

--- a/sql/rs/Cargo.toml
+++ b/sql/rs/Cargo.toml
@@ -45,7 +45,6 @@ exoware-server = { workspace = true }
 futures = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }
-tempfile = { workspace = true }
 
 [[bench]]
 name = "read_path_perf"

--- a/sql/rs/src/lib.rs
+++ b/sql/rs/src/lib.rs
@@ -8517,7 +8517,7 @@ mod tests {
         }
 
         async fn spawn_e2e_servers() -> TestServers {
-            let (_task, url) = exoware_simulator::test_spawn()
+            let (_task, url) = exoware_simulator::open_temp()
                 .await
                 .expect("spawn simulator");
             TestServers {

--- a/sql/rs/src/lib.rs
+++ b/sql/rs/src/lib.rs
@@ -8495,18 +8495,13 @@ mod tests {
 
     mod e2e {
         use super::*;
-        use axum::{routing::get, Router};
         use datafusion::prelude::SessionContext;
         use exoware_sdk::StoreClient;
-        use exoware_server::{connect_stack, AppState};
-        use exoware_simulator::RocksStore;
         use tempfile::tempdir;
 
         struct TestServers {
             ingest_url: String,
             query_url: String,
-            /// Keeps the store's data directory alive for the whole test.
-            _dir: tempfile::TempDir,
         }
 
         impl TestServers {
@@ -8524,34 +8519,15 @@ mod tests {
 
         async fn spawn_e2e_servers() -> TestServers {
             let dir = tempdir().expect("tempdir");
-            let db = RocksStore::open(dir.path(), None).expect("db");
-            let state = AppState::new(std::sync::Arc::new(db));
-            let connect = connect_stack(state);
-            let app = Router::new()
-                .route("/health", get(|| async { "ok" }))
-                .fallback_service(connect);
-            let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            let path = dir.path().to_path_buf();
+            // The tempdir guard lives inside the spawned store so it outlives every handle.
+            let (_handle, url) = exoware_simulator::spawn_for_test(&path, dir)
                 .await
-                .expect("bind");
-            let url = format!("http://{}", listener.local_addr().unwrap());
-            tokio::spawn(async move {
-                axum::serve(listener, app).await.expect("serve");
-            });
-            for _ in 0..200 {
-                if reqwest::get(format!("{url}/health"))
-                    .await
-                    .ok()
-                    .is_some_and(|r| r.status().is_success())
-                {
-                    return TestServers {
-                        ingest_url: url.clone(),
-                        query_url: url,
-                        _dir: dir,
-                    };
-                }
-                tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+                .expect("spawn simulator");
+            TestServers {
+                ingest_url: url.clone(),
+                query_url: url,
             }
-            panic!("e2e simulator did not become ready");
         }
 
         #[tokio::test]

--- a/sql/rs/src/lib.rs
+++ b/sql/rs/src/lib.rs
@@ -8505,6 +8505,8 @@ mod tests {
         struct TestServers {
             ingest_url: String,
             query_url: String,
+            /// Keeps the store's data directory alive for the whole test.
+            _dir: tempfile::TempDir,
         }
 
         impl TestServers {
@@ -8544,6 +8546,7 @@ mod tests {
                     return TestServers {
                         ingest_url: url.clone(),
                         query_url: url,
+                        _dir: dir,
                     };
                 }
                 tokio::time::sleep(std::time::Duration::from_millis(25)).await;

--- a/sql/rs/src/lib.rs
+++ b/sql/rs/src/lib.rs
@@ -8497,7 +8497,6 @@ mod tests {
         use super::*;
         use datafusion::prelude::SessionContext;
         use exoware_sdk::StoreClient;
-        use tempfile::tempdir;
 
         struct TestServers {
             ingest_url: String,
@@ -8518,10 +8517,7 @@ mod tests {
         }
 
         async fn spawn_e2e_servers() -> TestServers {
-            let dir = tempdir().expect("tempdir");
-            let path = dir.path().to_path_buf();
-            // The tempdir guard lives inside the spawned store so it outlives every handle.
-            let (_handle, url) = exoware_simulator::spawn_for_test(&path, dir)
+            let (_task, url) = exoware_simulator::test_spawn()
                 .await
                 .expect("spawn simulator");
             TestServers {

--- a/sql/rs/tests/common/mod.rs
+++ b/sql/rs/tests/common/mod.rs
@@ -2,11 +2,14 @@
 
 use exoware_sdk::StoreClient;
 
-pub async fn local_store_client() -> (tempfile::TempDir, tokio::task::JoinHandle<()>, StoreClient) {
+/// Keep `_server` alive for the whole test; the store's tempdir lives inside the server task so
+/// it cannot be deleted while the store is still running.
+pub async fn local_store_client() -> (tokio::task::JoinHandle<()>, StoreClient) {
     let dir = tempfile::tempdir().expect("tempdir");
-    let (jh, url) = exoware_simulator::spawn_for_test(dir.path())
+    let path = dir.path().to_path_buf();
+    let (jh, url) = exoware_simulator::spawn_for_test(&path, dir)
         .await
         .expect("spawn simulator");
     let client = StoreClient::new(&url);
-    (dir, jh, client)
+    (jh, client)
 }

--- a/sql/rs/tests/common/mod.rs
+++ b/sql/rs/tests/common/mod.rs
@@ -4,7 +4,7 @@ use exoware_sdk::StoreClient;
 
 /// Spawns a local simulator and returns a client for it.
 pub async fn local_store_client() -> StoreClient {
-    let (_task, url) = exoware_simulator::test_spawn()
+    let (_task, url) = exoware_simulator::open_temp()
         .await
         .expect("spawn simulator");
     StoreClient::new(&url)

--- a/sql/rs/tests/common/mod.rs
+++ b/sql/rs/tests/common/mod.rs
@@ -1,15 +1,11 @@
-//! Local E2E: ephemeral RocksDB dir + simulator on an ephemeral port (no env vars).
+//! Local E2E: simulator on an ephemeral port (no env vars).
 
 use exoware_sdk::StoreClient;
 
-/// Keep `_server` alive for the whole test; the store's tempdir lives inside the store engine
-/// so it cannot be deleted while the store is still running.
-pub async fn local_store_client() -> (tokio::task::JoinHandle<()>, StoreClient) {
-    let dir = tempfile::tempdir().expect("tempdir");
-    let path = dir.path().to_path_buf();
-    let (jh, url) = exoware_simulator::spawn_for_test(&path, dir)
+/// Spawns a local simulator and returns a client for it.
+pub async fn local_store_client() -> StoreClient {
+    let (_task, url) = exoware_simulator::test_spawn()
         .await
         .expect("spawn simulator");
-    let client = StoreClient::new(&url);
-    (jh, client)
+    StoreClient::new(&url)
 }

--- a/sql/rs/tests/common/mod.rs
+++ b/sql/rs/tests/common/mod.rs
@@ -2,8 +2,8 @@
 
 use exoware_sdk::StoreClient;
 
-/// Keep `_server` alive for the whole test; the store's tempdir lives inside the server task so
-/// it cannot be deleted while the store is still running.
+/// Keep `_server` alive for the whole test; the store's tempdir lives inside the store engine
+/// so it cannot be deleted while the store is still running.
 pub async fn local_store_client() -> (tokio::task::JoinHandle<()>, StoreClient) {
     let dir = tempfile::tempdir().expect("tempdir");
     let path = dir.path().to_path_buf();

--- a/sql/rs/tests/e2e_slam.rs
+++ b/sql/rs/tests/e2e_slam.rs
@@ -11,7 +11,7 @@ use exoware_sql::{CellValue, IndexSpec, KvSchema, TableColumnConfig};
 
 #[tokio::test]
 async fn sql_full_pipeline_insert_and_query() {
-    let (_dir, _server, write_client) = common::local_store_client().await;
+    let (_server, write_client) = common::local_store_client().await;
     let read_client = write_client.clone();
 
     let write_schema = KvSchema::new(PrefixedStoreClient::empty(write_client))

--- a/sql/rs/tests/e2e_slam.rs
+++ b/sql/rs/tests/e2e_slam.rs
@@ -11,7 +11,7 @@ use exoware_sql::{CellValue, IndexSpec, KvSchema, TableColumnConfig};
 
 #[tokio::test]
 async fn sql_full_pipeline_insert_and_query() {
-    let (_server, write_client) = common::local_store_client().await;
+    let write_client = common::local_store_client().await;
     let read_client = write_client.clone();
 
     let write_schema = KvSchema::new(PrefixedStoreClient::empty(write_client))

--- a/sql/rs/tests/examples_smoke.rs
+++ b/sql/rs/tests/examples_smoke.rs
@@ -99,7 +99,7 @@ fn collect_two_strings(
 
 #[tokio::test]
 async fn orders_example_queries_work_end_to_end() {
-    let (_dir, _server, client) = common::local_store_client().await;
+    let (_server, client) = common::local_store_client().await;
     let ctx = SessionContext::new();
 
     KvSchema::new(PrefixedStoreClient::empty(client))
@@ -180,7 +180,7 @@ async fn orders_example_queries_work_end_to_end() {
 
 #[tokio::test]
 async fn join_example_queries_work_end_to_end() {
-    let (_dir, _server, client) = common::local_store_client().await;
+    let (_server, client) = common::local_store_client().await;
     let ctx = SessionContext::new();
 
     KvSchema::new(PrefixedStoreClient::empty(client))
@@ -289,7 +289,7 @@ async fn join_example_queries_work_end_to_end() {
 
 #[tokio::test]
 async fn versioned_example_queries_work_end_to_end() {
-    let (_dir, _server, client) = common::local_store_client().await;
+    let (_server, client) = common::local_store_client().await;
     let ctx = SessionContext::new();
     let writer_client = client.clone();
 
@@ -409,7 +409,7 @@ async fn versioned_example_queries_work_end_to_end() {
 
 #[tokio::test]
 async fn fixed_binary_example_filters_work_end_to_end() {
-    let (_dir, _server, client) = common::local_store_client().await;
+    let (_server, client) = common::local_store_client().await;
     let ctx = SessionContext::new();
     let writer_client = client.clone();
 

--- a/sql/rs/tests/examples_smoke.rs
+++ b/sql/rs/tests/examples_smoke.rs
@@ -99,7 +99,7 @@ fn collect_two_strings(
 
 #[tokio::test]
 async fn orders_example_queries_work_end_to_end() {
-    let (_server, client) = common::local_store_client().await;
+    let client = common::local_store_client().await;
     let ctx = SessionContext::new();
 
     KvSchema::new(PrefixedStoreClient::empty(client))
@@ -180,7 +180,7 @@ async fn orders_example_queries_work_end_to_end() {
 
 #[tokio::test]
 async fn join_example_queries_work_end_to_end() {
-    let (_server, client) = common::local_store_client().await;
+    let client = common::local_store_client().await;
     let ctx = SessionContext::new();
 
     KvSchema::new(PrefixedStoreClient::empty(client))
@@ -289,7 +289,7 @@ async fn join_example_queries_work_end_to_end() {
 
 #[tokio::test]
 async fn versioned_example_queries_work_end_to_end() {
-    let (_server, client) = common::local_store_client().await;
+    let client = common::local_store_client().await;
     let ctx = SessionContext::new();
     let writer_client = client.clone();
 
@@ -409,7 +409,7 @@ async fn versioned_example_queries_work_end_to_end() {
 
 #[tokio::test]
 async fn fixed_binary_example_filters_work_end_to_end() {
-    let (_server, client) = common::local_store_client().await;
+    let client = common::local_store_client().await;
     let ctx = SessionContext::new();
     let writer_client = client.clone();
 


### PR DESCRIPTION
Optimizes the simulator's `RocksStore` ingest path for large batches (250k+ keys per `Put`), roughly doubling throughput in interleaved A/B runs against `main` on an Apple M5 Pro: ~4M to ~8M keys/s serial and ~4.7M to ~10M keys/s with 4 concurrent writers, with the same gains in sustained 48-batch runs. An `ingest` benchmark is included (`cargo bench -p exoware-simulator --bench ingest`, configurable via `BENCH_*` env vars).

Writes now bypass the WAL and memtables entirely. A two-stage `prepare`/`commit` pipeline coalesces queued requests into commit groups that share one sequence number, stages each group's two SST files in parallel (a single-row log SST holding the exact served response bytes, and a sorted, deduped state SST), then commits them by atomic ingestion, overlapping each commit with the next group's staging. Recovery derives the frontier from the retained log rows plus a floor meta row (written atomically with each sequence prune's tombstone) and re-applies at most the newest log row, so a crash can never surface a partial batch or regress the frontier; the prior invariants (gap-free sequences, ack only once durable) still hold. Write errors are fatal: once a log row is durable it cannot be rolled back, so write failures panic the writer, and the simulator binary installs a scoped panic hook that aborts the process so a supervised restart rolls the store forward.

Notable consequences and trade-offs: concurrent `put_batch` callers coalesced into one group receive the same sequence and merge into one served batch; key pruning is best-effort (the reopen replay can restore recently pruned keys until the next pass); small writes pay two ingestions instead of one WAL fsync, accepted for the large-batch target workload. Breaking for external callers: `spawn_for_test(&Path)` is replaced by `open_temp()`, backed by a new `open_owned` that lets the store own its data directory for its full lifetime. Adds `parking_lot` and `mimalloc` as workspace dependencies (the binary defaults to `mimalloc`, matching other deployed binaries). Stores created by `main` open cleanly; stores written by intermediate revisions of this branch should be wiped. `cargo test --workspace`, clippy, and fmt are all clean.
