### PR TITLE
remove AuthenticatedBackendNamespace

### DIFF
--- a/qmdb/rs/src/auth.rs
+++ b/qmdb/rs/src/auth.rs
@@ -6,10 +6,9 @@ use exoware_sdk::keys::Key;
 use exoware_sdk::{RangeMode, SerializableReadSession};
 
 use crate::codec::{
-    decode_digest, decode_operation_location_key, decode_watermark_location,
-    encode_node_key, encode_operation_key, encode_presence_key, encode_update_index_value,
-    encode_update_key, encode_watermark_key, ensure_encoded_value_size, merkle_size_for_watermark,
-    WATERMARK_PREFIX,
+    decode_digest, decode_operation_location_key, decode_watermark_location, encode_node_key,
+    encode_operation_key, encode_presence_key, encode_update_index_value, encode_update_key,
+    encode_watermark_key, ensure_encoded_value_size, merkle_size_for_watermark, WATERMARK_PREFIX,
 };
 use crate::error::QmdbError;
 

--- a/qmdb/rs/src/auth.rs
+++ b/qmdb/rs/src/auth.rs
@@ -2,100 +2,16 @@ use commonware_codec::{Decode, Encode};
 use commonware_cryptography::Hasher;
 use commonware_storage::merkle::{hasher::Hasher as MerkleHasher, Family, Location, Position};
 use commonware_utils::Array;
-use exoware_sdk::keys::{Key, Prefix};
+use exoware_sdk::keys::Key;
 use exoware_sdk::{RangeMode, SerializableReadSession};
 
 use crate::codec::{
-    decode_digest, decode_location_bytes, encode_update_index_value, encode_update_key,
-    ensure_encoded_value_size, merkle_size_for_watermark, NODE_PREFIX, OPERATION_PREFIX,
-    PRESENCE_PREFIX, WATERMARK_PREFIX,
+    decode_digest, decode_operation_location_key, decode_watermark_location,
+    encode_node_key, encode_operation_key, encode_presence_key, encode_update_index_value,
+    encode_update_key, encode_watermark_key, ensure_encoded_value_size, merkle_size_for_watermark,
+    WATERMARK_PREFIX,
 };
 use crate::error::QmdbError;
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) enum AuthenticatedBackendNamespace {
-    Immutable = 1,
-    Keyless = 2,
-}
-
-impl AuthenticatedBackendNamespace {
-    pub(crate) const fn tag(self) -> u8 {
-        self as u8
-    }
-}
-
-const AUTH_NAMESPACE_LEN: usize = 1;
-
-pub(crate) fn auth_namespace_bounds(
-    prefix: &Prefix,
-    namespace: AuthenticatedBackendNamespace,
-) -> (Key, Key) {
-    (
-        encode_auth_namespaced_key(prefix, namespace.tag(), 0),
-        encode_auth_namespaced_key(prefix, namespace.tag(), u64::MAX),
-    )
-}
-
-/// Strip `prefix` from `key`, verify the namespace tag, and return the
-/// stripped payload (tag byte included).
-pub(crate) fn ensure_auth_namespace(
-    prefix: &Prefix,
-    namespace: AuthenticatedBackendNamespace,
-    key: &Key,
-    label: &str,
-) -> Result<Key, QmdbError> {
-    let payload = prefix
-        .strip(key)
-        .map_err(|_| QmdbError::CorruptData(format!("{label} key prefix mismatch")))?;
-    let actual = *payload.first().ok_or_else(|| {
-        QmdbError::CorruptData(format!("cannot decode {label} namespace: short key"))
-    })?;
-    if actual != namespace.tag() {
-        return Err(QmdbError::CorruptData(format!(
-            "{label} namespace mismatch: expected {}, got {actual}",
-            namespace.tag()
-        )));
-    }
-    Ok(payload)
-}
-
-/// Build a `[namespace tag] ++ 8-byte big-endian value` auth-family key.
-fn encode_auth_namespaced_key(prefix: &Prefix, tag: u8, value: u64) -> Key {
-    let mut payload = [0u8; AUTH_NAMESPACE_LEN + 8];
-    payload[0] = tag;
-    payload[AUTH_NAMESPACE_LEN..].copy_from_slice(&value.to_be_bytes());
-    prefix
-        .encode(&payload)
-        .expect("authenticated namespaced key length should fit")
-}
-
-pub(crate) fn encode_auth_operation_key<F: Family>(
-    namespace: AuthenticatedBackendNamespace,
-    location: Location<F>,
-) -> Key {
-    encode_auth_namespaced_key(&OPERATION_PREFIX, namespace.tag(), location.as_u64())
-}
-
-pub(crate) fn encode_auth_node_key<F: Family>(
-    namespace: AuthenticatedBackendNamespace,
-    position: Position<F>,
-) -> Key {
-    encode_auth_namespaced_key(&NODE_PREFIX, namespace.tag(), position.as_u64())
-}
-
-pub(crate) fn encode_auth_watermark_key<F: Family>(
-    namespace: AuthenticatedBackendNamespace,
-    location: Location<F>,
-) -> Key {
-    encode_auth_namespaced_key(&WATERMARK_PREFIX, namespace.tag(), location.as_u64())
-}
-
-pub(crate) fn encode_auth_presence_key<F: Family>(
-    namespace: AuthenticatedBackendNamespace,
-    location: Location<F>,
-) -> Key {
-    encode_auth_namespaced_key(&PRESENCE_PREFIX, namespace.tag(), location.as_u64())
-}
 
 pub(crate) async fn load_latest_auth_immutable_update_row<F: Family>(
     session: &SerializableReadSession,
@@ -115,28 +31,26 @@ pub(crate) async fn load_latest_auth_immutable_update_row<F: Family>(
 
 pub(crate) async fn read_latest_auth_watermark<F: Family>(
     session: &SerializableReadSession,
-    namespace: AuthenticatedBackendNamespace,
 ) -> Result<Option<Location<F>>, QmdbError> {
-    let (start, end) = auth_namespace_bounds(&WATERMARK_PREFIX, namespace);
+    let (start, end) = WATERMARK_PREFIX.bounds();
     let rows = session
         .range_with_mode(&start, &end, 1, RangeMode::Reverse)
         .await?;
     match rows.into_iter().next() {
-        Some((key, _)) => Ok(Some(decode_auth_watermark_location(namespace, &key)?)),
+        Some((key, _)) => Ok(Some(decode_watermark_location(&key)?)),
         None => Ok(None),
     }
 }
 
 pub(crate) async fn require_published_auth_watermark<F: Family>(
     session: &SerializableReadSession,
-    namespace: AuthenticatedBackendNamespace,
     watermark: Location<F>,
 ) -> Result<(), QmdbError> {
-    let available = read_latest_auth_watermark::<F>(session, namespace)
+    let available = read_latest_auth_watermark::<F>(session)
         .await?
         .unwrap_or(Location::new(0));
     let watermark_exists = session
-        .get(&encode_auth_watermark_key(namespace, watermark))
+        .get(&encode_watermark_key(watermark))
         .await?
         .is_some();
     if available < watermark
@@ -153,7 +67,6 @@ pub(crate) async fn require_published_auth_watermark<F: Family>(
 /// Consumes `encoded_operations` into the returned `PreparedUpload`'s
 /// `op_rows` — no clones.
 pub(crate) fn build_auth_upload_rows<F: Family>(
-    namespace: AuthenticatedBackendNamespace,
     latest_location: Location<F>,
     encoded_operations: Vec<Vec<u8>>,
 ) -> Result<crate::core::PreparedUpload, QmdbError> {
@@ -172,10 +85,7 @@ pub(crate) fn build_auth_upload_rows<F: Family>(
     let mut op_rows = Vec::<(Key, Vec<u8>)>::with_capacity(count);
     for (index, encoded) in encoded_operations.into_iter().enumerate() {
         ensure_encoded_value_size(encoded.len())?;
-        op_rows.push((
-            encode_auth_operation_key(namespace, start_location + index as u64),
-            encoded,
-        ));
+        op_rows.push((encode_operation_key(start_location + index as u64), encoded));
     }
     let operation_count = u32::try_from(count).map_err(|_| {
         QmdbError::CorruptData("authenticated operation count overflow".to_string())
@@ -184,10 +94,7 @@ pub(crate) fn build_auth_upload_rows<F: Family>(
         operation_count,
         keyed_operation_count: 0,
         op_rows,
-        aux_rows: vec![(
-            encode_auth_presence_key(namespace, latest_location),
-            Vec::new(),
-        )],
+        aux_rows: vec![(encode_presence_key(latest_location), Vec::new())],
     })
 }
 
@@ -224,10 +131,7 @@ where
         let location = start_location + index as u64;
         let encoded = operation.encode().to_vec();
         ensure_encoded_value_size(encoded.len())?;
-        op_rows.push((
-            encode_auth_operation_key(AuthenticatedBackendNamespace::Immutable, location),
-            encoded,
-        ));
+        op_rows.push((encode_operation_key(location), encoded));
         if let ImmutableOperation::Set(key, _) = operation {
             keyed_operation_count += 1;
             aux_rows.push((
@@ -236,10 +140,7 @@ where
             ));
         }
     }
-    aux_rows.push((
-        encode_auth_presence_key(AuthenticatedBackendNamespace::Immutable, latest_location),
-        Vec::new(),
-    ));
+    aux_rows.push((encode_presence_key(latest_location), Vec::new()));
     let operation_count = u32::try_from(count).map_err(|_| {
         QmdbError::CorruptData("authenticated operation count overflow".to_string())
     })?;
@@ -263,7 +164,6 @@ pub(crate) fn auth_inactive_peaks<F: Family>(
 
 pub(crate) async fn compute_auth_root<F: Family, H: Hasher>(
     session: &SerializableReadSession,
-    namespace: AuthenticatedBackendNamespace,
     watermark: Location<F>,
     inactive_peaks: usize,
 ) -> Result<H::Digest, QmdbError> {
@@ -277,7 +177,7 @@ pub(crate) async fn compute_auth_root<F: Family, H: Hasher>(
     } else {
         let peak_keys: Vec<Key> = peak_positions
             .iter()
-            .map(|(pos, _)| encode_auth_node_key(namespace, *pos))
+            .map(|(pos, _)| encode_node_key(*pos))
             .collect();
         let peak_key_refs: Vec<&Key> = peak_keys.iter().collect();
         session
@@ -288,7 +188,7 @@ pub(crate) async fn compute_auth_root<F: Family, H: Hasher>(
     };
     let mut peaks = Vec::with_capacity(peak_positions.len());
     for (peak_pos, _) in &peak_positions {
-        let key = encode_auth_node_key(namespace, *peak_pos);
+        let key = encode_node_key(*peak_pos);
         let Some(bytes) = fetched.get(&key) else {
             return Err(QmdbError::CorruptData(format!(
                 "missing authenticated Merkle peak node at position {peak_pos}"
@@ -307,17 +207,13 @@ pub(crate) async fn compute_auth_root<F: Family, H: Hasher>(
 
 pub(crate) async fn load_auth_operation_at<F: Family, Op>(
     session: &SerializableReadSession,
-    namespace: AuthenticatedBackendNamespace,
     location: Location<F>,
     cfg: &Op::Cfg,
 ) -> Result<Op, QmdbError>
 where
     Op: Decode,
 {
-    let Some(bytes) = session
-        .get(&encode_auth_operation_key(namespace, location))
-        .await?
-    else {
+    let Some(bytes) = session.get(&encode_operation_key(location)).await? else {
         return Err(QmdbError::CorruptData(format!(
             "missing authenticated operation row at location {location}"
         )));
@@ -331,15 +227,14 @@ where
 
 pub(crate) async fn load_auth_operation_bytes_range<F: Family>(
     session: &SerializableReadSession,
-    namespace: AuthenticatedBackendNamespace,
     start_location: Location<F>,
     end_location_exclusive: Location<F>,
 ) -> Result<Vec<Vec<u8>>, QmdbError> {
     if start_location >= end_location_exclusive {
         return Ok(Vec::new());
     }
-    let start = encode_auth_operation_key(namespace, start_location);
-    let end = encode_auth_operation_key(namespace, end_location_exclusive - 1);
+    let start = encode_operation_key(start_location);
+    let end = encode_operation_key(end_location_exclusive - 1);
     let rows = session
         .range(
             &start,
@@ -357,7 +252,7 @@ pub(crate) async fn load_auth_operation_bytes_range<F: Family>(
     let mut operations = Vec::with_capacity(rows.len());
     for (offset, (key, value)) in rows.into_iter().enumerate() {
         let expected_location = start_location + offset as u64;
-        let location = decode_auth_operation_location(namespace, &key)?;
+        let location = decode_operation_location_key::<F>(&key)?;
         if location != expected_location {
             return Err(QmdbError::CorruptData(format!(
                 "authenticated operation row order mismatch: expected {expected_location}, got {location}"
@@ -366,40 +261,6 @@ pub(crate) async fn load_auth_operation_bytes_range<F: Family>(
         operations.push(value.to_vec());
     }
     Ok(operations)
-}
-
-fn decode_auth_location_field<F: Family>(
-    prefix: &Prefix,
-    namespace: AuthenticatedBackendNamespace,
-    key: &Key,
-    label: &str,
-) -> Result<Location<F>, QmdbError> {
-    let payload = ensure_auth_namespace(prefix, namespace, key, label)?;
-    Ok(Location::new(decode_location_bytes(
-        &payload[AUTH_NAMESPACE_LEN..],
-        format_args!("{label} location"),
-    )?))
-}
-
-pub(crate) fn decode_auth_operation_location<F: Family>(
-    namespace: AuthenticatedBackendNamespace,
-    key: &Key,
-) -> Result<Location<F>, QmdbError> {
-    decode_auth_location_field(&OPERATION_PREFIX, namespace, key, "authenticated operation")
-}
-
-pub(crate) fn decode_auth_watermark_location<F: Family>(
-    namespace: AuthenticatedBackendNamespace,
-    key: &Key,
-) -> Result<Location<F>, QmdbError> {
-    decode_auth_location_field(&WATERMARK_PREFIX, namespace, key, "authenticated watermark")
-}
-
-pub(crate) fn decode_auth_presence_location<F: Family>(
-    namespace: AuthenticatedBackendNamespace,
-    key: &Key,
-) -> Result<Location<F>, QmdbError> {
-    decode_auth_location_field(&PRESENCE_PREFIX, namespace, key, "authenticated presence")
 }
 
 #[cfg(test)]

--- a/qmdb/rs/src/connect.rs
+++ b/qmdb/rs/src/connect.rs
@@ -160,12 +160,6 @@ trait OperationLogBackend: Clone + Send + Sync + 'static {
     const REJECTS_KEY_FILTERS: bool = false;
 
     fn store_client(&self) -> &exoware_sdk::PrefixedStoreClient;
-    fn classify_and_filter(
-        &self,
-    ) -> (
-        RowClassifier<Self::Family>,
-        exoware_sdk::stream_filter::StreamFilter,
-    );
     fn extract_operation_kv(
         &self,
         location: Location<Self::Family>,
@@ -250,10 +244,6 @@ where
         OrderedClient::store_client(self)
     }
 
-    fn classify_and_filter(&self) -> (RowClassifier<F>, exoware_sdk::stream_filter::StreamFilter) {
-        sub::classify_and_filter::<F>()
-    }
-
     fn extract_operation_kv(
         &self,
         location: Location<F>,
@@ -302,10 +292,6 @@ where
 
     fn store_client(&self) -> &exoware_sdk::PrefixedStoreClient {
         UnorderedClient::store_client(self)
-    }
-
-    fn classify_and_filter(&self) -> (RowClassifier<F>, exoware_sdk::stream_filter::StreamFilter) {
-        sub::classify_and_filter::<F>()
     }
 
     fn extract_operation_kv(
@@ -365,10 +351,6 @@ where
         ImmutableClient::store_client(self)
     }
 
-    fn classify_and_filter(&self) -> (RowClassifier<F>, exoware_sdk::stream_filter::StreamFilter) {
-        sub::classify_and_filter::<F>()
-    }
-
     fn extract_operation_kv(
         &self,
         location: Location<F>,
@@ -417,10 +399,6 @@ where
 
     fn store_client(&self) -> &exoware_sdk::PrefixedStoreClient {
         KeylessClient::store_client(self)
-    }
-
-    fn classify_and_filter(&self) -> (RowClassifier<F>, exoware_sdk::stream_filter::StreamFilter) {
-        sub::classify_and_filter::<F>()
     }
 
     fn extract_operation_kv(
@@ -992,7 +970,7 @@ impl<B: OperationLogBackend> OperationLogService for OperationLogConnect<B> {
             let value_matcher = parse_filters(request.value_filters.iter(), "value")
                 .map_err(ConnectError::invalid_argument)?;
             let since = decode_since(request.since_sequence_number);
-            let (classify, filter) = backend.classify_and_filter();
+            let (classify, filter) = sub::classify_and_filter::<B::Family>();
             let sub = sub::open_store_subscription(backend.store_client(), filter, since)
                 .await
                 .map_err(qmdb_error_to_connect)?;

--- a/qmdb/rs/src/connect.rs
+++ b/qmdb/rs/src/connect.rs
@@ -37,7 +37,6 @@ use exoware_sdk::stream_filter::{CompiledFilters, Filter};
 use futures::future::BoxFuture;
 use futures::{FutureExt, Stream};
 
-use crate::auth::AuthenticatedBackendNamespace;
 use crate::proof::{
     CurrentOperationRangeProofResult, OperationRangeCheckpoint, RawBatchMultiProof,
 };
@@ -252,7 +251,7 @@ where
     }
 
     fn classify_and_filter(&self) -> (RowClassifier<F>, exoware_sdk::stream_filter::StreamFilter) {
-        sub::classify_and_filter::<F>(None)
+        sub::classify_and_filter::<F>()
     }
 
     fn extract_operation_kv(
@@ -306,7 +305,7 @@ where
     }
 
     fn classify_and_filter(&self) -> (RowClassifier<F>, exoware_sdk::stream_filter::StreamFilter) {
-        sub::classify_and_filter::<F>(None)
+        sub::classify_and_filter::<F>()
     }
 
     fn extract_operation_kv(
@@ -367,7 +366,7 @@ where
     }
 
     fn classify_and_filter(&self) -> (RowClassifier<F>, exoware_sdk::stream_filter::StreamFilter) {
-        sub::classify_and_filter::<F>(Some(AuthenticatedBackendNamespace::Immutable))
+        sub::classify_and_filter::<F>()
     }
 
     fn extract_operation_kv(
@@ -421,7 +420,7 @@ where
     }
 
     fn classify_and_filter(&self) -> (RowClassifier<F>, exoware_sdk::stream_filter::StreamFilter) {
-        sub::classify_and_filter::<F>(Some(AuthenticatedBackendNamespace::Keyless))
+        sub::classify_and_filter::<F>()
     }
 
     fn extract_operation_kv(

--- a/qmdb/rs/src/immutable.rs
+++ b/qmdb/rs/src/immutable.rs
@@ -13,7 +13,6 @@ use commonware_storage::{
 use commonware_utils::Array;
 use exoware_sdk::{PrefixedStoreClient, SerializableReadSession};
 
-use crate::auth::AuthenticatedBackendNamespace;
 use crate::auth::{
     auth_inactive_peaks, compute_auth_root, load_auth_operation_at,
     load_auth_operation_bytes_range, load_latest_auth_immutable_update_row,
@@ -24,7 +23,7 @@ use crate::connect::OperationKv;
 use crate::core::retry_transient_post_ingest_query;
 use crate::error::QmdbError;
 use crate::proof::{OperationRangeCheckpoint, RawBatchMultiProof, VerifiedOperationRange};
-use crate::storage::AuthKvMerkleStorage;
+use crate::storage::KvMerkleStorage;
 use crate::VersionedValue;
 
 #[derive(Clone)]
@@ -108,20 +107,16 @@ where
     pub async fn writer_location_watermark(&self) -> Result<Option<Location<F>>, QmdbError> {
         retry_transient_post_ingest_query(|| {
             let session = self.client.create_session();
-            async move {
-                read_latest_auth_watermark::<F>(&session, AuthenticatedBackendNamespace::Immutable)
-                    .await
-            }
+            async move { read_latest_auth_watermark::<F>(&session).await }
         })
         .await
     }
 
     pub async fn root_at(&self, watermark: Location<F>) -> Result<H::Digest, QmdbError> {
-        let namespace = AuthenticatedBackendNamespace::Immutable;
         let session = self.client.create_session();
-        require_published_auth_watermark(&session, namespace, watermark).await?;
+        require_published_auth_watermark(&session, watermark).await?;
         let inactive_peaks = self.inactive_peaks_at(&session, watermark).await?;
-        compute_auth_root::<F, H>(&session, namespace, watermark, inactive_peaks).await
+        compute_auth_root::<F, H>(&session, watermark, inactive_peaks).await
     }
 
     pub async fn get_at(
@@ -129,9 +124,8 @@ where
         key: &K,
         watermark: Location<F>,
     ) -> Result<Option<VersionedValue<K, V, F>>, QmdbError> {
-        let namespace = AuthenticatedBackendNamespace::Immutable;
         let session = self.client.create_session();
-        require_published_auth_watermark(&session, namespace, watermark).await?;
+        require_published_auth_watermark(&session, watermark).await?;
         let Some((row_key, _row_value)) =
             load_latest_auth_immutable_update_row(&session, watermark, key.as_ref()).await?
         else {
@@ -140,7 +134,6 @@ where
         let location = decode_update_location::<F>(&row_key)?;
         let operation = load_auth_operation_at::<F, immutable::Operation<F, K, E>>(
             &session,
-            namespace,
             location,
             &self.operation_cfg,
         )
@@ -184,20 +177,17 @@ where
         watermark: Location<F>,
         operations: Vec<(Location<F>, Vec<u8>)>,
     ) -> Result<RawBatchMultiProof<H::Digest, F>, QmdbError> {
-        let namespace = AuthenticatedBackendNamespace::Immutable;
         let session = self
             .client
             .create_session_with_sequence(read_floor_sequence);
-        require_published_auth_watermark(&session, namespace, watermark).await?;
-        let storage = AuthKvMerkleStorage::<F, H::Digest> {
+        require_published_auth_watermark(&session, watermark).await?;
+        let storage = KvMerkleStorage::<F, H::Digest> {
             session: &session,
-            namespace,
             size: merkle_size_for_watermark(watermark)?,
             _marker: PhantomData::<H::Digest>,
         };
         let inactive_peaks = self.inactive_peaks_at(&session, watermark).await?;
-        let root =
-            compute_auth_root::<F, H>(&session, namespace, watermark, inactive_peaks).await?;
+        let root = compute_auth_root::<F, H>(&session, watermark, inactive_peaks).await?;
         crate::proof::build_batch_multi_proof::<F, H, _>(
             &storage,
             watermark,
@@ -215,7 +205,6 @@ where
     ) -> Result<usize, QmdbError> {
         let operation = load_auth_operation_at::<F, immutable::Operation<F, K, E>>(
             session,
-            AuthenticatedBackendNamespace::Immutable,
             watermark,
             &self.operation_cfg,
         )
@@ -235,19 +224,17 @@ where
         start_location: Location<F>,
         max_locations: u32,
     ) -> Result<OperationRangeCheckpoint<H::Digest, F>, QmdbError> {
-        let namespace = AuthenticatedBackendNamespace::Immutable;
-        require_published_auth_watermark(session, namespace, watermark).await?;
+        require_published_auth_watermark(session, watermark).await?;
         let end = crate::proof::resolve_range_bounds(watermark, start_location, max_locations)?;
-        let storage = AuthKvMerkleStorage::<F, H::Digest> {
+        let storage = KvMerkleStorage::<F, H::Digest> {
             session,
-            namespace,
             size: merkle_size_for_watermark(watermark)?,
             _marker: PhantomData::<H::Digest>,
         };
         let inactive_peaks = self.inactive_peaks_at(session, watermark).await?;
-        let root = compute_auth_root::<F, H>(session, namespace, watermark, inactive_peaks).await?;
+        let root = compute_auth_root::<F, H>(session, watermark, inactive_peaks).await?;
         let encoded_operations =
-            load_auth_operation_bytes_range(session, namespace, start_location, end).await?;
+            load_auth_operation_bytes_range(session, start_location, end).await?;
         crate::proof::build_operation_range_checkpoint::<F, H, _>(
             &storage,
             watermark,

--- a/qmdb/rs/src/keyless.rs
+++ b/qmdb/rs/src/keyless.rs
@@ -11,7 +11,6 @@ use commonware_storage::{
 };
 use exoware_sdk::{PrefixedStoreClient, SerializableReadSession};
 
-use crate::auth::AuthenticatedBackendNamespace;
 use crate::auth::{
     auth_inactive_peaks, compute_auth_root, load_auth_operation_at,
     load_auth_operation_bytes_range, read_latest_auth_watermark, require_published_auth_watermark,
@@ -21,7 +20,7 @@ use crate::connect::OperationKv;
 use crate::core::retry_transient_post_ingest_query;
 use crate::error::QmdbError;
 use crate::proof::{OperationRangeCheckpoint, RawBatchMultiProof, VerifiedOperationRange};
-use crate::storage::AuthKvMerkleStorage;
+use crate::storage::KvMerkleStorage;
 
 #[derive(Clone)]
 pub struct KeylessClient<
@@ -99,20 +98,16 @@ where
     pub async fn writer_location_watermark(&self) -> Result<Option<Location<F>>, QmdbError> {
         retry_transient_post_ingest_query(|| {
             let session = self.client.create_session();
-            async move {
-                read_latest_auth_watermark::<F>(&session, AuthenticatedBackendNamespace::Keyless)
-                    .await
-            }
+            async move { read_latest_auth_watermark::<F>(&session).await }
         })
         .await
     }
 
     pub async fn root_at(&self, watermark: Location<F>) -> Result<H::Digest, QmdbError> {
-        let namespace = AuthenticatedBackendNamespace::Keyless;
         let session = self.client.create_session();
-        require_published_auth_watermark(&session, namespace, watermark).await?;
+        require_published_auth_watermark(&session, watermark).await?;
         let inactive_peaks = self.inactive_peaks_at(&session, watermark).await?;
-        compute_auth_root::<F, H>(&session, namespace, watermark, inactive_peaks).await
+        compute_auth_root::<F, H>(&session, watermark, inactive_peaks).await
     }
 
     pub async fn get_at(
@@ -120,9 +115,8 @@ where
         location: Location<F>,
         watermark: Location<F>,
     ) -> Result<Option<V>, QmdbError> {
-        let namespace = AuthenticatedBackendNamespace::Keyless;
         let session = self.client.create_session();
-        require_published_auth_watermark(&session, namespace, watermark).await?;
+        require_published_auth_watermark(&session, watermark).await?;
         let count = watermark
             .checked_add(1)
             .ok_or_else(|| QmdbError::CorruptData("watermark overflow".to_string()))?;
@@ -132,13 +126,9 @@ where
                 count: count.as_u64(),
             });
         }
-        let operation = load_auth_operation_at::<F, keyless::Operation<F, E>>(
-            &session,
-            namespace,
-            location,
-            &self.op_cfg,
-        )
-        .await?;
+        let operation =
+            load_auth_operation_at::<F, keyless::Operation<F, E>>(&session, location, &self.op_cfg)
+                .await?;
         Ok(operation.into_value())
     }
 
@@ -164,20 +154,17 @@ where
         watermark: Location<F>,
         operations: Vec<(Location<F>, Vec<u8>)>,
     ) -> Result<RawBatchMultiProof<H::Digest, F>, QmdbError> {
-        let namespace = AuthenticatedBackendNamespace::Keyless;
         let session = self
             .client
             .create_session_with_sequence(read_floor_sequence);
-        require_published_auth_watermark(&session, namespace, watermark).await?;
-        let storage = AuthKvMerkleStorage::<F, H::Digest> {
+        require_published_auth_watermark(&session, watermark).await?;
+        let storage = KvMerkleStorage::<F, H::Digest> {
             session: &session,
-            namespace,
             size: merkle_size_for_watermark(watermark)?,
             _marker: PhantomData::<H::Digest>,
         };
         let inactive_peaks = self.inactive_peaks_at(&session, watermark).await?;
-        let root =
-            compute_auth_root::<F, H>(&session, namespace, watermark, inactive_peaks).await?;
+        let root = compute_auth_root::<F, H>(&session, watermark, inactive_peaks).await?;
         crate::proof::build_batch_multi_proof::<F, H, _>(
             &storage,
             watermark,
@@ -193,13 +180,9 @@ where
         session: &SerializableReadSession,
         watermark: Location<F>,
     ) -> Result<usize, QmdbError> {
-        let operation = load_auth_operation_at::<F, keyless::Operation<F, E>>(
-            session,
-            AuthenticatedBackendNamespace::Keyless,
-            watermark,
-            &self.op_cfg,
-        )
-        .await?;
+        let operation =
+            load_auth_operation_at::<F, keyless::Operation<F, E>>(session, watermark, &self.op_cfg)
+                .await?;
         let keyless::Operation::Commit(_, floor) = operation else {
             return Err(QmdbError::CorruptData(format!(
                 "keyless watermark {watermark} does not point at a Commit operation"
@@ -215,19 +198,17 @@ where
         start_location: Location<F>,
         max_locations: u32,
     ) -> Result<OperationRangeCheckpoint<H::Digest, F>, QmdbError> {
-        let namespace = AuthenticatedBackendNamespace::Keyless;
-        require_published_auth_watermark(session, namespace, watermark).await?;
+        require_published_auth_watermark(session, watermark).await?;
         let end = crate::proof::resolve_range_bounds(watermark, start_location, max_locations)?;
-        let storage = AuthKvMerkleStorage::<F, H::Digest> {
+        let storage = KvMerkleStorage::<F, H::Digest> {
             session,
-            namespace,
             size: merkle_size_for_watermark(watermark)?,
             _marker: PhantomData::<H::Digest>,
         };
         let inactive_peaks = self.inactive_peaks_at(session, watermark).await?;
-        let root = compute_auth_root::<F, H>(session, namespace, watermark, inactive_peaks).await?;
+        let root = compute_auth_root::<F, H>(session, watermark, inactive_peaks).await?;
         let encoded_operations =
-            load_auth_operation_bytes_range(session, namespace, start_location, end).await?;
+            load_auth_operation_bytes_range(session, start_location, end).await?;
         crate::proof::build_operation_range_checkpoint::<F, H, _>(
             &storage,
             watermark,

--- a/qmdb/rs/src/storage.rs
+++ b/qmdb/rs/src/storage.rs
@@ -8,8 +8,6 @@ use commonware_storage::merkle::{
 use commonware_storage::qmdb::current::grafting;
 use exoware_sdk::{RangeMode, SerializableReadSession};
 
-use crate::auth::encode_auth_node_key;
-use crate::auth::AuthenticatedBackendNamespace;
 use crate::codec::{encode_grafted_node_key, encode_node_key};
 
 pub(crate) struct KvMerkleStorage<'a, F: Family, D: Digest> {
@@ -128,37 +126,3 @@ impl<F: Graftable, D: Digest, const N: usize> MerkleStorage<F> for KvCurrentStor
     }
 }
 
-pub(crate) struct AuthKvMerkleStorage<'a, F: Family, D: Digest> {
-    pub(crate) session: &'a SerializableReadSession,
-    pub(crate) namespace: AuthenticatedBackendNamespace,
-    pub(crate) size: Position<F>,
-    pub(crate) _marker: PhantomData<D>,
-}
-
-impl<F: Family, D: Digest> MerkleStorage<F> for AuthKvMerkleStorage<'_, F, D> {
-    type Digest = D;
-
-    fn size(&self) -> Position<F> {
-        self.size
-    }
-
-    async fn get_node(&self, position: Position<F>) -> Result<Option<D>, merkle::Error<F>> {
-        let key = encode_auth_node_key(self.namespace, position);
-        let bytes = self
-            .session
-            .get(&key)
-            .await
-            .map_err(|_| merkle::Error::DataCorrupted("exoware-qmdb node fetch failed"))?;
-        let Some(bytes) = bytes else {
-            return Ok(None);
-        };
-        if bytes.len() != D::SIZE {
-            return Err(merkle::Error::DataCorrupted(
-                "exoware-qmdb node digest has invalid length",
-            ));
-        }
-        let digest = D::decode(bytes.as_ref())
-            .map_err(|_| merkle::Error::DataCorrupted("exoware-qmdb node digest decode failed"))?;
-        Ok(Some(digest))
-    }
-}

--- a/qmdb/rs/src/storage.rs
+++ b/qmdb/rs/src/storage.rs
@@ -125,4 +125,3 @@ impl<F: Graftable, D: Digest, const N: usize> MerkleStorage<F> for KvCurrentStor
         })
     }
 }
-

--- a/qmdb/rs/src/subscription.rs
+++ b/qmdb/rs/src/subscription.rs
@@ -6,10 +6,6 @@ use exoware_sdk::selector::Selector;
 use exoware_sdk::stream_filter::StreamFilter;
 use exoware_sdk::{PrefixedStoreClient, StreamSubscription};
 
-use crate::auth::{
-    decode_auth_operation_location, decode_auth_presence_location, decode_auth_watermark_location,
-    AuthenticatedBackendNamespace,
-};
 use crate::codec::{
     decode_operation_location_key, decode_presence_location, decode_watermark_location,
     OPERATION_PREFIX, PRESENCE_PREFIX, WATERMARK_PREFIX,
@@ -55,12 +51,8 @@ pub(crate) async fn open_store_subscription(
 }
 
 /// Build the classifier + stream filter selecting the Op / Presence /
-/// Watermark rows of a QMDB backend's historical op log. Pass
-/// `Some(namespace)` for the authenticated backends (immutable, keyless) and
-/// `None` for the plain-store backends (ordered, unordered).
-pub(crate) fn classify_and_filter<F: Family>(
-    namespace: Option<AuthenticatedBackendNamespace>,
-) -> (RowClassifier<F>, StreamFilter) {
+/// Watermark rows of a QMDB backend's historical op log.
+pub(crate) fn classify_and_filter<F: Family>() -> (RowClassifier<F>, StreamFilter) {
     use exoware_sdk::keys::{Key as StoreKey, Prefix};
     use exoware_sdk::kv_codec::Utf8;
 
@@ -70,57 +62,28 @@ pub(crate) fn classify_and_filter<F: Family>(
         decode: Arc<dyn Fn(&StoreKey) -> Option<Location<F>> + Send + Sync>,
     }
 
-    // The family byte encodes row semantics and is shared across every backend
-    // variant, so the Op / Presence / Watermark stream-filter prefixes are
-    // identical for the merkleized and authenticated backends. Only the
-    // per-namespace payload layout (payload_regex) and the namespace-aware row
-    // decoders still differ, so those stay inside the match.
     let op_prefix = OPERATION_PREFIX.as_bytes().clone();
     let presence_prefix = PRESENCE_PREFIX.as_bytes().clone();
     let watermark_prefix = WATERMARK_PREFIX.as_bytes().clone();
 
-    let (compiled, payload_regex) = match namespace {
-        None => {
-            let compiled: [RowRule<F>; 3] = [
-                RowRule {
-                    prefix: OPERATION_PREFIX,
-                    family: RowFamily::Op,
-                    decode: Arc::new(|key| decode_operation_location_key::<F>(key).ok()),
-                },
-                RowRule {
-                    prefix: PRESENCE_PREFIX,
-                    family: RowFamily::Presence,
-                    decode: Arc::new(|key| decode_presence_location::<F>(key).ok()),
-                },
-                RowRule {
-                    prefix: WATERMARK_PREFIX,
-                    family: RowFamily::Watermark,
-                    decode: Arc::new(|key| decode_watermark_location::<F>(key).ok()),
-                },
-            ];
-            (compiled, "(?s-u)^.{8}$".to_string())
-        }
-        Some(ns) => {
-            let compiled: [RowRule<F>; 3] = [
-                RowRule {
-                    prefix: OPERATION_PREFIX,
-                    family: RowFamily::Op,
-                    decode: Arc::new(move |key| decode_auth_operation_location::<F>(ns, key).ok()),
-                },
-                RowRule {
-                    prefix: PRESENCE_PREFIX,
-                    family: RowFamily::Presence,
-                    decode: Arc::new(move |key| decode_auth_presence_location::<F>(ns, key).ok()),
-                },
-                RowRule {
-                    prefix: WATERMARK_PREFIX,
-                    family: RowFamily::Watermark,
-                    decode: Arc::new(move |key| decode_auth_watermark_location::<F>(ns, key).ok()),
-                },
-            ];
-            (compiled, format!(r"(?s-u)^\x{:02X}.{{8}}$", ns.tag()))
-        }
-    };
+    let compiled: [RowRule<F>; 3] = [
+        RowRule {
+            prefix: OPERATION_PREFIX,
+            family: RowFamily::Op,
+            decode: Arc::new(|key| decode_operation_location_key::<F>(key).ok()),
+        },
+        RowRule {
+            prefix: PRESENCE_PREFIX,
+            family: RowFamily::Presence,
+            decode: Arc::new(|key| decode_presence_location::<F>(key).ok()),
+        },
+        RowRule {
+            prefix: WATERMARK_PREFIX,
+            family: RowFamily::Watermark,
+            decode: Arc::new(|key| decode_watermark_location::<F>(key).ok()),
+        },
+    ];
+    let payload_regex = "(?s-u)^.{8}$".to_string();
 
     let classify = RowClassifier::new(move |key: &StoreKey, _value: &[u8]| {
         for rule in &compiled {
@@ -158,10 +121,6 @@ mod tests {
     use exoware_sdk::selector::compile_payload_regex;
 
     use super::{classify_and_filter, RowFamily};
-    use crate::auth::{
-        encode_auth_operation_key, encode_auth_presence_key, encode_auth_watermark_key,
-        AuthenticatedBackendNamespace,
-    };
     use crate::codec::{encode_operation_key, encode_presence_key, encode_watermark_key};
 
     const LOCATIONS: [u64; 4] = [0, 1, 0x0102_0304_0506_0708, u64::MAX];
@@ -170,22 +129,16 @@ mod tests {
     // drops any row a selector fails to match, so pin them together: every
     // Op / Presence / Watermark key the codec can produce must match its
     // selector's regex in full and classify to the same family and location.
-    fn assert_rows_match_filter(namespace: Option<AuthenticatedBackendNamespace>) {
-        let (classifier, filter) = classify_and_filter::<mmr::Family>(namespace);
+    #[test]
+    fn backend_selectors_match_their_row_payloads() {
+        let (classifier, filter) = classify_and_filter::<mmr::Family>();
         for location in LOCATIONS {
             let loc = Location::new(location);
-            let rows: [(RowFamily, Key); 3] = match namespace {
-                None => [
-                    (RowFamily::Op, encode_operation_key(loc)),
-                    (RowFamily::Presence, encode_presence_key(loc)),
-                    (RowFamily::Watermark, encode_watermark_key(loc)),
-                ],
-                Some(ns) => [
-                    (RowFamily::Op, encode_auth_operation_key(ns, loc)),
-                    (RowFamily::Presence, encode_auth_presence_key(ns, loc)),
-                    (RowFamily::Watermark, encode_auth_watermark_key(ns, loc)),
-                ],
-            };
+            let rows: [(RowFamily, Key); 3] = [
+                (RowFamily::Op, encode_operation_key(loc)),
+                (RowFamily::Presence, encode_presence_key(loc)),
+                (RowFamily::Watermark, encode_watermark_key(loc)),
+            ];
             for (family, key) in rows {
                 let selector = filter
                     .selectors
@@ -201,38 +154,5 @@ mod tests {
                 assert_eq!(classifier.classify(&key, &[]), Some((family, loc)));
             }
         }
-    }
-
-    #[test]
-    fn plain_backend_selectors_match_their_row_payloads() {
-        assert_rows_match_filter(None);
-    }
-
-    #[test]
-    fn authenticated_backend_selectors_match_their_row_payloads() {
-        assert_rows_match_filter(Some(AuthenticatedBackendNamespace::Immutable));
-        assert_rows_match_filter(Some(AuthenticatedBackendNamespace::Keyless));
-    }
-
-    // Plain payloads are a bare 8-byte location; authenticated payloads
-    // prepend a namespace tag. Each selector shape must reject the others so a
-    // subscription never claims rows from a differently-shaped backend.
-    #[test]
-    fn selectors_reject_payloads_of_the_other_shape() {
-        let loc = Location::<mmr::Family>::new(7);
-        let (_, plain) = classify_and_filter::<mmr::Family>(None);
-        let (_, auth) =
-            classify_and_filter::<mmr::Family>(Some(AuthenticatedBackendNamespace::Immutable));
-        let plain_key = encode_operation_key(loc);
-        let immutable_key =
-            encode_auth_operation_key(AuthenticatedBackendNamespace::Immutable, loc);
-        let keyless_key = encode_auth_operation_key(AuthenticatedBackendNamespace::Keyless, loc);
-        let plain_regex = compile_payload_regex(&plain.selectors[0].payload_regex).expect("regex");
-        let auth_regex = compile_payload_regex(&auth.selectors[0].payload_regex).expect("regex");
-        assert!(plain_regex.is_match(&plain_key[1..]));
-        assert!(!plain_regex.is_match(&immutable_key[1..]));
-        assert!(auth_regex.is_match(&immutable_key[1..]));
-        assert!(!auth_regex.is_match(&keyless_key[1..]));
-        assert!(!auth_regex.is_match(&plain_key[1..]));
     }
 }

--- a/qmdb/rs/src/writer/immutable.rs
+++ b/qmdb/rs/src/writer/immutable.rs
@@ -18,16 +18,12 @@ use exoware_sdk::{
 };
 use futures::future::BoxFuture;
 
-use crate::auth::{
-    build_auth_immutable_upload_rows, encode_auth_node_key, encode_auth_watermark_key,
-    AuthenticatedBackendNamespace,
-};
+use crate::auth::build_auth_immutable_upload_rows;
+use crate::codec::{encode_node_key, encode_watermark_key};
 use crate::core::extend_merkle_from_peaks_with_inactive_peaks;
 use crate::error::QmdbError;
 use crate::writer::core::{Cache, WriterCore};
 use crate::{PublishedCheckpoint, UploadReceipt, WriterState};
-
-const NAMESPACE: AuthenticatedBackendNamespace = AuthenticatedBackendNamespace::Immutable;
 
 #[derive(Clone, Debug)]
 pub struct BuiltImmutableUpload<D, F: Family> {
@@ -70,13 +66,10 @@ where
     let keyed_operation_count = prepared.keyed_operation_count;
     let mut rows = prepared.into_all_rows();
     for (pos, digest) in &ext.new_nodes {
-        rows.push((
-            encode_auth_node_key(NAMESPACE, *pos),
-            digest.as_ref().to_vec(),
-        ));
+        rows.push((encode_node_key(*pos), digest.as_ref().to_vec()));
     }
     if let Some(loc) = watermark_at {
-        rows.push((encode_auth_watermark_key(NAMESPACE, loc), Vec::new()));
+        rows.push((encode_watermark_key(loc), Vec::new()));
     }
     Ok(BuiltImmutableUpload {
         rows,
@@ -224,7 +217,7 @@ where
         };
         Ok(Some(super::PreparedWatermark::<F> {
             location: target,
-            row: (encode_auth_watermark_key(NAMESPACE, target), Vec::new()),
+            row: (encode_watermark_key(target), Vec::new()),
         }))
     }
 
@@ -248,7 +241,7 @@ where
         };
         Ok(Some(super::PreparedWatermark::<F> {
             location: target,
-            row: (encode_auth_watermark_key(NAMESPACE, target), Vec::new()),
+            row: (encode_watermark_key(target), Vec::new()),
         }))
     }
 

--- a/qmdb/rs/src/writer/keyless.rs
+++ b/qmdb/rs/src/writer/keyless.rs
@@ -16,16 +16,12 @@ use exoware_sdk::{
 };
 use futures::future::BoxFuture;
 
-use crate::auth::{
-    build_auth_upload_rows, encode_auth_node_key, encode_auth_watermark_key,
-    AuthenticatedBackendNamespace,
-};
+use crate::auth::build_auth_upload_rows;
+use crate::codec::{encode_node_key, encode_watermark_key};
 use crate::core::extend_merkle_from_peaks_with_inactive_peaks;
 use crate::error::QmdbError;
 use crate::writer::core::{Cache, WriterCore};
 use crate::{PublishedCheckpoint, UploadReceipt, WriterState};
-
-const NAMESPACE: AuthenticatedBackendNamespace = AuthenticatedBackendNamespace::Keyless;
 
 /// Deterministic output of a keyless row-build.
 #[derive(Clone, Debug)]
@@ -64,7 +60,7 @@ where
         return Err(QmdbError::EmptyBatch);
     }
     let encoded: Vec<Vec<u8>> = ops.iter().map(|op| op.encode().to_vec()).collect();
-    let prepared = build_auth_upload_rows(NAMESPACE, latest_location, encoded)?;
+    let prepared = build_auth_upload_rows(latest_location, encoded)?;
     let inactive_peaks = keyless_inactive_peaks(latest_location, ops)?;
     let ext = extend_merkle_from_peaks_with_inactive_peaks::<F, H, _>(
         peaks,
@@ -75,13 +71,10 @@ where
     let operation_count = prepared.operation_count;
     let mut rows = prepared.into_all_rows();
     for (pos, digest) in &ext.new_nodes {
-        rows.push((
-            encode_auth_node_key(NAMESPACE, *pos),
-            digest.as_ref().to_vec(),
-        ));
+        rows.push((encode_node_key(*pos), digest.as_ref().to_vec()));
     }
     if let Some(loc) = watermark_at {
-        rows.push((encode_auth_watermark_key(NAMESPACE, loc), Vec::new()));
+        rows.push((encode_watermark_key(loc), Vec::new()));
     }
     Ok(BuiltKeylessUpload {
         rows,
@@ -258,7 +251,7 @@ where
         };
         Ok(Some(super::PreparedWatermark::<F> {
             location: target,
-            row: (encode_auth_watermark_key(NAMESPACE, target), Vec::new()),
+            row: (encode_watermark_key(target), Vec::new()),
         }))
     }
 
@@ -282,7 +275,7 @@ where
         };
         Ok(Some(super::PreparedWatermark::<F> {
             location: target,
-            row: (encode_auth_watermark_key(NAMESPACE, target), Vec::new()),
+            row: (encode_watermark_key(target), Vec::new()),
         }))
     }
 


### PR DESCRIPTION
Resolves #96 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes on-disk key encoding for immutable/keyless authenticated data—existing stores written with namespace-tagged keys would be unreadable without migration, though isolation via `PrefixedStoreClient` is the intended model.
> 
> **Overview**
> **Removes `AuthenticatedBackendNamespace`** and all auth-specific key helpers (namespaced operation/presence/watermark/node encode/decode, bounds checks, and `AuthKvMerkleStorage`). Immutable and keyless paths now use the same **`encode_*` / `decode_*` helpers** as ordered/unordered and no longer take a namespace argument on auth helpers (`read_latest_auth_watermark`, `compute_auth_root`, upload row builders, etc.).
> 
> **Connect and subscriptions** drop per-backend `classify_and_filter` wiring; **`OperationLogService::subscribe`** always builds filters via **`sub::classify_and_filter()`** with a single 8-byte payload regex (no Immutable vs Keyless tag in keys). **Writers** for immutable/keyless stage Merkle and watermark rows with **`encode_node_key` / `encode_watermark_key`** instead of namespaced auth keys.
> 
> Subscription tests are collapsed to one selector shape; tests that enforced plain vs authenticated payload isolation are removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36e2fc060fde18f786db191e86bee2f712955a31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->