### PR TITLE
Use Client for Namespacing in Batch

### DIFF
--- a/integration/tests/multi_instance.rs
+++ b/integration/tests/multi_instance.rs
@@ -276,15 +276,9 @@ async fn raw_prefixes_support_atomic_batch_fetch_range_and_stream() {
     let shared = Bytes::from_static(b"shared-key");
     let only_a = Bytes::from_static(b"only-a");
     let mut batch = StoreWriteBatch::new();
-    batch
-        .push(a.key_prefix(), &shared, b"value-a")
-        .expect("push a shared");
-    batch
-        .push(b.key_prefix(), &shared, b"value-b")
-        .expect("push b shared");
-    batch
-        .push(a.key_prefix(), &only_a, b"value-a2")
-        .expect("push a only");
+    batch.push(&a, &shared, b"value-a").expect("push a shared");
+    batch.push(&b, &shared, b"value-b").expect("push b shared");
+    batch.push(&a, &only_a, b"value-a2").expect("push a only");
     let sequence = batch
         .commit(&base)
         .await
@@ -789,9 +783,7 @@ async fn prefixed_prune_composes_selector_and_prunes_cleanly() {
         (&alt_v7, b"alt-v7".as_slice()),
         (&alt_v8, b"alt-v8".as_slice()),
     ] {
-        batch
-            .push(client.key_prefix(), key, value)
-            .expect("push versioned key");
+        batch.push(&client, key, value).expect("push versioned key");
     }
     batch.commit(&base).await.expect("commit versioned keys");
 

--- a/qmdb/rs/src/writer/immutable.rs
+++ b/qmdb/rs/src/writer/immutable.rs
@@ -195,7 +195,7 @@ where
         prepared: &mut super::PreparedUpload<F>,
         batch: &mut StoreWriteBatch,
     ) -> Result<(), QmdbError> {
-        super::stage_rows(self.client.key_prefix(), batch, prepared.rows.drain(..))
+        super::stage_rows(&self.client, batch, prepared.rows.drain(..))
     }
 
     pub async fn mark_upload_persisted(
@@ -257,7 +257,7 @@ where
         prepared: &super::PreparedWatermark<F>,
         batch: &mut StoreWriteBatch,
     ) -> Result<(), QmdbError> {
-        super::stage_watermark(self.client.key_prefix(), batch, prepared)
+        super::stage_watermark(&self.client, batch, prepared)
     }
 
     pub async fn mark_flush_persisted(

--- a/qmdb/rs/src/writer/keyless.rs
+++ b/qmdb/rs/src/writer/keyless.rs
@@ -229,7 +229,7 @@ where
         prepared: &mut super::PreparedUpload<F>,
         batch: &mut StoreWriteBatch,
     ) -> Result<(), QmdbError> {
-        super::stage_rows(self.client.key_prefix(), batch, prepared.rows.drain(..))
+        super::stage_rows(&self.client, batch, prepared.rows.drain(..))
     }
 
     pub async fn mark_upload_persisted(
@@ -291,7 +291,7 @@ where
         prepared: &super::PreparedWatermark<F>,
         batch: &mut StoreWriteBatch,
     ) -> Result<(), QmdbError> {
-        super::stage_watermark(self.client.key_prefix(), batch, prepared)
+        super::stage_watermark(&self.client, batch, prepared)
     }
 
     pub async fn mark_flush_persisted(

--- a/qmdb/rs/src/writer/mod.rs
+++ b/qmdb/rs/src/writer/mod.rs
@@ -130,3 +130,35 @@ pub(crate) fn upload_receipt<F: Family>(
         }),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use exoware_sdk::{StoreClient, StoreKeyPrefix};
+
+    /// Rows staged through a writer's client must land under that client's
+    /// namespace — the property the client-taking `push` API guarantees.
+    #[test]
+    fn stage_rows_encodes_under_the_clients_namespace() {
+        let client = StoreClient::new("http://localhost:10000")
+            .prefixed(StoreKeyPrefix::new(vec![0x07]).unwrap());
+        let other = StoreClient::new("http://localhost:10000")
+            .prefixed(StoreKeyPrefix::new(vec![0x08]).unwrap());
+
+        let rows = vec![
+            (Key::from_static(b"row-a"), b"va".to_vec()),
+            (Key::from_static(b"row-b"), b"vb".to_vec()),
+        ];
+        let logical: Vec<Key> = rows.iter().map(|(key, _)| key.clone()).collect();
+
+        let mut batch = StoreWriteBatch::new();
+        stage_rows(&client, &mut batch, rows).expect("stage rows");
+
+        assert_eq!(batch.entries().len(), logical.len());
+        for ((physical, _), expected) in batch.entries().iter().zip(&logical) {
+            assert!(client.key_prefix().matches(physical));
+            assert_eq!(&client.decode_store_key(physical).unwrap(), expected);
+            assert!(other.decode_store_key(physical).is_err());
+        }
+    }
+}

--- a/qmdb/rs/src/writer/mod.rs
+++ b/qmdb/rs/src/writer/mod.rs
@@ -33,7 +33,7 @@ pub use unordered::{build_unordered_upload, BuiltUnorderedUpload, UnorderedWrite
 use std::borrow::Borrow;
 
 use commonware_storage::merkle::{Family, Location};
-use exoware_sdk::{keys::Key, IntoStoreWriteValue, StoreKeyPrefix, StoreWriteBatch};
+use exoware_sdk::{keys::Key, IntoStoreWriteValue, PrefixedStoreClient, StoreWriteBatch};
 
 use crate::{PublishedCheckpoint, QmdbError, UploadReceipt};
 
@@ -86,7 +86,7 @@ impl<F: Family> PreparedWatermark<F> {
 }
 
 pub(crate) fn stage_rows<I, K, V>(
-    prefix: &StoreKeyPrefix,
+    client: &PrefixedStoreClient,
     batch: &mut StoreWriteBatch,
     rows: I,
 ) -> Result<(), QmdbError>
@@ -99,18 +99,18 @@ where
     let rows = rows.into_iter();
     batch.reserve(rows.len());
     for (key, value) in rows {
-        batch.push(prefix, key.borrow(), value)?;
+        batch.push(client, key.borrow(), value)?;
     }
     Ok(())
 }
 
 pub(crate) fn stage_watermark(
-    prefix: &StoreKeyPrefix,
+    client: &PrefixedStoreClient,
     batch: &mut StoreWriteBatch,
     watermark: &PreparedWatermark<impl Family>,
 ) -> Result<(), QmdbError> {
     let (key, value) = &watermark.row;
-    batch.push(prefix, key, value)?;
+    batch.push(client, key, value)?;
     Ok(())
 }
 

--- a/qmdb/rs/src/writer/ordered.rs
+++ b/qmdb/rs/src/writer/ordered.rs
@@ -247,7 +247,7 @@ where
         prepared: &mut super::PreparedUpload<F>,
         batch: &mut StoreWriteBatch,
     ) -> Result<(), QmdbError> {
-        super::stage_rows(self.client.key_prefix(), batch, prepared.rows.drain(..))
+        super::stage_rows(&self.client, batch, prepared.rows.drain(..))
     }
 
     pub async fn mark_upload_persisted(
@@ -309,7 +309,7 @@ where
         prepared: &super::PreparedWatermark<F>,
         batch: &mut StoreWriteBatch,
     ) -> Result<(), QmdbError> {
-        super::stage_watermark(self.client.key_prefix(), batch, prepared)
+        super::stage_watermark(&self.client, batch, prepared)
     }
 
     pub async fn mark_flush_persisted(

--- a/qmdb/rs/src/writer/unordered.rs
+++ b/qmdb/rs/src/writer/unordered.rs
@@ -259,7 +259,7 @@ where
         prepared: &mut super::PreparedUpload<F>,
         batch: &mut StoreWriteBatch,
     ) -> Result<(), QmdbError> {
-        super::stage_rows(self.client.key_prefix(), batch, prepared.rows.drain(..))
+        super::stage_rows(&self.client, batch, prepared.rows.drain(..))
     }
 
     pub async fn mark_upload_persisted(
@@ -321,7 +321,7 @@ where
         prepared: &super::PreparedWatermark<F>,
         batch: &mut StoreWriteBatch,
     ) -> Result<(), QmdbError> {
-        super::stage_watermark(self.client.key_prefix(), batch, prepared)
+        super::stage_watermark(&self.client, batch, prepared)
     }
 
     pub async fn mark_flush_persisted(

--- a/qmdb/rs/tests/e2e_immutable.rs
+++ b/qmdb/rs/tests/e2e_immutable.rs
@@ -120,7 +120,9 @@ async fn build_local_db() -> LocalReference {
                     .new_batch()
                     .set(key_a, val_a)
                     .set(key_b.clone(), val_b.clone());
-                batch.merkleize(&db, None::<Vec<u8>>, db.inactivity_floor_loc())
+                batch
+                    .merkleize(&db, None::<Vec<u8>>, db.inactivity_floor_loc())
+                    .await
             };
             db.apply_batch(finalized).await.expect("apply");
 
@@ -173,7 +175,9 @@ async fn build_fixed_local_db() -> FixedLocalReference {
 
             let finalized = {
                 let batch = db.new_batch().set(key_a, val_a).set(key_b.clone(), val_b);
-                batch.merkleize(&db, None::<Digest>, db.inactivity_floor_loc())
+                batch
+                    .merkleize(&db, None::<Digest>, db.inactivity_floor_loc())
+                    .await
             };
             db.apply_batch(finalized).await.expect("apply fixed");
 

--- a/qmdb/rs/tests/e2e_immutable_connect.rs
+++ b/qmdb/rs/tests/e2e_immutable_connect.rs
@@ -83,12 +83,16 @@ async fn build_local_batch() -> LocalBatch {
                     .new_batch()
                     .set(key_a, b"alpha".to_vec())
                     .set(key_b, b"beta".to_vec());
-                batch.merkleize(&db, None::<Vec<u8>>, db.inactivity_floor_loc())
+                batch
+                    .merkleize(&db, None::<Vec<u8>>, db.inactivity_floor_loc())
+                    .await
             };
             db.apply_batch(finalized).await.expect("apply");
             let finalized = {
                 let batch = db.new_batch().set(key_c, b"gamma".to_vec());
-                batch.merkleize(&db, None::<Vec<u8>>, db.bounds().end - 1)
+                batch
+                    .merkleize(&db, None::<Vec<u8>>, db.bounds().end - 1)
+                    .await
             };
             db.apply_batch(finalized).await.expect("apply second");
 

--- a/qmdb/rs/tests/e2e_immutable_writer.rs
+++ b/qmdb/rs/tests/e2e_immutable_writer.rs
@@ -69,7 +69,9 @@ async fn build_local_reference(batches: Vec<Vec<(K, V)>>) -> LocalReference {
                     for (k, v) in batch_writes {
                         batch = batch.set(k.clone(), v.clone());
                     }
-                    batch.merkleize(&db, None::<Vec<u8>>, db.bounds().end - 1)
+                    batch
+                        .merkleize(&db, None::<Vec<u8>>, db.bounds().end - 1)
+                        .await
                 };
                 db.apply_batch(finalized).await.expect("apply");
             }

--- a/qmdb/rs/tests/e2e_keyless.rs
+++ b/qmdb/rs/tests/e2e_keyless.rs
@@ -94,7 +94,9 @@ where
             let second = b"second-value".to_vec();
             let finalized = {
                 let batch = db.new_batch().append(first.clone()).append(second);
-                batch.merkleize(&db, None::<Vec<u8>>, db.inactivity_floor_loc())
+                batch
+                    .merkleize(&db, None::<Vec<u8>>, db.inactivity_floor_loc())
+                    .await
             };
             db.apply_batch(finalized).await.expect("apply");
 
@@ -153,7 +155,9 @@ where
             let second = commonware_cryptography::Sha256::fill(0x22);
             let finalized = {
                 let batch = db.new_batch().append(first).append(second);
-                batch.merkleize(&db, None::<Digest>, db.inactivity_floor_loc())
+                batch
+                    .merkleize(&db, None::<Digest>, db.inactivity_floor_loc())
+                    .await
             };
             db.apply_batch(finalized).await.expect("apply fixed");
 

--- a/qmdb/rs/tests/e2e_keyless_connect.rs
+++ b/qmdb/rs/tests/e2e_keyless_connect.rs
@@ -83,12 +83,16 @@ async fn build_local_batch() -> LocalBatch {
                     .new_batch()
                     .append(b"first-value".to_vec())
                     .append(b"second-value".to_vec());
-                batch.merkleize(&db, None::<Vec<u8>>, db.inactivity_floor_loc())
+                batch
+                    .merkleize(&db, None::<Vec<u8>>, db.inactivity_floor_loc())
+                    .await
             };
             db.apply_batch(finalized).await.expect("apply");
             let finalized = {
                 let batch = db.new_batch().append(b"third-value".to_vec());
-                batch.merkleize(&db, None::<Vec<u8>>, db.bounds().end - 1)
+                batch
+                    .merkleize(&db, None::<Vec<u8>>, db.bounds().end - 1)
+                    .await
             };
             db.apply_batch(finalized).await.expect("apply second");
 

--- a/qmdb/rs/tests/e2e_keyless_writer.rs
+++ b/qmdb/rs/tests/e2e_keyless_writer.rs
@@ -59,7 +59,9 @@ async fn build_local_reference(
                     for v in batch_values {
                         batch = batch.append(v.clone());
                     }
-                    batch.merkleize(&db, None::<Vec<u8>>, db.bounds().end - 1)
+                    batch
+                        .merkleize(&db, None::<Vec<u8>>, db.bounds().end - 1)
+                        .await
                 };
                 db.apply_batch(finalized).await.expect("apply");
             }

--- a/qmdb/rs/tests/e2e_mirror_from_local.rs
+++ b/qmdb/rs/tests/e2e_mirror_from_local.rs
@@ -121,6 +121,7 @@ async fn run_keyless_local(
                         b = b.append(v);
                     }
                     b.merkleize(&db, None::<Vec<u8>>, db.inactivity_floor_loc())
+                        .await
                 };
                 db.apply_batch(finalized).await.expect("apply");
             }
@@ -351,6 +352,7 @@ async fn run_immutable_local(
                         b = b.set(k, v);
                     }
                     b.merkleize(&db, None::<Vec<u8>>, db.inactivity_floor_loc())
+                        .await
                 };
                 db.apply_batch(finalized).await.expect("apply");
             }

--- a/sdk/rs/README.md
+++ b/sdk/rs/README.md
@@ -17,8 +17,8 @@ Use `StoreKeyPrefix` when multiple logical QMDB, SQL, or raw KV instances share 
 use exoware_sdk::{StoreClient, StoreKeyPrefix};
 
 let base = StoreClient::new("http://localhost:10000");
-let orders = base.with_key_prefix(StoreKeyPrefix::new(4, 1)?);
-let accounts = base.with_key_prefix(StoreKeyPrefix::new(4, 2)?);
+let orders = base.prefixed(StoreKeyPrefix::new(vec![1])?);
+let accounts = base.prefixed(StoreKeyPrefix::new(vec![2])?);
 ```
 
 For an atomic write spanning multiple prefixed clients, add each logical row through the client that owns it and commit once:

--- a/sdk/rs/src/lib.rs
+++ b/sdk/rs/src/lib.rs
@@ -874,6 +874,11 @@ impl StoreWriteBatch {
         Ok(self)
     }
 
+    /// The staged physical entries, in staging order.
+    pub fn entries(&self) -> &[(Key, Bytes)] {
+        &self.entries
+    }
+
     pub async fn commit(&self, client: &StoreClient) -> Result<u64, ClientError> {
         client.put_prepared_physical(&self.entries).await
     }
@@ -3233,6 +3238,58 @@ mod tests {
             batch.entries[1].0,
             b.key_prefix().encode_key(&key_b).unwrap()
         );
+    }
+
+    #[test]
+    fn pushed_rows_round_trip_only_through_their_own_client() {
+        let base = StoreClient::new("http://localhost:10000");
+        let a = base.prefixed(StoreKeyPrefix::new(vec![1]).unwrap());
+        let b = base.prefixed(StoreKeyPrefix::new(vec![2]).unwrap());
+        let key = Bytes::from_static(b"shared-logical-key");
+
+        let mut batch = StoreWriteBatch::new();
+        batch.push(&a, &key, b"va").unwrap();
+        batch.push(&b, &key, b"vb").unwrap();
+
+        // The same logical key staged through two namespaces produces two
+        // distinct physical rows, in staging order.
+        let entries = batch.entries();
+        assert_eq!(entries.len(), 2);
+        assert_ne!(entries[0].0, entries[1].0);
+
+        // Each physical key decodes back through its own namespace and is
+        // rejected by the other.
+        assert_eq!(a.decode_store_key(&entries[0].0).unwrap(), key);
+        assert_eq!(b.decode_store_key(&entries[1].0).unwrap(), key);
+        assert!(a.decode_store_key(&entries[1].0).is_err());
+        assert!(b.decode_store_key(&entries[0].0).is_err());
+    }
+
+    #[test]
+    fn identity_prefix_stages_keys_verbatim() {
+        let base = StoreClient::new("http://localhost:10000");
+        let plain = PrefixedStoreClient::empty(base);
+        let key = Bytes::from_static(b"raw-key");
+
+        let mut batch = StoreWriteBatch::new();
+        batch.push(&plain, &key, b"v").unwrap();
+
+        assert_eq!(batch.entries()[0].0, key);
+    }
+
+    #[test]
+    fn push_rejects_keys_exceeding_prefixed_capacity() {
+        let base = StoreClient::new("http://localhost:10000");
+        let a = base.prefixed(StoreKeyPrefix::new(vec![1]).unwrap());
+        let max = a.key_prefix().max_logical_key_len();
+
+        let mut batch = StoreWriteBatch::new();
+        let at_capacity = Key::from(vec![7u8; max]);
+        batch.push(&a, &at_capacity, b"v").unwrap();
+
+        let oversize = Key::from(vec![7u8; max + 1]);
+        assert!(batch.push(&a, &oversize, b"v").is_err());
+        assert_eq!(batch.len(), 1);
     }
 
     fn hex_encode(data: &[u8]) -> String {

--- a/sdk/rs/src/lib.rs
+++ b/sdk/rs/src/lib.rs
@@ -856,14 +856,21 @@ impl StoreWriteBatch {
         self.entries.reserve(additional);
     }
 
+    /// Stage a logical row under `client`'s namespace.
+    ///
+    /// The key is encoded as it is staged, so rows from several namespaces
+    /// can share one batch; [`Self::commit`] writes the encoded rows
+    /// verbatim through the physical client.
     pub fn push(
         &mut self,
-        prefix: &StoreKeyPrefix,
+        client: &PrefixedStoreClient,
         key: &Key,
         value: impl IntoStoreWriteValue,
     ) -> Result<&mut Self, ClientError> {
-        self.entries
-            .push((prefix.encode_key(key)?, value.into_store_write_value()));
+        self.entries.push((
+            client.encode_store_key(key)?,
+            value.into_store_write_value(),
+        ));
         Ok(self)
     }
 
@@ -3215,8 +3222,8 @@ mod tests {
         let key_b = Bytes::from_static(b"b");
 
         let mut batch = StoreWriteBatch::new();
-        batch.push(a.key_prefix(), &key_a, b"va").unwrap();
-        batch.push(b.key_prefix(), &key_b, b"vb").unwrap();
+        batch.push(&a, &key_a, b"va").unwrap();
+        batch.push(&b, &key_b, b"vb").unwrap();
 
         assert_eq!(
             batch.entries[0].0,

--- a/sdk/ts/README.md
+++ b/sdk/ts/README.md
@@ -16,8 +16,8 @@ Use `StoreKeyPrefix` when multiple logical QMDB, SQL, or raw KV instances share 
 import { Client, StoreKeyPrefix, StoreWriteBatch } from '@exowarexyz/sdk';
 
 const base = new Client('http://localhost:10000').store();
-const orders = base.withKeyPrefix(new StoreKeyPrefix(4, 1));
-const accounts = base.withKeyPrefix(new StoreKeyPrefix(4, 2));
+const orders = base.withKeyPrefix(new StoreKeyPrefix(new Uint8Array([1])));
+const accounts = base.withKeyPrefix(new StoreKeyPrefix(new Uint8Array([2])));
 
 const batch = new StoreWriteBatch()
     .push(orders, orderKey, orderValue)

--- a/simplex/rs/src/bin/simplex.rs
+++ b/simplex/rs/src/bin/simplex.rs
@@ -222,30 +222,30 @@ async fn upload_certificates(
     let block = encode_block_data(&finalized.header, body);
     let notarized_bytes = notarized.encode();
     let finalized_bytes = finalized.encode();
-    let prefix = client.store_client().key_prefix();
+    let store = client.store_client();
     let mut batch = StoreWriteBatch::new();
     batch.push(
-        prefix,
+        store,
         &keys::header_by_digest(&finalized.header.digest()),
         header,
     )?;
     batch.push(
-        prefix,
+        store,
         &keys::block_by_digest(&finalized.header.digest()),
         block,
     )?;
     batch.push(
-        prefix,
+        store,
         &keys::notarization_by_view(notarized.proof.view()),
         notarized_bytes,
     )?;
     batch.push(
-        prefix,
+        store,
         &keys::finalization_by_view(finalized.proof.view()),
         finalized_bytes.clone(),
     )?;
     batch.push(
-        prefix,
+        store,
         &keys::finalized_by_height(finalized.header.height()),
         finalized_bytes,
     )?;

--- a/simplex/rs/src/client.rs
+++ b/simplex/rs/src/client.rs
@@ -177,9 +177,8 @@ impl SimplexClient {
         if prepared.is_empty() {
             return Err(SimplexError::EmptyUpload);
         }
-        let prefix = self.client.key_prefix();
         for entry in prepared.entries() {
-            batch.push(prefix, &entry.key, entry.value.clone())?;
+            batch.push(&self.client, &entry.key, entry.value.clone())?;
         }
         Ok(())
     }

--- a/sql/rs/src/writer.rs
+++ b/sql/rs/src/writer.rs
@@ -193,10 +193,9 @@ impl BatchWriter {
         prepared: &PreparedBatch,
         batch: &mut StoreWriteBatch,
     ) -> DataFusionResult<()> {
-        let key_prefix = self.client.key_prefix();
         for (key, value) in prepared.keys.iter().zip(prepared.values.iter()) {
             batch
-                .push(key_prefix, key, value)
+                .push(&self.client, key, value)
                 .map_err(|e| DataFusionError::External(Box::new(e)))?;
         }
         Ok(())
@@ -966,10 +965,9 @@ pub(crate) async fn flush_ingest_batch(
         return Ok(0);
     }
     let mut batch = StoreWriteBatch::new();
-    let key_prefix = client.key_prefix();
     for (key, value) in keys.iter().zip(values.iter()) {
         batch
-            .push(key_prefix, key, value)
+            .push(client, key, value)
             .map_err(|e| DataFusionError::External(Box::new(e)))?;
     }
     let token = batch


### PR DESCRIPTION
`StoreWriteBatch::push` now takes the `PrefixedStoreClient` that owns the row instead of a raw `StoreKeyPrefix`, so the namespace is applied at the point of staging by the client that owns it — a row staged under a mismatched namespace is no longer expressible. This also matches the TypeScript SDK, whose `push(client, key, value)` already had this shape.

## What changed

- **`sdk`**: `push(&PrefixedStoreClient, key, value)` encodes via `client.encode_store_key`; a public read-only `entries()` accessor is added (TS parity), which is also what lets downstream crates assert staging correctness. `commit(&StoreClient)` is unchanged and deliberately stays on the physical client: rows are already encoded when staged, a batch may span namespaces (the QMDB writers rely on this), and commit writes the entries verbatim with no re-prefixing.
- **`qmdb`**: `stage_rows`/`stage_watermark` take the writer's client; all four writers pass `&self.client` instead of `self.client.key_prefix()`.
- **`simplex`**: `stage_upload` and the demo bin stage through the client.
- **`sql`**: both flush paths drop their local `key_prefix` bindings.
- **Docs**: both SDK READMEs' prefix examples were stale (`with_key_prefix`, the removed two-argument `StoreKeyPrefix` constructor) — fixed to the real APIs. The Rust README's batch example already showed the client-taking `push`, so the code now matches its own docs.

## Tests

Four regression tests pin the contract:

- the same logical key staged through two namespaces produces two distinct physical rows, each decodable only through its own client (`PrefixMismatch` from the other);
- the identity prefix stages keys byte-for-byte verbatim;
- a key at exactly `max_logical_key_len()` stages, one byte over is rejected and leaves the batch untouched;
- rows staged through a QMDB writer's client land under that client's namespace and no other.

## Also in this PR (separable)

12 missing `.await`s in the qmdb e2e tests from the async-`merkleize` Commonware bump — the base revision did not compile its own test targets, so no branch could pass `cargo clippy --all-targets -- -D warnings` without this.

## Verification

- `cargo clippy --all-targets -- -D warnings` (first revision where every target compiles), `cargo +nightly fmt --all --check`, `cargo doc --no-deps --document-private-items` with `-D warnings`.
- Unit tests: sdk 83, qmdb 34, sql 207. E2E/integration tests are compile-verified (they need a live store stack).
- A repo-wide sweep found no remaining stale references: every `batch.push` call site passes a client, and the three surviving `key_prefix()` calls are read-side test introspection.

Downstream consumers that stage through the writer clients (e.g. constantinople) need no changes — they never touched a prefix directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016iug4eqB5GJu6LP4GR144f
