### PR TITLE
sql: fix where clauses for short pk strings

### DIFF
--- a/sql/rs/src/codec.rs
+++ b/sql/rs/src/codec.rs
@@ -388,7 +388,7 @@ pub(crate) fn encode_primary_key_bound(
     let payload_len = if upper_tail {
         codec.payload_capacity_bytes()
     } else {
-        model.primary_key_width.max(encoded_width)
+        encoded_width
     };
     let mut key = allocate_codec_key(codec, payload_len)?;
     let mut payload_offset = 0usize;

--- a/sql/rs/src/lib.rs
+++ b/sql/rs/src/lib.rs
@@ -1234,6 +1234,183 @@ mod tests {
     }
 
     #[test]
+    fn zorder_index_range_includes_short_utf8_pk_rows() {
+        // Regression: the z-order lower bound zero-padded the variable-width
+        // Utf8 pk suffix to its reserved key width (16). A stored entry whose
+        // pk encodes below that padding (the empty string encodes to a lone
+        // terminator byte) sorted below the bound and was missed.
+        let config = KvTableConfig::new(
+            0,
+            vec![
+                TableColumnConfig::new("name", DataType::Utf8, false),
+                TableColumnConfig::new("x", DataType::Int64, false),
+                TableColumnConfig::new("y", DataType::Int64, false),
+                TableColumnConfig::new("value", DataType::Int64, false),
+            ],
+            vec!["name".to_string()],
+            vec![IndexSpec::z_order("xy_z", vec!["x".to_string(), "y".to_string()])
+                .expect("valid")
+                .with_cover_columns(vec!["value".to_string()])],
+        )
+        .expect("valid config");
+        let model = TableModel::from_config(&config).expect("model");
+        let specs = model
+            .resolve_index_specs(&config.index_specs)
+            .expect("specs");
+        let x_idx = *model.columns_by_name.get("x").unwrap();
+        let y_idx = *model.columns_by_name.get("y").unwrap();
+
+        // Box query x=5, y=7.
+        let mut pred = QueryPredicate::default();
+        pred.constraints.insert(
+            x_idx,
+            PredicateConstraint::IntRange {
+                min: Some(5),
+                max: Some(5),
+            },
+        );
+        pred.constraints.insert(
+            y_idx,
+            PredicateConstraint::IntRange {
+                min: Some(7),
+                max: Some(7),
+            },
+        );
+        let ranges = pred
+            .expand_zorder_index_ranges(model.table_prefix, &model, &specs[0])
+            .expect("ranges");
+        assert_eq!(ranges.len(), 1);
+
+        // The empty string is the discriminating case: its encoding is the
+        // lexicographic minimum, so it is the pk that zero-padding excluded.
+        for name in ["", "bob"] {
+            let row = KvRow {
+                values: vec![
+                    CellValue::Utf8(name.to_string()),
+                    CellValue::Int64(5),
+                    CellValue::Int64(7),
+                    CellValue::Int64(100),
+                ],
+            };
+            let stored = encode_secondary_index_key(model.table_prefix, &specs[0], &model, &row)
+                .expect("stored");
+            assert!(
+                ranges[0].start <= stored && stored <= ranges[0].end,
+                "zorder range for x=5,y=7 must include stored entry with pk '{name}'"
+            );
+        }
+    }
+
+    #[test]
+    fn utf8_pk_behind_lex_index_range_includes_short_pk_rows() {
+        // Regression: for a lexicographic index whose TABLE pk is Utf8, the
+        // lower bound zero-padded the pk suffix to its reserved key width.
+        // A stored entry with the empty-string pk (minimal encoding) sorted
+        // below the bound and was missed.
+        let config = KvTableConfig::new(
+            0,
+            vec![
+                TableColumnConfig::new("name", DataType::Utf8, false),
+                TableColumnConfig::new("age", DataType::Int64, false),
+            ],
+            vec!["name".to_string()],
+            vec![IndexSpec::new("age_idx", vec!["age".to_string()]).unwrap()],
+        )
+        .unwrap();
+        let model = TableModel::from_config(&config).unwrap();
+        let specs = model.resolve_index_specs(&config.index_specs).unwrap();
+        let age_idx = *model.columns_by_name.get("age").unwrap();
+
+        let mut pred = QueryPredicate::default();
+        pred.constraints.insert(
+            age_idx,
+            PredicateConstraint::IntRange {
+                min: Some(5),
+                max: Some(5),
+            },
+        );
+        let start = pred
+            .encode_index_bound_key(model.table_prefix, &model, &specs[0], 1, false)
+            .unwrap();
+        let end = pred
+            .encode_index_bound_key(model.table_prefix, &model, &specs[0], 1, true)
+            .unwrap();
+
+        for name in ["", "bob"] {
+            let row = KvRow {
+                values: vec![CellValue::Utf8(name.to_string()), CellValue::Int64(5)],
+            };
+            let stored = encode_secondary_index_key(model.table_prefix, &specs[0], &model, &row)
+                .expect("stored index key encodes");
+            assert!(
+                start <= stored && stored <= end,
+                "index range for age=5 must include stored entry with pk '{name}'"
+            );
+        }
+    }
+
+    #[test]
+    fn multi_column_index_utf8_prefix_range_includes_min_suffix_rows() {
+        // Lexicographic index (a Utf8, b Int64) constrained on the Utf8
+        // prefix only: the lower bound must admit the minimal unconstrained
+        // suffix (b = i64::MIN encodes to all zeros) and minimal pk.
+        let config = KvTableConfig::new(
+            0,
+            vec![
+                TableColumnConfig::new("id", DataType::Int64, false),
+                TableColumnConfig::new("a", DataType::Utf8, false),
+                TableColumnConfig::new("b", DataType::Int64, false),
+            ],
+            vec!["id".to_string()],
+            vec![IndexSpec::new("ab_idx", vec!["a".to_string(), "b".to_string()]).unwrap()],
+        )
+        .unwrap();
+        let model = TableModel::from_config(&config).unwrap();
+        let specs = model.resolve_index_specs(&config.index_specs).unwrap();
+        let a_idx = *model.columns_by_name.get("a").unwrap();
+
+        let mut pred = QueryPredicate::default();
+        pred.constraints
+            .insert(a_idx, PredicateConstraint::StringEq("x".to_string()));
+        let start = pred
+            .encode_index_bound_key(model.table_prefix, &model, &specs[0], 1, false)
+            .unwrap();
+        let end = pred
+            .encode_index_bound_key(model.table_prefix, &model, &specs[0], 1, true)
+            .unwrap();
+
+        for (b, id) in [(i64::MIN, i64::MIN), (0, 0), (i64::MAX, i64::MAX)] {
+            let row = KvRow {
+                values: vec![
+                    CellValue::Int64(id),
+                    CellValue::Utf8("x".to_string()),
+                    CellValue::Int64(b),
+                ],
+            };
+            let stored = encode_secondary_index_key(model.table_prefix, &specs[0], &model, &row)
+                .expect("stored index key encodes");
+            assert!(
+                start <= stored && stored <= end,
+                "index range for a='x' must include stored entry with b={b}, id={id}"
+            );
+        }
+
+        let row = KvRow {
+            values: vec![
+                CellValue::Int64(0),
+                CellValue::Utf8("y".to_string()),
+                CellValue::Int64(0),
+            ],
+        };
+        let excluded = encode_secondary_index_key(model.table_prefix, &specs[0], &model, &row)
+            .expect("stored index key encodes");
+        assert!(
+            excluded > end,
+            "index range for a='x' must exclude entries for a='y'"
+        );
+    }
+
+    #[test]
     fn table_config_supports_non_orders_schema() {
         let config = KvTableConfig::new(
             0,
@@ -2868,6 +3045,46 @@ mod tests {
     }
 
     #[test]
+    fn variable_width_column_rejected_in_zorder_index() {
+        // Z-order stored keys interleave the actual encoded bytes, but decode
+        // and bound construction assume the reserved fixed key width, so a
+        // Utf8 z-order key column silently matches no rows (and trips a
+        // debug_assert in debug builds). Reject it at resolve time.
+        let config = KvTableConfig::new(
+            0,
+            vec![
+                TableColumnConfig::new("id", DataType::Int64, false),
+                TableColumnConfig::new("x", DataType::Int64, false),
+                TableColumnConfig::new("region", DataType::Utf8, false),
+            ],
+            vec!["id".to_string()],
+            vec![
+                IndexSpec::z_order("xr_z", vec!["x".to_string(), "region".to_string()]).unwrap(),
+            ],
+        )
+        .unwrap();
+        let model = TableModel::from_config(&config).unwrap();
+        let result = model.resolve_index_specs(&config.index_specs);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("z-order key column"));
+
+        // The same column in a lexicographic index stays valid.
+        let lex_config = KvTableConfig::new(
+            0,
+            vec![
+                TableColumnConfig::new("id", DataType::Int64, false),
+                TableColumnConfig::new("x", DataType::Int64, false),
+                TableColumnConfig::new("region", DataType::Utf8, false),
+            ],
+            vec!["id".to_string()],
+            vec![IndexSpec::new("r_idx", vec!["region".to_string()]).unwrap()],
+        )
+        .unwrap();
+        let lex_model = TableModel::from_config(&lex_config).unwrap();
+        assert!(lex_model.resolve_index_specs(&lex_config.index_specs).is_ok());
+    }
+
+    #[test]
     fn base_row_round_trip_with_null() {
         let config = KvTableConfig::new(
             0,
@@ -4085,14 +4302,171 @@ mod tests {
         .iter()
         .all(|&b| b == 0xFF));
 
-        // Lower bound: trailing bytes should be 0x00
+        // Lower bound: exactly the encoded prefix
         let lower =
             encode_primary_key_bound(0, &[&entity], &model, false).expect("pk bound encodes");
         assert_eq!(primary_payload(&model, &lower, 0, 16), vec![0xAA; 16]);
         assert_eq!(
-            primary_payload(&model, &lower, 16, 8),
-            vec![0x00; 8],
-            "trailing PK column (version) must be 0x00 for lower bound"
+            lower,
+            model
+                .primary_key_codec
+                .encode(&[0xAA; 16])
+                .expect("encode entity prefix"),
+            "lower bound must be exactly the encoded prefix"
+        );
+    }
+
+    #[test]
+    fn utf8_pk_point_query_range_includes_short_string_row() {
+        // Regression: the lower scan bound for a Utf8 primary key used to be
+        // zero-padded to the fixed PK width (16), sorting it above the
+        // variable-length stored key, so `WHERE name = 'alice'` returned
+        // no rows for any name shorter than 16 encoded bytes.
+        let config = KvTableConfig::new(
+            0,
+            vec![
+                TableColumnConfig::new("name", DataType::Utf8, false),
+                TableColumnConfig::new("age", DataType::Int64, false),
+            ],
+            vec!["name".to_string()],
+            vec![],
+        )
+        .unwrap();
+        let model = TableModel::from_config(&config).unwrap();
+        let name_idx = *model.columns_by_name.get("name").unwrap();
+
+        for name in ["alice", "", "a", "exactly15chars!", "longer-than-sixteen-bytes"] {
+            let value = CellValue::Utf8(name.to_string());
+            let stored = encode_primary_key(0, &[&value], &model).expect("stored key encodes");
+
+            let mut pred = QueryPredicate::default();
+            pred.constraints
+                .insert(name_idx, PredicateConstraint::StringEq(name.to_string()));
+            let ranges = pred.primary_key_ranges(&model).unwrap();
+            assert_eq!(ranges.len(), 1, "point query on '{name}' must yield one range");
+            assert!(
+                ranges[0].start <= stored,
+                "lower bound must not exceed stored key for '{name}'"
+            );
+            assert!(
+                stored <= ranges[0].end,
+                "stored key must not exceed upper bound for '{name}'"
+            );
+            assert_eq!(
+                ranges[0].start, stored,
+                "point lower bound must equal the stored key for '{name}'"
+            );
+        }
+
+        // Prefix-freeness: the range for 'al' must not admit 'alice'.
+        let mut pred = QueryPredicate::default();
+        pred.constraints
+            .insert(name_idx, PredicateConstraint::StringEq("al".to_string()));
+        let ranges = pred.primary_key_ranges(&model).unwrap();
+        let alice = CellValue::Utf8("alice".to_string());
+        let alice_key = encode_primary_key(0, &[&alice], &model).expect("stored key encodes");
+        assert!(
+            alice_key > ranges[0].end,
+            "range for 'al' must exclude the stored key for 'alice'"
+        );
+    }
+
+    #[test]
+    fn utf8_pk_prefix_query_range_includes_composite_rows() {
+        // Composite PK (name Utf8, id Int64) constrained on name only: the
+        // range must admit every id — including i64::MIN, whose ordered
+        // encoding is all zeros and therefore sorts lowest.
+        let config = KvTableConfig::new(
+            0,
+            vec![
+                TableColumnConfig::new("name", DataType::Utf8, false),
+                TableColumnConfig::new("id", DataType::Int64, false),
+            ],
+            vec!["name".to_string(), "id".to_string()],
+            vec![],
+        )
+        .unwrap();
+        let model = TableModel::from_config(&config).unwrap();
+        let name_idx = *model.columns_by_name.get("name").unwrap();
+
+        let mut pred = QueryPredicate::default();
+        pred.constraints
+            .insert(name_idx, PredicateConstraint::StringEq("al".to_string()));
+        let ranges = pred.primary_key_ranges(&model).unwrap();
+        assert_eq!(ranges.len(), 1);
+
+        for id in [i64::MIN, 0, 42, i64::MAX] {
+            let name = CellValue::Utf8("al".to_string());
+            let id_value = CellValue::Int64(id);
+            let stored =
+                encode_primary_key(0, &[&name, &id_value], &model).expect("stored key encodes");
+            assert!(
+                ranges[0].start <= stored && stored <= ranges[0].end,
+                "range for name='al' must include stored key with id={id}"
+            );
+        }
+
+        let other = CellValue::Utf8("alx".to_string());
+        let id_value = CellValue::Int64(0);
+        let excluded =
+            encode_primary_key(0, &[&other, &id_value], &model).expect("stored key encodes");
+        assert!(
+            excluded > ranges[0].end,
+            "range for name='al' must exclude rows with name='alx'"
+        );
+    }
+
+    #[test]
+    fn utf8_index_point_query_range_includes_min_pk_row() {
+        // Regression: the secondary-index lower bound was allocated at the
+        // full fixed key width, leaving trailing zeros past the encoded
+        // content. A stored entry for a short Utf8 value whose pk suffix
+        // encodes to all zeros (id = i64::MIN) sorted below that bound and
+        // was missed.
+        let config = KvTableConfig::new(
+            0,
+            vec![
+                TableColumnConfig::new("id", DataType::Int64, false),
+                TableColumnConfig::new("region", DataType::Utf8, false),
+            ],
+            vec!["id".to_string()],
+            vec![IndexSpec::new("region_idx", vec!["region".to_string()]).unwrap()],
+        )
+        .unwrap();
+        let model = TableModel::from_config(&config).unwrap();
+        let specs = model.resolve_index_specs(&config.index_specs).unwrap();
+        let region_idx = *model.columns_by_name.get("region").unwrap();
+
+        let mut pred = QueryPredicate::default();
+        pred.constraints
+            .insert(region_idx, PredicateConstraint::StringEq("us".to_string()));
+        let start = pred
+            .encode_index_bound_key(model.table_prefix, &model, &specs[0], 1, false)
+            .unwrap();
+        let end = pred
+            .encode_index_bound_key(model.table_prefix, &model, &specs[0], 1, true)
+            .unwrap();
+
+        for id in [i64::MIN, 0, i64::MAX] {
+            let row = KvRow {
+                values: vec![CellValue::Int64(id), CellValue::Utf8("us".to_string())],
+            };
+            let stored = encode_secondary_index_key(model.table_prefix, &specs[0], &model, &row)
+                .expect("stored index key encodes");
+            assert!(
+                start <= stored && stored <= end,
+                "index range for region='us' must include stored entry with id={id}"
+            );
+        }
+
+        let row = KvRow {
+            values: vec![CellValue::Int64(0), CellValue::Utf8("ut".to_string())],
+        };
+        let excluded = encode_secondary_index_key(model.table_prefix, &specs[0], &model, &row)
+            .expect("stored index key encodes");
+        assert!(
+            excluded > end,
+            "index range for region='us' must exclude entries for region='ut'"
         );
     }
 
@@ -5655,6 +6029,177 @@ mod tests {
             .collect();
         assert_eq!(ids, vec![1, 3]);
         assert_eq!(notes, vec!["first", "third"]);
+
+        let _ = shutdown_tx.send(());
+    }
+
+    #[tokio::test]
+    async fn utf8_pk_point_query_returns_row() {
+        // Regression: `WHERE name = 'alice'` on a Utf8 primary key returned
+        // no rows because the lower scan bound was zero-padded past the
+        // variable-length stored key.
+        let state = MockState {
+            kv: Arc::new(Mutex::new(BTreeMap::new())),
+            range_calls: Arc::new(AtomicUsize::new(0)),
+            range_reduce_calls: Arc::new(AtomicUsize::new(0)),
+            sequence_number: Arc::new(AtomicU64::new(0)),
+        };
+        let (base_url, shutdown_tx) = spawn_mock_server(state.clone()).await;
+        let client = StoreClient::new(&base_url);
+
+        let schema = KvSchema::new(PrefixedStoreClient::empty(client.clone()))
+            .table(
+                "users",
+                vec![
+                    TableColumnConfig::new("name", DataType::Utf8, false),
+                    TableColumnConfig::new("age", DataType::Int64, false),
+                ],
+                vec!["name".to_string()],
+                vec![],
+            )
+            .expect("schema");
+        let mut writer = schema.batch_writer();
+        for (name, age) in [("alice", 30i64), ("bob", 25), ("", 99)] {
+            writer
+                .insert(
+                    "users",
+                    vec![CellValue::Utf8(name.to_string()), CellValue::Int64(age)],
+                )
+                .expect("row");
+        }
+        writer.flush().await.expect("flush");
+
+        let ctx = SessionContext::new();
+        schema.register_all(&ctx).expect("register");
+
+        for (name, expected_age) in [("alice", 30i64), ("bob", 25), ("", 99)] {
+            let df = ctx
+                .sql(&format!("SELECT age FROM users WHERE name = '{name}'"))
+                .await
+                .expect("plan");
+            let batches = df.collect().await.expect("collect");
+            let ages: Vec<i64> = batches
+                .iter()
+                .flat_map(|b| {
+                    b.column(0)
+                        .as_any()
+                        .downcast_ref::<datafusion::arrow::array::Int64Array>()
+                        .unwrap()
+                        .iter()
+                        .map(|v| v.unwrap())
+                })
+                .collect();
+            assert_eq!(
+                ages,
+                vec![expected_age],
+                "point query on name='{name}' must return exactly its row"
+            );
+        }
+
+        let df = ctx
+            .sql("SELECT age FROM users WHERE name = 'al'")
+            .await
+            .expect("plan");
+        let batches = df.collect().await.expect("collect");
+        let total: usize = batches.iter().map(|b| b.num_rows()).sum();
+        assert_eq!(total, 0, "prefix of a stored name must match nothing");
+
+        let _ = shutdown_tx.send(());
+    }
+
+    #[tokio::test]
+    async fn utf8_index_point_query_returns_min_pk_row() {
+        // Regression: an index lookup on a short Utf8 value missed rows whose
+        // pk suffix encodes to all zeros (id = i64::MIN sorts lowest), because
+        // the lower bound was zero-padded past the stored entry. Exercises
+        // both index streams: non-covering (point lookup) and covering.
+        let state = MockState {
+            kv: Arc::new(Mutex::new(BTreeMap::new())),
+            range_calls: Arc::new(AtomicUsize::new(0)),
+            range_reduce_calls: Arc::new(AtomicUsize::new(0)),
+            sequence_number: Arc::new(AtomicU64::new(0)),
+        };
+        let (base_url, shutdown_tx) = spawn_mock_server(state.clone()).await;
+        let client = StoreClient::new(&base_url);
+
+        let schema = KvSchema::new(PrefixedStoreClient::empty(client.clone()))
+            .table(
+                "orders_nc",
+                vec![
+                    TableColumnConfig::new("id", DataType::Int64, false),
+                    TableColumnConfig::new("region", DataType::Utf8, false),
+                    TableColumnConfig::new("amount", DataType::Int64, false),
+                ],
+                vec!["id".to_string()],
+                vec![IndexSpec::new("region_idx", vec!["region".to_string()]).expect("valid")],
+            )
+            .expect("schema")
+            .table(
+                "orders_cov",
+                vec![
+                    TableColumnConfig::new("id", DataType::Int64, false),
+                    TableColumnConfig::new("region", DataType::Utf8, false),
+                    TableColumnConfig::new("amount", DataType::Int64, false),
+                ],
+                vec!["id".to_string()],
+                vec![IndexSpec::new("region_idx", vec!["region".to_string()])
+                    .expect("valid")
+                    .with_cover_columns(vec!["amount".to_string()])],
+            )
+            .expect("schema");
+        let mut writer = schema.batch_writer();
+        for table in ["orders_nc", "orders_cov"] {
+            writer
+                .insert(
+                    table,
+                    vec![
+                        CellValue::Int64(i64::MIN),
+                        CellValue::Utf8("us".to_string()),
+                        CellValue::Int64(7),
+                    ],
+                )
+                .expect("row");
+            writer
+                .insert(
+                    table,
+                    vec![
+                        CellValue::Int64(1),
+                        CellValue::Utf8("eu".to_string()),
+                        CellValue::Int64(8),
+                    ],
+                )
+                .expect("row");
+        }
+        writer.flush().await.expect("flush");
+
+        let ctx = SessionContext::new();
+        schema.register_all(&ctx).expect("register");
+
+        for table in ["orders_nc", "orders_cov"] {
+            let df = ctx
+                .sql(&format!(
+                    "SELECT amount FROM {table} WHERE region = 'us'"
+                ))
+                .await
+                .expect("plan");
+            let batches = df.collect().await.expect("collect");
+            let amounts: Vec<i64> = batches
+                .iter()
+                .flat_map(|b| {
+                    b.column(0)
+                        .as_any()
+                        .downcast_ref::<datafusion::arrow::array::Int64Array>()
+                        .unwrap()
+                        .iter()
+                        .map(|v| v.unwrap())
+                })
+                .collect();
+            assert_eq!(
+                amounts,
+                vec![7],
+                "index lookup on {table} must return the id=i64::MIN row"
+            );
+        }
 
         let _ = shutdown_tx.send(());
     }

--- a/sql/rs/src/lib.rs
+++ b/sql/rs/src/lib.rs
@@ -1248,9 +1248,11 @@ mod tests {
                 TableColumnConfig::new("value", DataType::Int64, false),
             ],
             vec!["name".to_string()],
-            vec![IndexSpec::z_order("xy_z", vec!["x".to_string(), "y".to_string()])
-                .expect("valid")
-                .with_cover_columns(vec!["value".to_string()])],
+            vec![
+                IndexSpec::z_order("xy_z", vec!["x".to_string(), "y".to_string()])
+                    .expect("valid")
+                    .with_cover_columns(vec!["value".to_string()]),
+            ],
         )
         .expect("valid config");
         let model = TableModel::from_config(&config).expect("model");
@@ -3058,9 +3060,7 @@ mod tests {
                 TableColumnConfig::new("region", DataType::Utf8, false),
             ],
             vec!["id".to_string()],
-            vec![
-                IndexSpec::z_order("xr_z", vec!["x".to_string(), "region".to_string()]).unwrap(),
-            ],
+            vec![IndexSpec::z_order("xr_z", vec!["x".to_string(), "region".to_string()]).unwrap()],
         )
         .unwrap();
         let model = TableModel::from_config(&config).unwrap();
@@ -3081,7 +3081,9 @@ mod tests {
         )
         .unwrap();
         let lex_model = TableModel::from_config(&lex_config).unwrap();
-        assert!(lex_model.resolve_index_specs(&lex_config.index_specs).is_ok());
+        assert!(lex_model
+            .resolve_index_specs(&lex_config.index_specs)
+            .is_ok());
     }
 
     #[test]
@@ -4335,7 +4337,13 @@ mod tests {
         let model = TableModel::from_config(&config).unwrap();
         let name_idx = *model.columns_by_name.get("name").unwrap();
 
-        for name in ["alice", "", "a", "exactly15chars!", "longer-than-sixteen-bytes"] {
+        for name in [
+            "alice",
+            "",
+            "a",
+            "exactly15chars!",
+            "longer-than-sixteen-bytes",
+        ] {
             let value = CellValue::Utf8(name.to_string());
             let stored = encode_primary_key(0, &[&value], &model).expect("stored key encodes");
 
@@ -4343,7 +4351,11 @@ mod tests {
             pred.constraints
                 .insert(name_idx, PredicateConstraint::StringEq(name.to_string()));
             let ranges = pred.primary_key_ranges(&model).unwrap();
-            assert_eq!(ranges.len(), 1, "point query on '{name}' must yield one range");
+            assert_eq!(
+                ranges.len(),
+                1,
+                "point query on '{name}' must yield one range"
+            );
             assert!(
                 ranges[0].start <= stored,
                 "lower bound must not exceed stored key for '{name}'"
@@ -6177,9 +6189,7 @@ mod tests {
 
         for table in ["orders_nc", "orders_cov"] {
             let df = ctx
-                .sql(&format!(
-                    "SELECT amount FROM {table} WHERE region = 'us'"
-                ))
+                .sql(&format!("SELECT amount FROM {table} WHERE region = 'us'"))
                 .await
                 .expect("plan");
             let batches = df.collect().await.expect("collect");

--- a/sql/rs/src/predicate.rs
+++ b/sql/rs/src/predicate.rs
@@ -1268,12 +1268,7 @@ impl QueryPredicate {
         upper: bool,
     ) -> Result<Key, String> {
         let codec = spec.codec;
-        let payload_len = if upper {
-            codec.payload_capacity_bytes()
-        } else {
-            spec.key_columns_width + model.primary_key_width
-        };
-        let mut key = allocate_codec_key(codec, payload_len)?;
+        let mut key = allocate_codec_key(codec, codec.payload_capacity_bytes())?;
         let mut offset = 0usize;
         for (idx, col_idx) in spec.key_columns.iter().copied().enumerate() {
             let col = model.column(col_idx);
@@ -1547,6 +1542,11 @@ impl QueryPredicate {
                     offset += 8;
                 }
                 _ => {
+                    if !upper && pk_kind.fixed_key_width().is_none() {
+                        // Padding past a variable-width pk's stored encoding
+                        // would sort the lower bound above matching entries.
+                        break;
+                    }
                     let w = pk_kind.key_width();
                     if upper {
                         codec
@@ -1562,8 +1562,15 @@ impl QueryPredicate {
             codec
                 .fill_payload(&mut key, offset, remaining, 0xFF)
                 .map_err(|e| format!("failed to fill codec payload: {e}"))?;
+            return Ok(key.freeze());
         }
-        Ok(key.freeze())
+        let scratch = key.freeze();
+        let payload = codec
+            .read_payload(&scratch, 0, offset)
+            .map_err(|e| format!("failed to read codec payload: {e}"))?;
+        codec
+            .encode(&payload)
+            .map_err(|e| format!("failed to encode codec key: {e}"))
     }
 
     pub(crate) fn encode_zorder_index_bound_key(
@@ -1574,12 +1581,7 @@ impl QueryPredicate {
         upper: bool,
     ) -> Result<Key, String> {
         let codec = spec.codec;
-        let payload_len = if upper {
-            codec.payload_capacity_bytes()
-        } else {
-            spec.key_columns_width + model.primary_key_width
-        };
-        let mut key = allocate_codec_key(codec, payload_len)?;
+        let mut key = allocate_codec_key(codec, codec.payload_capacity_bytes())?;
         let mut encoded_fields = Vec::with_capacity(spec.key_columns.len());
         for &col_idx in &spec.key_columns {
             let col = model.column(col_idx);
@@ -1620,6 +1622,11 @@ impl QueryPredicate {
                     offset += 8;
                 }
                 _ => {
+                    if !upper && pk_kind.fixed_key_width().is_none() {
+                        // Padding past a variable-width pk's stored encoding
+                        // would sort the lower bound above matching entries.
+                        break;
+                    }
                     let w = pk_kind.key_width();
                     if upper {
                         codec
@@ -1635,8 +1642,17 @@ impl QueryPredicate {
             codec
                 .fill_payload(&mut key, offset, remaining, 0xFF)
                 .map_err(|e| format!("failed to fill codec payload: {e}"))?;
+            return Ok(key.freeze());
         }
-        Ok(key.freeze())
+        // Re-encode the lower bound at its exact written length so trailing
+        // scratch bytes never pad the bound above shorter stored keys.
+        let scratch = key.freeze();
+        let payload = codec
+            .read_payload(&scratch, 0, offset)
+            .map_err(|e| format!("failed to read codec payload: {e}"))?;
+        codec
+            .encode(&payload)
+            .map_err(|e| format!("failed to encode codec key: {e}"))
     }
 
     pub(crate) fn ordered_index_bound_bytes_for_column(

--- a/sql/rs/src/types.rs
+++ b/sql/rs/src/types.rs
@@ -467,6 +467,16 @@ impl TableModel {
                         spec.name, col_name
                     ));
                 }
+                if spec.layout == IndexLayout::ZOrder
+                    && self.columns[col_idx].kind.fixed_key_width().is_none()
+                {
+                    return Err(format!(
+                        "index '{}' z-order key column '{}' must have a \
+                         fixed-width kind; variable-width kinds (e.g. Utf8) \
+                         cannot be used in z-order index keys",
+                        spec.name, col_name
+                    ));
+                }
                 key_columns.push(col_idx);
                 key_columns_width += self.columns[col_idx].kind.key_width();
                 if !self.is_pk_column(col_idx) {


### PR DESCRIPTION
This is an agent flagged-bug:
> the lower scan bound for a Utf8 primary key used to be zero-padded to the fixed PK width (16), sorting it above the variable-length stored key, so `WHERE name = 'alice'` returned no rows for any name shorter than 16 encoded bytes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core key-range logic for PK and secondary-index scans; behavior fixes are broad but well-tested, and z-order schema rejection is a new validation constraint.
> 
> **Overview**
> Fixes **incorrect lower scan bounds** for variable-length **Utf8** keys so point and prefix queries no longer miss rows whose encoded keys are shorter than the reserved fixed key width.
> 
> **Primary key bounds** (`encode_primary_key_bound`): lower bounds are sized to the **actual encoded prefix length** instead of padding to `primary_key_width`.
> 
> **Index and z-order bounds** (`encode_index_bound_key`, `encode_zorder_index_bound_key`): lower bounds stop padding past variable-width PK suffixes, then **re-encode** only the bytes written so trailing scratch zeros cannot sit above real stored keys; upper bounds still fill to capacity with `0xFF`.
> 
> **Schema validation**: **z-order** indexes now **reject variable-width** key columns (e.g. Utf8) at `resolve_index_specs`, since z-order encoding assumes fixed widths.
> 
> Regression coverage spans unit tests for PK/index/z-order ranges and **tokio** integration tests for `WHERE name = …` and index lookups on short strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 856ac61ebb502371febcba1ada6caf091eb3be30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->