### PR TITLE
[deps] Update Commonware Dependency (`e1ab57dd8b372c8d80d36a7e3ef398bb2855725c`)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -942,7 +942,7 @@ dependencies = [
 [[package]]
 name = "commonware-actor"
 version = "2026.5.0"
-source = "git+https://github.com/commonwarexyz/monorepo.git?rev=85f7103e3b625d44a466d120aac5a3a13f2bb177#85f7103e3b625d44a466d120aac5a3a13f2bb177"
+source = "git+https://github.com/commonwarexyz/monorepo.git?rev=e1ab57dd8b372c8d80d36a7e3ef398bb2855725c#e1ab57dd8b372c8d80d36a7e3ef398bb2855725c"
 dependencies = [
  "cfg-if",
  "commonware-macros",
@@ -955,7 +955,7 @@ dependencies = [
 [[package]]
 name = "commonware-broadcast"
 version = "2026.5.0"
-source = "git+https://github.com/commonwarexyz/monorepo.git?rev=85f7103e3b625d44a466d120aac5a3a13f2bb177#85f7103e3b625d44a466d120aac5a3a13f2bb177"
+source = "git+https://github.com/commonwarexyz/monorepo.git?rev=e1ab57dd8b372c8d80d36a7e3ef398bb2855725c#e1ab57dd8b372c8d80d36a7e3ef398bb2855725c"
 dependencies = [
  "commonware-actor",
  "commonware-codec",
@@ -971,7 +971,7 @@ dependencies = [
 [[package]]
 name = "commonware-codec"
 version = "2026.5.0"
-source = "git+https://github.com/commonwarexyz/monorepo.git?rev=85f7103e3b625d44a466d120aac5a3a13f2bb177#85f7103e3b625d44a466d120aac5a3a13f2bb177"
+source = "git+https://github.com/commonwarexyz/monorepo.git?rev=e1ab57dd8b372c8d80d36a7e3ef398bb2855725c#e1ab57dd8b372c8d80d36a7e3ef398bb2855725c"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -986,7 +986,7 @@ dependencies = [
 [[package]]
 name = "commonware-codec-macros"
 version = "2026.5.0"
-source = "git+https://github.com/commonwarexyz/monorepo.git?rev=85f7103e3b625d44a466d120aac5a3a13f2bb177#85f7103e3b625d44a466d120aac5a3a13f2bb177"
+source = "git+https://github.com/commonwarexyz/monorepo.git?rev=e1ab57dd8b372c8d80d36a7e3ef398bb2855725c#e1ab57dd8b372c8d80d36a7e3ef398bb2855725c"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -997,7 +997,7 @@ dependencies = [
 [[package]]
 name = "commonware-coding"
 version = "2026.5.0"
-source = "git+https://github.com/commonwarexyz/monorepo.git?rev=85f7103e3b625d44a466d120aac5a3a13f2bb177#85f7103e3b625d44a466d120aac5a3a13f2bb177"
+source = "git+https://github.com/commonwarexyz/monorepo.git?rev=e1ab57dd8b372c8d80d36a7e3ef398bb2855725c#e1ab57dd8b372c8d80d36a7e3ef398bb2855725c"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -1017,7 +1017,7 @@ dependencies = [
 [[package]]
 name = "commonware-consensus"
 version = "2026.5.0"
-source = "git+https://github.com/commonwarexyz/monorepo.git?rev=85f7103e3b625d44a466d120aac5a3a13f2bb177#85f7103e3b625d44a466d120aac5a3a13f2bb177"
+source = "git+https://github.com/commonwarexyz/monorepo.git?rev=e1ab57dd8b372c8d80d36a7e3ef398bb2855725c#e1ab57dd8b372c8d80d36a7e3ef398bb2855725c"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -1048,7 +1048,7 @@ dependencies = [
 [[package]]
 name = "commonware-cryptography"
 version = "2026.5.0"
-source = "git+https://github.com/commonwarexyz/monorepo.git?rev=85f7103e3b625d44a466d120aac5a3a13f2bb177#85f7103e3b625d44a466d120aac5a3a13f2bb177"
+source = "git+https://github.com/commonwarexyz/monorepo.git?rev=e1ab57dd8b372c8d80d36a7e3ef398bb2855725c#e1ab57dd8b372c8d80d36a7e3ef398bb2855725c"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1088,7 +1088,7 @@ dependencies = [
 [[package]]
 name = "commonware-formatting"
 version = "2026.5.0"
-source = "git+https://github.com/commonwarexyz/monorepo.git?rev=85f7103e3b625d44a466d120aac5a3a13f2bb177#85f7103e3b625d44a466d120aac5a3a13f2bb177"
+source = "git+https://github.com/commonwarexyz/monorepo.git?rev=e1ab57dd8b372c8d80d36a7e3ef398bb2855725c#e1ab57dd8b372c8d80d36a7e3ef398bb2855725c"
 dependencies = [
  "commonware-macros",
  "const-hex",
@@ -1097,7 +1097,7 @@ dependencies = [
 [[package]]
 name = "commonware-glue"
 version = "2026.5.0"
-source = "git+https://github.com/commonwarexyz/monorepo.git?rev=85f7103e3b625d44a466d120aac5a3a13f2bb177#85f7103e3b625d44a466d120aac5a3a13f2bb177"
+source = "git+https://github.com/commonwarexyz/monorepo.git?rev=e1ab57dd8b372c8d80d36a7e3ef398bb2855725c#e1ab57dd8b372c8d80d36a7e3ef398bb2855725c"
 dependencies = [
  "bytes",
  "commonware-actor",
@@ -1122,7 +1122,7 @@ dependencies = [
 [[package]]
 name = "commonware-macros"
 version = "2026.5.0"
-source = "git+https://github.com/commonwarexyz/monorepo.git?rev=85f7103e3b625d44a466d120aac5a3a13f2bb177#85f7103e3b625d44a466d120aac5a3a13f2bb177"
+source = "git+https://github.com/commonwarexyz/monorepo.git?rev=e1ab57dd8b372c8d80d36a7e3ef398bb2855725c#e1ab57dd8b372c8d80d36a7e3ef398bb2855725c"
 dependencies = [
  "commonware-macros-impl",
  "tokio",
@@ -1131,7 +1131,7 @@ dependencies = [
 [[package]]
 name = "commonware-macros-impl"
 version = "2026.5.0"
-source = "git+https://github.com/commonwarexyz/monorepo.git?rev=85f7103e3b625d44a466d120aac5a3a13f2bb177#85f7103e3b625d44a466d120aac5a3a13f2bb177"
+source = "git+https://github.com/commonwarexyz/monorepo.git?rev=e1ab57dd8b372c8d80d36a7e3ef398bb2855725c#e1ab57dd8b372c8d80d36a7e3ef398bb2855725c"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -1143,7 +1143,7 @@ dependencies = [
 [[package]]
 name = "commonware-math"
 version = "2026.5.0"
-source = "git+https://github.com/commonwarexyz/monorepo.git?rev=85f7103e3b625d44a466d120aac5a3a13f2bb177#85f7103e3b625d44a466d120aac5a3a13f2bb177"
+source = "git+https://github.com/commonwarexyz/monorepo.git?rev=e1ab57dd8b372c8d80d36a7e3ef398bb2855725c#e1ab57dd8b372c8d80d36a7e3ef398bb2855725c"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -1156,7 +1156,7 @@ dependencies = [
 [[package]]
 name = "commonware-p2p"
 version = "2026.5.0"
-source = "git+https://github.com/commonwarexyz/monorepo.git?rev=85f7103e3b625d44a466d120aac5a3a13f2bb177#85f7103e3b625d44a466d120aac5a3a13f2bb177"
+source = "git+https://github.com/commonwarexyz/monorepo.git?rev=e1ab57dd8b372c8d80d36a7e3ef398bb2855725c#e1ab57dd8b372c8d80d36a7e3ef398bb2855725c"
 dependencies = [
  "commonware-actor",
  "commonware-codec",
@@ -1182,7 +1182,7 @@ dependencies = [
 [[package]]
 name = "commonware-parallel"
 version = "2026.5.0"
-source = "git+https://github.com/commonwarexyz/monorepo.git?rev=85f7103e3b625d44a466d120aac5a3a13f2bb177#85f7103e3b625d44a466d120aac5a3a13f2bb177"
+source = "git+https://github.com/commonwarexyz/monorepo.git?rev=e1ab57dd8b372c8d80d36a7e3ef398bb2855725c#e1ab57dd8b372c8d80d36a7e3ef398bb2855725c"
 dependencies = [
  "cfg-if",
  "commonware-macros",
@@ -1194,7 +1194,7 @@ dependencies = [
 [[package]]
 name = "commonware-resolver"
 version = "2026.5.0"
-source = "git+https://github.com/commonwarexyz/monorepo.git?rev=85f7103e3b625d44a466d120aac5a3a13f2bb177#85f7103e3b625d44a466d120aac5a3a13f2bb177"
+source = "git+https://github.com/commonwarexyz/monorepo.git?rev=e1ab57dd8b372c8d80d36a7e3ef398bb2855725c#e1ab57dd8b372c8d80d36a7e3ef398bb2855725c"
 dependencies = [
  "bytes",
  "commonware-actor",
@@ -1214,7 +1214,7 @@ dependencies = [
 [[package]]
 name = "commonware-runtime"
 version = "2026.5.0"
-source = "git+https://github.com/commonwarexyz/monorepo.git?rev=85f7103e3b625d44a466d120aac5a3a13f2bb177#85f7103e3b625d44a466d120aac5a3a13f2bb177"
+source = "git+https://github.com/commonwarexyz/monorepo.git?rev=e1ab57dd8b372c8d80d36a7e3ef398bb2855725c#e1ab57dd8b372c8d80d36a7e3ef398bb2855725c"
 dependencies = [
  "ahash",
  "axum",
@@ -1252,7 +1252,7 @@ dependencies = [
 [[package]]
 name = "commonware-runtime-macros"
 version = "2026.5.0"
-source = "git+https://github.com/commonwarexyz/monorepo.git?rev=85f7103e3b625d44a466d120aac5a3a13f2bb177#85f7103e3b625d44a466d120aac5a3a13f2bb177"
+source = "git+https://github.com/commonwarexyz/monorepo.git?rev=e1ab57dd8b372c8d80d36a7e3ef398bb2855725c#e1ab57dd8b372c8d80d36a7e3ef398bb2855725c"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -1263,7 +1263,7 @@ dependencies = [
 [[package]]
 name = "commonware-storage"
 version = "2026.5.0"
-source = "git+https://github.com/commonwarexyz/monorepo.git?rev=85f7103e3b625d44a466d120aac5a3a13f2bb177#85f7103e3b625d44a466d120aac5a3a13f2bb177"
+source = "git+https://github.com/commonwarexyz/monorepo.git?rev=e1ab57dd8b372c8d80d36a7e3ef398bb2855725c#e1ab57dd8b372c8d80d36a7e3ef398bb2855725c"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1287,7 +1287,7 @@ dependencies = [
 [[package]]
 name = "commonware-stream"
 version = "2026.5.0"
-source = "git+https://github.com/commonwarexyz/monorepo.git?rev=85f7103e3b625d44a466d120aac5a3a13f2bb177#85f7103e3b625d44a466d120aac5a3a13f2bb177"
+source = "git+https://github.com/commonwarexyz/monorepo.git?rev=e1ab57dd8b372c8d80d36a7e3ef398bb2855725c#e1ab57dd8b372c8d80d36a7e3ef398bb2855725c"
 dependencies = [
  "chacha20poly1305",
  "commonware-codec",
@@ -1307,7 +1307,7 @@ dependencies = [
 [[package]]
 name = "commonware-utils"
 version = "2026.5.0"
-source = "git+https://github.com/commonwarexyz/monorepo.git?rev=85f7103e3b625d44a466d120aac5a3a13f2bb177#85f7103e3b625d44a466d120aac5a3a13f2bb177"
+source = "git+https://github.com/commonwarexyz/monorepo.git?rev=e1ab57dd8b372c8d80d36a7e3ef398bb2855725c#e1ab57dd8b372c8d80d36a7e3ef398bb2855725c"
 dependencies = [
  "ahash",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,18 +33,18 @@ axum = "0.8.1"
 base64 = "0.22.1"
 hex = "0.4"
 regex = "1"
-commonware-codec = { git = "https://github.com/commonwarexyz/monorepo.git", rev = "85f7103e3b625d44a466d120aac5a3a13f2bb177" }
-commonware-actor = { git = "https://github.com/commonwarexyz/monorepo.git", rev = "85f7103e3b625d44a466d120aac5a3a13f2bb177" }
-commonware-consensus = { git = "https://github.com/commonwarexyz/monorepo.git", rev = "85f7103e3b625d44a466d120aac5a3a13f2bb177" }
-commonware-cryptography = { git = "https://github.com/commonwarexyz/monorepo.git", rev = "85f7103e3b625d44a466d120aac5a3a13f2bb177" }
-commonware-glue = { git = "https://github.com/commonwarexyz/monorepo.git", rev = "85f7103e3b625d44a466d120aac5a3a13f2bb177" }
-commonware-math = { git = "https://github.com/commonwarexyz/monorepo.git", rev = "85f7103e3b625d44a466d120aac5a3a13f2bb177" }
-commonware-parallel = { git = "https://github.com/commonwarexyz/monorepo.git", rev = "85f7103e3b625d44a466d120aac5a3a13f2bb177" }
-commonware-p2p = { git = "https://github.com/commonwarexyz/monorepo.git", rev = "85f7103e3b625d44a466d120aac5a3a13f2bb177" }
-commonware-resolver = { git = "https://github.com/commonwarexyz/monorepo.git", rev = "85f7103e3b625d44a466d120aac5a3a13f2bb177" }
-commonware-runtime = { git = "https://github.com/commonwarexyz/monorepo.git", rev = "85f7103e3b625d44a466d120aac5a3a13f2bb177" }
-commonware-storage = { git = "https://github.com/commonwarexyz/monorepo.git", rev = "85f7103e3b625d44a466d120aac5a3a13f2bb177" }
-commonware-utils = { git = "https://github.com/commonwarexyz/monorepo.git", rev = "85f7103e3b625d44a466d120aac5a3a13f2bb177" }
+commonware-codec = { git = "https://github.com/commonwarexyz/monorepo.git", rev = "e1ab57dd8b372c8d80d36a7e3ef398bb2855725c" }
+commonware-actor = { git = "https://github.com/commonwarexyz/monorepo.git", rev = "e1ab57dd8b372c8d80d36a7e3ef398bb2855725c" }
+commonware-consensus = { git = "https://github.com/commonwarexyz/monorepo.git", rev = "e1ab57dd8b372c8d80d36a7e3ef398bb2855725c" }
+commonware-cryptography = { git = "https://github.com/commonwarexyz/monorepo.git", rev = "e1ab57dd8b372c8d80d36a7e3ef398bb2855725c" }
+commonware-glue = { git = "https://github.com/commonwarexyz/monorepo.git", rev = "e1ab57dd8b372c8d80d36a7e3ef398bb2855725c" }
+commonware-math = { git = "https://github.com/commonwarexyz/monorepo.git", rev = "e1ab57dd8b372c8d80d36a7e3ef398bb2855725c" }
+commonware-parallel = { git = "https://github.com/commonwarexyz/monorepo.git", rev = "e1ab57dd8b372c8d80d36a7e3ef398bb2855725c" }
+commonware-p2p = { git = "https://github.com/commonwarexyz/monorepo.git", rev = "e1ab57dd8b372c8d80d36a7e3ef398bb2855725c" }
+commonware-resolver = { git = "https://github.com/commonwarexyz/monorepo.git", rev = "e1ab57dd8b372c8d80d36a7e3ef398bb2855725c" }
+commonware-runtime = { git = "https://github.com/commonwarexyz/monorepo.git", rev = "e1ab57dd8b372c8d80d36a7e3ef398bb2855725c" }
+commonware-storage = { git = "https://github.com/commonwarexyz/monorepo.git", rev = "e1ab57dd8b372c8d80d36a7e3ef398bb2855725c" }
+commonware-utils = { git = "https://github.com/commonwarexyz/monorepo.git", rev = "e1ab57dd8b372c8d80d36a7e3ef398bb2855725c" }
 rocksdb = "0.24.0"
 rand = "0.8.5"
 bincode = "1.3.3"

--- a/qmdb/rs/src/storage.rs
+++ b/qmdb/rs/src/storage.rs
@@ -21,7 +21,7 @@ pub(crate) struct KvMerkleStorage<'a, F: Family, D: Digest> {
 impl<F: Family, D: Digest> MerkleStorage<F> for KvMerkleStorage<'_, F, D> {
     type Digest = D;
 
-    async fn size(&self) -> Position<F> {
+    fn size(&self) -> Position<F> {
         self.size
     }
 
@@ -57,7 +57,7 @@ pub(crate) struct KvCurrentStorage<'a, F: Graftable, D: Digest, const N: usize> 
 impl<F: Graftable, D: Digest, const N: usize> MerkleStorage<F> for KvCurrentStorage<'_, F, D, N> {
     type Digest = D;
 
-    async fn size(&self) -> Position<F> {
+    fn size(&self) -> Position<F> {
         self.size
     }
 
@@ -138,7 +138,7 @@ pub(crate) struct AuthKvMerkleStorage<'a, F: Family, D: Digest> {
 impl<F: Family, D: Digest> MerkleStorage<F> for AuthKvMerkleStorage<'_, F, D> {
     type Digest = D;
 
-    async fn size(&self) -> Position<F> {
+    fn size(&self) -> Position<F> {
         self.size
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Updates the pinned Commonware monorepo revision from `85f7103e3b625d44a466d120aac5a3a13f2bb177` to `e1ab57dd8b372c8d80d36a7e3ef398bb2855725c` in `Cargo.toml` and `Cargo.lock`.

The new revision changes `commonware_storage::merkle::storage::Storage::size` from an async method to a synchronous one, so the three implementations in `qmdb/rs/src/storage.rs` (`KvMerkleStorage`, `KvCurrentStorage`, `AuthKvMerkleStorage`) were updated accordingly.

Verified locally: `cargo check --workspace --all-targets`, `cargo clippy --all-targets -- -D warnings`, `cargo test`, `cargo +nightly-2025-11-15 fmt --all -- --check`, and `cargo doc --no-deps --document-private-items` (with `RUSTDOCFLAGS="-D warnings"`) all pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f3f41-c491-7f71-ab4d-5ac764bbd41c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f3f41-c491-7f71-ab4d-5ac764bbd41c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

