### PR TITLE
move log retention into wal spec, enforce latest N

### DIFF
--- a/examples/simulator/Cargo.toml
+++ b/examples/simulator/Cargo.toml
@@ -14,6 +14,7 @@ documentation = "https://docs.rs/exoware-simulator"
 axum = { workspace = true }
 buffa = { workspace = true }
 bytes = { workspace = true }
+commonware-codec = { workspace = true }
 exoware-sdk = { workspace = true }
 exoware-server = { workspace = true }
 mimalloc = { workspace = true }
@@ -29,7 +30,6 @@ clap = { workspace = true }
 tower-http = { workspace = true }
 
 [dev-dependencies]
-commonware-codec = { workspace = true }
 connectrpc = { workspace = true }
 http = { workspace = true }
 

--- a/examples/simulator/src/lib.rs
+++ b/examples/simulator/src/lib.rs
@@ -3,7 +3,7 @@
 pub mod rocks;
 pub mod server;
 
-pub use exoware_server::{connect_stack, AppState, Ingest, Log, Prune, Query, Sequence};
+pub use exoware_server::{connect_stack, AppState, Ingest, Log, Prune, Query, Retention, Sequence};
 pub use rocks::{RocksConfig, RocksStore, RocksWritePipelineConfig};
 pub use rocksdb;
 pub use server::{open_temp, run, CMD, RUN_CMD};

--- a/examples/simulator/src/rocks.rs
+++ b/examples/simulator/src/rocks.rs
@@ -356,8 +356,8 @@ struct Frontiers {
     /// Highest `cutoff_exclusive` already applied by `prune_log` in this process. Lets the
     /// per-append retention hook skip the write entirely when the floor has not advanced
     /// (static thresholds, coalesced ingest waves), so redundant range tombstones never pile
-    /// up ahead of compaction. Starts at zero on open; the first trim after a reopen rewrites
-    /// one already-applied tombstone, which is harmless.
+    /// up ahead of compaction. Starts at zero; open's one-shot enforcement re-seeds it
+    /// when a rule is installed.
     trimmed: AtomicU64,
 }
 
@@ -1055,12 +1055,19 @@ impl RocksStore {
             frontiers.clone(),
             write_pipeline,
         ));
-        Ok(Self {
+        let store = Self {
             db,
             frontiers,
             writer,
             retention,
-        })
+        };
+        // Re-apply the rule against the reopened log before serving reads: a crash can
+        // lose the last (unsynced) trim, and a batch observed as evicted must never
+        // become readable again.
+        if store.retention.lock().is_some() {
+            store.enforce_retention()?;
+        }
+        Ok(store)
     }
 
     /// Returns the log column-family handle created during open.
@@ -1708,6 +1715,33 @@ mod tests {
         assert_eq!(
             store.oldest_retained_batch().await.expect("oldest"),
             Some(second)
+        );
+    }
+
+    #[tokio::test]
+    async fn reopen_enforces_restored_retention_rule() {
+        let dir = tempdir().expect("tempdir");
+        let (first, second, third) = {
+            let store = RocksStore::open(dir.path(), None).expect("open db");
+            let first = store.put_batch(large_batch(1)).await.expect("put");
+            let second = store.put_batch(large_batch(2)).await.expect("put");
+            let third = store.put_batch(large_batch(3)).await.expect("put");
+            // Persist the rule without running its enforcement, leaving rows below the
+            // rule's floor in the log — the state a crash that lost the last (unsynced)
+            // trim leaves behind.
+            store
+                .store_retention_policy(Some(&RetentionPolicy::KeepLatest { count: 1 }))
+                .expect("store policy");
+            (first, second, third)
+        };
+
+        let store = RocksStore::open(dir.path(), None).expect("reopen db");
+        for evicted in [first, second] {
+            assert!(store.get_batch(evicted).await.expect("get").is_none());
+        }
+        assert_eq!(
+            store.oldest_retained_batch().await.expect("oldest"),
+            Some(third)
         );
     }
 

--- a/examples/simulator/src/rocks.rs
+++ b/examples/simulator/src/rocks.rs
@@ -16,9 +16,11 @@
 //! atomic and strictly ordered, so a crash never leaves a partial batch and at most the
 //! newest ingested group can be missing its state ingestion; `open` repairs that by
 //! re-applying the newest retained log row (idempotent: its rows are the newest writes for
-//! their keys). The floor meta row is written only by pruning and is durable by the time a
-//! prune acks: it marks state the replay must never touch (re-applying key-pruned rows would
-//! resurrect them) and keeps a fully-pruned log from regressing the frontier.
+//! their keys). The floor meta row is written by key pruning and by sequence-log retention
+//! enforcement, and is durable by the time either acks: it marks state the replay must never
+//! touch (re-applying key-pruned rows would resurrect them) and keeps a fully-evicted log from
+//! regressing the frontier. A separate meta row persists the active retention rule (see the
+//! [`Retention`] impl), which the ingest path re-enforces continuously as the log grows.
 //!
 //! Any write failure in the pipeline is fatal: once a group's log row is durable it cannot be
 //! rolled back (its sequence number must never be re-issued), so the writer panics and the next
@@ -34,18 +36,18 @@ use std::thread;
 
 use buffa::{Message, MessageView};
 use bytes::Bytes;
+use commonware_codec::{DecodeExt, Encode};
 use exoware_sdk::common::kv::v1::Entry;
 use exoware_sdk::keys::Prefix;
 use exoware_sdk::log::stream::v1::{
     GetResponse as StreamGetResponse, GetResponseView as StreamGetResponseView,
 };
-use exoware_sdk::prune_policy::{
-    KeysScope, OrderEncoding, PolicyScope, PrunePolicyDocument, RetainPolicy,
-};
+use exoware_sdk::prune_policy::{KeysScope, OrderEncoding, PrunePolicyDocument, RetainPolicy};
+use exoware_sdk::retention::RetentionPolicy;
 use exoware_sdk::selector::compile_payload_regex;
 use exoware_server::{
     Ingest, IngestError, Log, LogBatch, Prune, Query, QueryExtra, RangeScan, RangeScanBatch,
-    Sequence,
+    Retention, Sequence,
 };
 use parking_lot::Mutex;
 use regex::bytes::Regex;
@@ -59,6 +61,9 @@ use tracing::debug;
 const STATE_CF: &str = rocksdb::DEFAULT_COLUMN_FAMILY_NAME;
 const META_CF: &str = "meta";
 const SEQ_META_KEY: &[u8] = b"sequence";
+/// Meta row holding the active sequence-log retention rule (the codec-encoded
+/// [`RetentionPolicy`]). Absence of the row means no rule is installed.
+const RETENTION_META_KEY: &[u8] = b"retention";
 const PRUNE_SCAN_BATCH_SIZE: usize = 4096;
 const PRUNE_DELETE_CHUNK_KEYS: usize = 4096;
 const DEFAULT_COMMIT_COALESCE_MAX_BATCH_BYTES: usize = 16 * 1024 * 1024;
@@ -348,6 +353,12 @@ struct Frontiers {
     /// loads `published` under it sees a frontier covering every row its scan could have
     /// observed.
     persist: Mutex<()>,
+    /// Highest `cutoff_exclusive` already applied by `prune_log` in this process. Lets the
+    /// per-append retention hook skip the write entirely when the floor has not advanced
+    /// (static thresholds, coalesced ingest waves), so redundant range tombstones never pile
+    /// up ahead of compaction. Starts at zero on open; the first trim after a reopen rewrites
+    /// one already-applied tombstone, which is harmless.
+    trimmed: AtomicU64,
 }
 
 impl Frontiers {
@@ -355,6 +366,7 @@ impl Frontiers {
         Self {
             published: AtomicU64::new(published),
             persist: Mutex::new(()),
+            trimmed: AtomicU64::new(0),
         }
     }
 }
@@ -821,6 +833,35 @@ fn read_state_floor(db: &DB) -> Result<u64, String> {
     }
 }
 
+/// Reads the persisted retention rule. Absence of the row means no rule is installed (a cleared
+/// rule deletes the row), so enforcement stops. A malformed row is corruption and fails the open.
+fn read_retention_policy(db: &DB) -> Result<Option<RetentionPolicy>, String> {
+    let meta_cf = db
+        .cf_handle(META_CF)
+        .expect("meta CF must exist (created on open)");
+    match db
+        .get_cf(meta_cf, RETENTION_META_KEY)
+        .map_err(|e| e.to_string())?
+    {
+        Some(bytes) => RetentionPolicy::decode(bytes.as_slice())
+            .map(Some)
+            .map_err(|e| format!("corrupt retention rule meta row: {e}")),
+        None => Ok(None),
+    }
+}
+
+/// Lowest sequence a retention rule keeps against `frontier`: the exclusive cutoff for log
+/// trimming, so every row below it is evicted and the row at it (if any) is the oldest retained.
+/// Mirrors the floor math the stream service owns end to end.
+fn retention_floor(policy: &RetentionPolicy, frontier: u64) -> u64 {
+    match policy {
+        RetentionPolicy::KeepLatest { count } => frontier.saturating_sub(*count).saturating_add(1),
+        RetentionPolicy::GreaterThan { threshold } => threshold.saturating_add(1),
+        RetentionPolicy::GreaterThanOrEqual { threshold } => *threshold,
+        RetentionPolicy::DropAll => frontier.saturating_add(1),
+    }
+}
+
 /// Re-applies the newest retained log row to the state column family and returns its sequence
 /// (zero when the log is empty). Rows are only ever ingested by sequential, atomic commits, so
 /// the returned sequence is a lower bound on the durable frontier. `commit` ingests strictly
@@ -939,6 +980,10 @@ pub struct RocksStore {
     writer: Arc<Writer>,
     db: Arc<Database>,
     frontiers: Arc<Frontiers>,
+    /// In-memory mirror of the persisted retention rule (the meta row is the source of truth
+    /// across reopens). The ingest path reads it on every commit to trim continuously, so a
+    /// cheap cache keeps a rule-less store off the disk on that hot path.
+    retention: Arc<Mutex<Option<RetentionPolicy>>>,
 }
 
 impl RocksStore {
@@ -1000,6 +1045,9 @@ impl RocksStore {
         let floor = read_state_floor(&db)?;
         let seq = floor.max(replay_newest_log_row(&db, floor)?);
 
+        // Restore the retention rule so the ingest path keeps enforcing it after a reopen.
+        let retention = Arc::new(Mutex::new(read_retention_policy(&db)?));
+
         let frontiers = Arc::new(Frontiers::new(seq));
         let writer = Arc::new(Writer::start(
             db.clone(),
@@ -1011,6 +1059,7 @@ impl RocksStore {
             db,
             frontiers,
             writer,
+            retention,
         })
     }
 
@@ -1075,21 +1124,34 @@ impl RocksStore {
         Ok(())
     }
 
-    /// Deletes replay-log rows with sequence numbers below `cutoff_exclusive`.
+    /// Deletes replay-log rows with sequence numbers below `cutoff_exclusive`. A no-op when
+    /// the cutoff does not advance past what this process already trimmed.
     fn prune_log(&self, cutoff_exclusive: u64) -> Result<(), String> {
-        if cutoff_exclusive == 0 {
+        if cutoff_exclusive == 0
+            || self.frontiers.trimmed.load(Ordering::Acquire) >= cutoff_exclusive
+        {
             return Ok(());
         }
         let _guard = self.frontiers.persist.lock();
+        // Recheck under the lock: a concurrent trim from the same ingest wave may have
+        // covered this cutoff while we waited.
+        if self.frontiers.trimmed.load(Ordering::Acquire) >= cutoff_exclusive {
+            return Ok(());
+        }
 
-        // One synced, atomic batch: the range tombstone that deletes the rows, and the state
-        // floor that keeps `open` from re-deriving a regressed frontier once they are gone.
+        // One atomic batch: the range tombstone that deletes the rows, and the state floor
+        // that keeps `open` from re-deriving a regressed frontier once they are gone.
         // The published frontier covers every pruned row (the cutoff is capped at
         // published + 1), and everything at or below it is durable and applied to the state.
         // That also makes this safe against the writer's concurrent, lock-free log ingestion:
         // an in-flight group's row sits above every published frontier this prune could have
         // loaded. Space is reclaimed by ordinary compaction; nothing assumes which SST files
         // hold the rows.
+        //
+        // Unsynced: batch atomicity means a crash loses the tombstone and the floor raise
+        // together, leaving the rows intact and open's re-derivation consistent; the next
+        // enforcement reapplies the trim. This keeps the per-append retention hook from
+        // adding a second fsync to every ingest.
         let published = self.frontiers.published.load(Ordering::Acquire);
         let mut batch = rocksdb::WriteBatch::default();
         batch.put_cf(self.meta_cf(), SEQ_META_KEY, published.to_le_bytes());
@@ -1098,20 +1160,19 @@ impl RocksStore {
             sequence_log_key(0),
             sequence_log_key(cutoff_exclusive),
         );
-        write_synced_batch(&self.db, batch)
+        self.db.write(batch).map_err(|e| e.to_string())?;
+        self.frontiers
+            .trimmed
+            .store(cutoff_exclusive, Ordering::Release);
+        Ok(())
     }
 
-    /// Applies each prune policy in document order to either current rows or replay-log rows.
+    /// Applies each prune policy in document order to current rows. A prune document is
+    /// Keys-only; sequence-log retention is handled by the stream service's `SetRetention`
+    /// (see the [`Retention`] impl).
     fn apply_prune_policies(&self, document: PrunePolicyDocument) -> Result<(), String> {
         for policy in &document.policies {
-            match &policy.scope {
-                PolicyScope::Keys(scope) => {
-                    self.apply_key_prune_policy(scope, &policy.retain)?;
-                }
-                PolicyScope::Sequence => {
-                    self.apply_sequence_prune_policy(&policy.retain)?;
-                }
-            }
+            self.apply_key_prune_policy(&policy.scope, &policy.retain)?;
         }
         Ok(())
     }
@@ -1173,24 +1234,70 @@ impl RocksStore {
         self.delete_keys(&all_deletes)
     }
 
-    /// Computes the replay-log cutoff for a sequence policy and prunes only log rows.
-    fn apply_sequence_prune_policy(&self, retain: &RetainPolicy) -> Result<(), String> {
-        let current = self.frontiers.published.load(Ordering::Acquire);
-        let cutoff_exclusive = match retain {
-            RetainPolicy::KeepLatest { count } => {
-                let count = *count as u64;
-                current.saturating_add(1).saturating_sub(count)
-            }
-            RetainPolicy::GreaterThan { threshold } => threshold.saturating_add(1),
-            RetainPolicy::GreaterThanOrEqual { threshold } => *threshold,
-            RetainPolicy::DropAll => current.saturating_add(1),
-        };
+    /// Lowest retained log sequence at or below the published frontier, or `None` when the log
+    /// holds no such row. Shared by `oldest_retained_batch` and retention enforcement.
+    fn oldest_retained_sequence(&self) -> Result<Option<u64>, String> {
+        let mut it = self.db.iterator_cf(self.log_cf(), IteratorMode::Start);
+        match it.next() {
+            None => Ok(None),
+            Some(item) => {
+                let (key, _) = item.map_err(|e| e.to_string())?;
+                let sequence = sequence_from_log_key(key.as_ref())?;
 
-        // Never delete log rows above the published frontier: a group whose log ingestion
-        // committed but whose state ingestion did not still needs its rows for the repair replay
-        // at the next open.
-        let cutoff_exclusive = cutoff_exclusive.min(current.saturating_add(1));
-        self.prune_log(cutoff_exclusive)
+                // Gate on the published frontier: never advertise an oldest batch that
+                // `get_batch` would then hide (a log row can outrun the published frontier while
+                // its group's state ingestion is in flight or has failed).
+                if sequence > self.frontiers.published.load(Ordering::Acquire) {
+                    return Ok(None);
+                }
+                Ok(Some(sequence))
+            }
+        }
+    }
+
+    /// Persists the retention rule durably, or deletes the row when clearing. A single-admin
+    /// control write, so it is synced and last-write-wins; enforcement reads go through the
+    /// in-memory cache seeded from this row at open.
+    fn store_retention_policy(&self, policy: Option<&RetentionPolicy>) -> Result<(), String> {
+        let mut batch = rocksdb::WriteBatch::default();
+        match policy {
+            Some(policy) => batch.put_cf(self.meta_cf(), RETENTION_META_KEY, policy.encode()),
+            None => batch.delete_cf(self.meta_cf(), RETENTION_META_KEY),
+        }
+        write_synced_batch(&self.db, batch)
+    }
+
+    /// Runs one round of retention enforcement against the current frontier and returns the
+    /// resulting oldest retained sequence (`None` when the log is empty / no floor exists). With
+    /// no rule installed this only reports the current oldest batch, leaving the log untouched.
+    fn enforce_retention(&self) -> Result<Option<u64>, String> {
+        // Clone the rule out in its own statement so the cache lock drops before trimming:
+        // an `if let self.retention.lock().clone()` scrutinee would (edition 2021) hold the
+        // guard for the whole block. `prune_log` takes the persist lock and issues a range
+        // delete; holding the retention mutex across that disk write would block every
+        // `put_batch` rule check on a Tokio worker.
+        let policy = self.retention.lock().clone();
+        if let Some(policy) = policy {
+            let frontier = self.frontiers.published.load(Ordering::Acquire);
+
+            // Never delete log rows above the published frontier: a group whose log ingestion
+            // committed but whose state ingestion did not still needs its rows for the repair
+            // replay at the next open.
+            let cutoff_exclusive =
+                retention_floor(&policy, frontier).min(frontier.saturating_add(1));
+            self.prune_log(cutoff_exclusive)?;
+        }
+        self.oldest_retained_sequence()
+    }
+
+    /// Installs (`Some`) or clears (`None`) the retention rule, then enforces it once. The rule
+    /// is persisted durably and mirrored into the cache the ingest path reads, so it keeps
+    /// tracking the frontier continuously; clearing stops enforcement but leaves already-evicted
+    /// rows evicted. Returns the oldest retained sequence after this enforcement.
+    fn set_retention(&self, policy: Option<RetentionPolicy>) -> Result<Option<u64>, String> {
+        self.store_retention_policy(policy.as_ref())?;
+        *self.retention.lock() = policy;
+        self.enforce_retention()
     }
 }
 
@@ -1205,7 +1312,34 @@ impl Sequence for RocksStore {
 // number and replay-log batch.
 impl Ingest for RocksStore {
     async fn put_batch(&self, kvs: Vec<(Bytes, Bytes)>) -> Result<u64, IngestError> {
-        self.writer.put_batch(kvs).await
+        let sequence = self.writer.put_batch(kvs).await?;
+
+        // Continuous retention: trim the just-grown log to the active rule's floor so the rule
+        // tracks the frontier without another RPC. The rule-less case is a cheap cache check;
+        // an installed rule takes the blocking trim (an unsynced range tombstone, skipped
+        // outright when the floor has not advanced) off the Tokio worker.
+        //
+        // Best-effort: the batch is already durably committed and acked above, so a trim failure
+        // must NOT fail the ingest. Failing here would make the caller re-ingest durable data
+        // under a fresh sequence, duplicating the batch for subscribers. The trim is idempotent,
+        // so the next append (or a `SetRetention`) reapplies it.
+        if self.retention.lock().is_some() {
+            let store = self.clone();
+            match tokio::task::spawn_blocking(move || store.enforce_retention()).await {
+                Ok(Ok(_)) => {}
+                Ok(Err(message)) => tracing::warn!(
+                    sequence,
+                    error = %message,
+                    "continuous retention trim failed after commit; batch is durable, retrying on the next append",
+                ),
+                Err(join_error) => tracing::warn!(
+                    sequence,
+                    error = %join_error,
+                    "retention enforcement task failed after commit; batch is durable, retrying on the next append",
+                ),
+            }
+        }
+        Ok(sequence)
     }
 }
 
@@ -1285,22 +1419,19 @@ impl Log for RocksStore {
     }
 
     async fn oldest_retained_batch(&self) -> Result<Option<u64>, String> {
-        let mut it = self.db.iterator_cf(self.log_cf(), IteratorMode::Start);
-        match it.next() {
-            None => Ok(None),
-            Some(item) => {
-                let (key, _) = item.map_err(|e| e.to_string())?;
-                let sequence = sequence_from_log_key(key.as_ref())?;
+        self.oldest_retained_sequence()
+    }
+}
 
-                // Gate on the published frontier like `get_batch`: never advertise an oldest
-                // batch that `get_batch` would then hide (a log row can outrun the published
-                // frontier while its group's state ingestion is in flight or has failed).
-                if sequence > self.frontiers.published.load(Ordering::Acquire) {
-                    return Ok(None);
-                }
-                Ok(Some(sequence))
-            }
-        }
+// Retention persists a rule (a synced write) and trims the sequence log, so it runs on the
+// blocking pool instead of occupying a Tokio worker. The ingest path enforces the same rule
+// continuously as the log grows (see `Ingest::put_batch`).
+impl Retention for RocksStore {
+    async fn set_retention(&self, policy: Option<RetentionPolicy>) -> Result<Option<u64>, String> {
+        let store = self.clone();
+        tokio::task::spawn_blocking(move || store.set_retention(policy))
+            .await
+            .map_err(|e| format!("retention task failed: {e}"))?
     }
 }
 
@@ -1568,16 +1699,10 @@ mod tests {
             Some(vec![1u8; 4096])
         );
 
-        // Sequence pruning deletes the rows by key; space reclamation is compaction's job.
+        // Retention evicts log rows by key; space reclamation is compaction's job.
         store
-            .apply_prune_policies(PrunePolicyDocument {
-                version: exoware_sdk::prune_policy::PRUNE_POLICY_DOCUMENT_VERSION,
-                policies: vec![exoware_sdk::prune_policy::PrunePolicy {
-                    scope: PolicyScope::Sequence,
-                    retain: RetainPolicy::KeepLatest { count: 1 },
-                }],
-            })
-            .expect("prune");
+            .set_retention(Some(RetentionPolicy::KeepLatest { count: 1 }))
+            .expect("set retention");
         assert!(store.get_batch(first).await.expect("get").is_none());
         assert!(store.get_batch(second).await.expect("get").is_some());
         assert_eq!(
@@ -1863,28 +1988,22 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn sequence_prune_spares_log_rows_above_published_frontier() {
+    async fn retention_spares_log_rows_above_published_frontier() {
         let dir = tempdir().expect("tempdir");
         let store = RocksStore::open(dir.path(), None).expect("open db");
 
         // A durable log row whose group never published (its state ingestion was in flight at
-        // a crash): pruning must spare it. It is the repair replay's input at the next open.
+        // a crash): retention must spare it. It is the repair replay's input at the next open.
         seed_log_row(&store, 1, &encoded_log_entry(1, b"k", b"v"));
 
         store
-            .apply_prune_policies(PrunePolicyDocument {
-                version: exoware_sdk::prune_policy::PRUNE_POLICY_DOCUMENT_VERSION,
-                policies: vec![exoware_sdk::prune_policy::PrunePolicy {
-                    scope: PolicyScope::Sequence,
-                    retain: RetainPolicy::DropAll,
-                }],
-            })
-            .expect("prune");
+            .set_retention(Some(RetentionPolicy::DropAll))
+            .expect("set retention");
 
         assert_eq!(
             live_log_rows(&store),
             1,
-            "unpublished log row must survive the prune"
+            "unpublished log row must survive retention enforcement"
         );
     }
 

--- a/examples/simulator/src/rocks.rs
+++ b/examples/simulator/src/rocks.rs
@@ -43,7 +43,7 @@ use exoware_sdk::log::stream::v1::{
     GetResponse as StreamGetResponse, GetResponseView as StreamGetResponseView,
 };
 use exoware_sdk::prune_policy::{KeysScope, OrderEncoding, PrunePolicyDocument, RetainPolicy};
-use exoware_sdk::retention::RetentionPolicy;
+use exoware_sdk::retention::{validate_retention_policy, RetentionPolicy};
 use exoware_sdk::selector::compile_payload_regex;
 use exoware_server::{
     Ingest, IngestError, Log, LogBatch, Prune, Query, QueryExtra, RangeScan, RangeScanBatch,
@@ -834,7 +834,9 @@ fn read_state_floor(db: &DB) -> Result<u64, String> {
 }
 
 /// Reads the persisted retention rule. Absence of the row means no rule is installed (a cleared
-/// rule deletes the row), so enforcement stops. A malformed row is corruption and fails the open.
+/// rule deletes the row), so enforcement stops. A row that fails to decode or validate is
+/// corruption and fails the open: a rule the RPC layer would reject (`keep_latest` count zero
+/// enforces like `drop_all`) must not be enforced just because it round-trips the codec.
 fn read_retention_policy(db: &DB) -> Result<Option<RetentionPolicy>, String> {
     let meta_cf = db
         .cf_handle(META_CF)
@@ -843,9 +845,13 @@ fn read_retention_policy(db: &DB) -> Result<Option<RetentionPolicy>, String> {
         .get_cf(meta_cf, RETENTION_META_KEY)
         .map_err(|e| e.to_string())?
     {
-        Some(bytes) => RetentionPolicy::decode(bytes.as_slice())
-            .map(Some)
-            .map_err(|e| format!("corrupt retention rule meta row: {e}")),
+        Some(bytes) => {
+            let policy = RetentionPolicy::decode(bytes.as_slice())
+                .map_err(|e| format!("corrupt retention rule meta row: {e}"))?;
+            validate_retention_policy(&policy)
+                .map_err(|e| format!("corrupt retention rule meta row: {e}"))?;
+            Ok(Some(policy))
+        }
         None => Ok(None),
     }
 }
@@ -1743,6 +1749,24 @@ mod tests {
             store.oldest_retained_batch().await.expect("oldest"),
             Some(third)
         );
+    }
+
+    #[tokio::test]
+    async fn reopen_rejects_invalid_persisted_retention_rule() {
+        let dir = tempdir().expect("tempdir");
+        {
+            let store = RocksStore::open(dir.path(), None).expect("open db");
+            // Bypass `set_retention` (whose callers validate) to persist a rule the RPC
+            // layer would reject: `keep_latest` count zero enforces like `drop_all`.
+            store
+                .store_retention_policy(Some(&RetentionPolicy::KeepLatest { count: 0 }))
+                .expect("store policy");
+        }
+
+        let Err(error) = RocksStore::open(dir.path(), None) else {
+            panic!("invalid rule must fail open");
+        };
+        assert!(error.contains("keep_latest count must be > 0"), "{error}");
     }
 
     /// Number of retained rows in the log column family.

--- a/examples/simulator/tests/e2e_connect.rs
+++ b/examples/simulator/tests/e2e_connect.rs
@@ -3,7 +3,7 @@ use commonware_codec::Encode;
 use connectrpc::client::ClientConfig;
 use exoware_sdk::common::Selector as ProtoSelector;
 use exoware_sdk::compact::{
-    policy, policy_retain, KeysScope as ProtoKeysScope, Policy, PolicyGroupBy, PolicyOrderBy,
+    policy_retain, KeysScope as ProtoKeysScope, Policy, PolicyGroupBy, PolicyOrderBy,
     PolicyOrderEncoding, PolicyRetain, PruneRequest, RetainGreaterThan, RetainKeepLatest,
     ServiceClient as CompactServiceClient,
 };
@@ -273,7 +273,7 @@ async fn prune_drop_all_removes_keys() {
     compact_client
         .prune(PruneRequest {
             policies: vec![Policy {
-                scope: Some(policy::Scope::Keys(Box::new(ProtoKeysScope {
+                keys: Some(ProtoKeysScope {
                     selector: Some(ProtoSelector {
                         prefix: Bytes::from(vec![1]),
                         payload_regex: "(?s-u)^.*$".to_string(),
@@ -287,7 +287,8 @@ async fn prune_drop_all_removes_keys() {
                     .into(),
                     order_by: Default::default(),
                     ..Default::default()
-                }))),
+                })
+                .into(),
                 retain: Some(PolicyRetain {
                     kind: Some(policy_retain::Kind::DropAll(Box::default())),
                     ..Default::default()
@@ -439,7 +440,7 @@ async fn prune_keep_latest_retains_newest() {
     compact_client
         .prune(PruneRequest {
             policies: vec![Policy {
-                scope: Some(policy::Scope::Keys(Box::new(ProtoKeysScope {
+                keys: Some(ProtoKeysScope {
                     selector: Some(ProtoSelector {
                         prefix: Bytes::from(vec![2]),
                         payload_regex: "(?s-u)^(?P<logical>.{3})\\x00\\x00(?P<version>.{8})$"
@@ -459,7 +460,8 @@ async fn prune_keep_latest_retains_newest() {
                     })
                     .into(),
                     ..Default::default()
-                }))),
+                })
+                .into(),
                 retain: Some(PolicyRetain {
                     kind: Some(policy_retain::Kind::KeepLatest(Box::new(
                         RetainKeepLatest {
@@ -612,14 +614,14 @@ async fn store_client_prune_drop_all() {
     client
         .compact()
         .prune(&[prune_policy::PrunePolicy {
-            scope: prune_policy::PolicyScope::Keys(prune_policy::KeysScope {
+            scope: prune_policy::KeysScope {
                 selector: DomainSelector {
                     prefix: Bytes::from(vec![5]),
                     payload_regex: ".*".into(),
                 },
                 group_by: prune_policy::GroupBy::default(),
                 order_by: None,
-            }),
+            },
             retain: prune_policy::RetainPolicy::DropAll,
         }])
         .await
@@ -660,7 +662,7 @@ async fn prune_greater_than_retains_above_threshold() {
     compact_client
         .prune(PruneRequest {
             policies: vec![Policy {
-                scope: Some(policy::Scope::Keys(Box::new(ProtoKeysScope {
+                keys: Some(ProtoKeysScope {
                     selector: Some(ProtoSelector {
                         prefix: Bytes::from(vec![3]),
                         payload_regex: "(?s-u)^(?P<logical>.{2})(?P<version>.{8})$".to_string(),
@@ -679,7 +681,8 @@ async fn prune_greater_than_retains_above_threshold() {
                     })
                     .into(),
                     ..Default::default()
-                }))),
+                })
+                .into(),
                 retain: Some(PolicyRetain {
                     kind: Some(policy_retain::Kind::GreaterThan(Box::new(
                         RetainGreaterThan {

--- a/examples/simulator/tests/e2e_stream.rs
+++ b/examples/simulator/tests/e2e_stream.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use bytes::Bytes;
 use exoware_sdk::keys::{Key, Prefix};
 use exoware_sdk::kv_codec::Utf8;
-use exoware_sdk::prune_policy::{PolicyScope, PrunePolicy, RetainPolicy};
+use exoware_sdk::retention::RetentionPolicy;
 use exoware_sdk::selector::Selector;
 use exoware_sdk::stream_filter::StreamFilter;
 use exoware_sdk::{PrefixedStoreClient, RetryConfig, StoreClient};
@@ -30,20 +30,6 @@ fn filter(family: u8) -> StreamFilter {
             payload_regex: Utf8::from("(?s).*"),
         }],
         value_filters: vec![],
-    }
-}
-
-fn keep_latest_batches(count: usize) -> PrunePolicy {
-    PrunePolicy {
-        scope: PolicyScope::Sequence,
-        retain: RetainPolicy::KeepLatest { count },
-    }
-}
-
-fn drop_all_batches() -> PrunePolicy {
-    PrunePolicy {
-        scope: PolicyScope::Sequence,
-        retain: RetainPolicy::DropAll,
     }
 }
 
@@ -248,7 +234,7 @@ async fn replay_past_end_delivers_only_live() {
 }
 
 #[tokio::test]
-async fn replay_miss_after_prune_returns_batch_evicted() {
+async fn replay_miss_after_retention_returns_batch_evicted() {
     let client = spawn_client().await;
     for i in 0..20u8 {
         client
@@ -257,12 +243,14 @@ async fn replay_miss_after_prune_returns_batch_evicted() {
             .await
             .expect("put");
     }
-    // Prune via compact batch-log policy: keep last 10.
-    client
-        .compact()
-        .prune(&[keep_latest_batches(10)])
+    // Install a keep-last-10 retention rule via the stream service; one synchronous enforcement
+    // reports 11 as the oldest retained sequence.
+    let oldest = client
+        .stream()
+        .set_retention(Some(RetentionPolicy::KeepLatest { count: 10 }))
         .await
-        .expect("prune keep_latest batches");
+        .expect("set_retention keep_latest");
+    assert_eq!(oldest, Some(11));
 
     // Subscribing from seq 1 should fail with BATCH_EVICTED. The error may
     // surface either on the subscribe call itself or on the first next()
@@ -332,14 +320,16 @@ async fn get_batch_after_drop_all_returns_none() {
         .put(&[(&key(1, b"a"), b"1")])
         .await
         .expect("put");
-    client
-        .compact()
-        .prune(&[drop_all_batches()])
+    // drop_all evicts up to the live frontier, so nothing is retained.
+    let oldest = client
+        .stream()
+        .set_retention(Some(RetentionPolicy::DropAll))
         .await
-        .expect("prune");
+        .expect("set_retention drop_all");
+    assert_eq!(oldest, None);
 
     let got = client.stream().get(seq).await.expect("get_batch");
-    assert!(got.is_none(), "pruned batch should return None");
+    assert!(got.is_none(), "evicted batch should return None");
 }
 
 #[tokio::test]
@@ -354,11 +344,12 @@ async fn get_batch_after_keep_latest_evicts_old_but_keeps_new() {
             .expect("put");
         seqs.push(s);
     }
-    client
-        .compact()
-        .prune(&[keep_latest_batches(10)])
+    let oldest = client
+        .stream()
+        .set_retention(Some(RetentionPolicy::KeepLatest { count: 10 }))
         .await
-        .expect("prune keep_latest batches");
+        .expect("set_retention keep_latest");
+    assert_eq!(oldest, Some(*seqs.last().unwrap() - 9));
 
     // Earliest seq should be evicted.
     assert!(client.stream().get(seqs[0]).await.expect("get").is_none());

--- a/examples/simulator/tests/prune_contract.rs
+++ b/examples/simulator/tests/prune_contract.rs
@@ -1,4 +1,5 @@
-//! Contract tests for RocksDB simulator pruning.
+//! Contract tests for RocksDB simulator pruning (user-key scopes via `Prune`) and sequence-log
+//! retention (continuously enforced via `Retention`/`SetRetention`).
 
 use std::future::Future;
 
@@ -6,11 +7,12 @@ use bytes::Bytes;
 use exoware_sdk::keys::Prefix;
 use exoware_sdk::kv_codec::Utf8;
 use exoware_sdk::prune_policy::{
-    GroupBy, KeysScope, OrderBy, OrderEncoding, PolicyScope, PrunePolicy, PrunePolicyDocument,
-    RetainPolicy, PRUNE_POLICY_DOCUMENT_VERSION,
+    GroupBy, KeysScope, OrderBy, OrderEncoding, PrunePolicy, PrunePolicyDocument, RetainPolicy,
+    PRUNE_POLICY_DOCUMENT_VERSION,
 };
+use exoware_sdk::retention::RetentionPolicy;
 use exoware_sdk::selector::Selector;
-use exoware_server::{Ingest, Log, Prune, Query, Sequence};
+use exoware_server::{Ingest, Log, Prune, Query, Retention, Sequence};
 use exoware_simulator::RocksStore;
 use tempfile::tempdir;
 
@@ -40,8 +42,31 @@ fn put_batch(store: &RocksStore, kvs: Vec<(Bytes, Bytes)>) -> u64 {
     block_on(store.put_batch(kvs)).expect("put_batch")
 }
 
+fn put_one(store: &RocksStore, key: &'static [u8], value: &'static [u8]) -> u64 {
+    put_batch(
+        store,
+        vec![(Bytes::from_static(key), Bytes::from_static(value))],
+    )
+}
+
 fn get_value(store: &RocksStore, key: &Bytes) -> Option<Bytes> {
     block_on(store.get(key.clone())).expect("get").0
+}
+
+/// True when the log still serves a batch at `sequence`.
+fn has_batch(store: &RocksStore, sequence: u64) -> bool {
+    block_on(store.get_batch(sequence))
+        .expect("get batch")
+        .is_some()
+}
+
+fn oldest_retained(store: &RocksStore) -> Option<u64> {
+    block_on(store.oldest_retained_batch()).expect("oldest retained")
+}
+
+/// Drives the `Retention` RPC surface (async trait method) the way the server does.
+fn set_retention(store: &RocksStore, policy: Option<RetentionPolicy>) -> Option<u64> {
+    block_on(store.set_retention(policy)).expect("set_retention")
 }
 
 fn prune_document(policies: &[PrunePolicy]) -> PrunePolicyDocument {
@@ -61,7 +86,7 @@ fn apply_prune(store: &RocksStore, policies: &[PrunePolicy]) {
 
 fn version_policy_with_encoding(retain: RetainPolicy, encoding: OrderEncoding) -> PrunePolicy {
     PrunePolicy {
-        scope: PolicyScope::Keys(KeysScope {
+        scope: KeysScope {
             selector: Selector {
                 prefix: Bytes::from(vec![TEST_PREFIX]),
                 payload_regex: Utf8::from(
@@ -75,20 +100,13 @@ fn version_policy_with_encoding(retain: RetainPolicy, encoding: OrderEncoding) -
                 capture_group: Utf8::from("version"),
                 encoding,
             }),
-        }),
+        },
         retain,
     }
 }
 
 fn version_policy(retain: RetainPolicy) -> PrunePolicy {
     version_policy_with_encoding(retain, OrderEncoding::U64Be)
-}
-
-fn sequence_policy(retain: RetainPolicy) -> PrunePolicy {
-    PrunePolicy {
-        scope: PolicyScope::Sequence,
-        retain,
-    }
 }
 
 #[test]
@@ -225,73 +243,173 @@ fn keys_threshold_retention_rejects_i64_ordering() {
     assert_eq!(get_value(&store, &v1).as_deref(), Some(b"v1".as_slice()));
 }
 
+/// An installed rule keeps trimming as later batches arrive, with no further RPC:
+/// `keep_latest{2}`'s window follows the frontier across two enforcement rounds driven purely
+/// by ingest.
 #[test]
-fn sequence_scope_prunes_log_without_advancing_sequence() {
+fn retention_keep_latest_tracks_frontier_continuously() {
     let dir = tempdir().expect("tempdir");
     let store = RocksStore::open(dir.path(), None).expect("open db");
-    put_batch(
-        &store,
-        vec![(Bytes::from_static(b"a"), Bytes::from_static(b"1"))],
-    );
-    put_batch(
-        &store,
-        vec![(Bytes::from_static(b"b"), Bytes::from_static(b"2"))],
-    );
-    let current = put_batch(
-        &store,
-        vec![(Bytes::from_static(b"c"), Bytes::from_static(b"3"))],
-    );
+    put_one(&store, b"a", b"1");
+    put_one(&store, b"b", b"2");
+    put_one(&store, b"c", b"3");
 
-    apply_prune(
-        &store,
-        &[sequence_policy(RetainPolicy::KeepLatest { count: 1 })],
+    // One synchronous enforcement against frontier 3 keeps the newest two batches.
+    assert_eq!(
+        set_retention(&store, Some(RetentionPolicy::KeepLatest { count: 2 })),
+        Some(2)
     );
+    assert!(!has_batch(&store, 1));
+    assert!(has_batch(&store, 2));
+    assert!(has_batch(&store, 3));
+    assert_eq!(store.current_sequence(), 3);
 
-    assert_eq!(store.current_sequence(), current);
-    assert!(block_on(store.get_batch(1)).expect("get batch").is_none());
-    assert!(block_on(store.get_batch(2)).expect("get batch").is_none());
-    assert!(block_on(store.get_batch(3)).expect("get batch").is_some());
+    // Two more batches, no new RPC: the ingest path re-enforces each time, so the retained
+    // window slides forward to [4, 5].
+    put_one(&store, b"d", b"4");
+    put_one(&store, b"e", b"5");
+
+    assert!(!has_batch(&store, 2));
+    assert!(!has_batch(&store, 3));
+    assert!(has_batch(&store, 4));
+    assert!(has_batch(&store, 5));
+    assert_eq!(oldest_retained(&store), Some(4));
+
+    // Retention never advances the ingest frontier; it only evicts log rows.
+    assert_eq!(store.current_sequence(), 5);
 }
 
 #[test]
-fn pruned_state_survives_reopen() {
+fn retention_greater_than_and_greater_than_or_equal_thresholds() {
     let dir = tempdir().expect("tempdir");
-    let (v1, v2, v3, retained_sequence) = {
+    let store = RocksStore::open(dir.path(), None).expect("open db");
+    put_one(&store, b"a", b"1");
+    put_one(&store, b"b", b"2");
+    put_one(&store, b"c", b"3");
+    put_one(&store, b"d", b"4");
+    put_one(&store, b"e", b"5");
+
+    // `greater_than{2}` retains sequence numbers strictly above 2, so the floor is 3.
+    assert_eq!(
+        set_retention(&store, Some(RetentionPolicy::GreaterThan { threshold: 2 })),
+        Some(3)
+    );
+    assert!(!has_batch(&store, 1));
+    assert!(!has_batch(&store, 2));
+    assert!(has_batch(&store, 3));
+
+    // Tightening to `greater_than_or_equal{4}` moves the floor to 4 (4 itself is retained).
+    assert_eq!(
+        set_retention(
+            &store,
+            Some(RetentionPolicy::GreaterThanOrEqual { threshold: 4 })
+        ),
+        Some(4)
+    );
+    assert!(!has_batch(&store, 3));
+    assert!(has_batch(&store, 4));
+    assert!(has_batch(&store, 5));
+    assert_eq!(store.current_sequence(), 5);
+}
+
+#[test]
+fn retention_drop_all_keeps_log_empty_as_batches_arrive() {
+    let dir = tempdir().expect("tempdir");
+    let store = RocksStore::open(dir.path(), None).expect("open db");
+    put_one(&store, b"a", b"1");
+    put_one(&store, b"b", b"2");
+
+    // drop_all evicts everything up to the live frontier; the log has no retained row.
+    assert_eq!(set_retention(&store, Some(RetentionPolicy::DropAll)), None);
+    assert_eq!(oldest_retained(&store), None);
+    assert!(!has_batch(&store, 1));
+    assert!(!has_batch(&store, 2));
+
+    // Later batches are evicted continuously, so the log stays empty without another RPC. The
+    // ingest frontier still advances (put_batch returns the committed sequence).
+    let third = put_one(&store, b"c", b"3");
+    assert_eq!(third, 3);
+    assert_eq!(store.current_sequence(), 3);
+    assert_eq!(oldest_retained(&store), None);
+    assert!(!has_batch(&store, 3));
+}
+
+#[test]
+fn retention_clear_stops_enforcement() {
+    let dir = tempdir().expect("tempdir");
+    let store = RocksStore::open(dir.path(), None).expect("open db");
+    put_one(&store, b"a", b"1");
+    put_one(&store, b"b", b"2");
+    put_one(&store, b"c", b"3");
+
+    assert_eq!(
+        set_retention(&store, Some(RetentionPolicy::KeepLatest { count: 2 })),
+        Some(2)
+    );
+    assert!(!has_batch(&store, 1));
+
+    // Clearing stops enforcement; already-evicted batches stay evicted.
+    set_retention(&store, None);
+    assert!(!has_batch(&store, 1));
+
+    // With the rule cleared the ingest path stops trimming: batches 4 and 5 join 2 and 3
+    // untouched.
+    put_one(&store, b"d", b"4");
+    put_one(&store, b"e", b"5");
+    assert_eq!(oldest_retained(&store), Some(2));
+    for sequence in 2..=5 {
+        assert!(has_batch(&store, sequence), "batch {sequence} must survive");
+    }
+}
+
+/// Key pruning (`Prune`) and sequence-log retention (`SetRetention`) target different data and
+/// compose: current key rows are deleted by the prune, log rows are trimmed by retention, and
+/// neither advances the ingest frontier.
+#[test]
+fn keys_prune_and_retention_compose() {
+    let dir = tempdir().expect("tempdir");
+    let (v1, v2, v3, last) = {
         let store = RocksStore::open(dir.path(), None).expect("open db");
         let v1 = versioned_key(b"row", 1);
         let v2 = versioned_key(b"row", 2);
         let v3 = versioned_key(b"row", 3);
         put_batch(&store, vec![(v1.clone(), Bytes::from_static(b"v1"))]);
         put_batch(&store, vec![(v2.clone(), Bytes::from_static(b"v2"))]);
-        let retained_sequence = put_batch(&store, vec![(v3.clone(), Bytes::from_static(b"v3"))]);
+        let last = put_batch(&store, vec![(v3.clone(), Bytes::from_static(b"v3"))]);
 
+        // Prune keeps only the newest key version; retention keeps only the newest log batch.
         apply_prune(
             &store,
-            &[
-                version_policy(RetainPolicy::KeepLatest { count: 1 }),
-                sequence_policy(RetainPolicy::KeepLatest { count: 1 }),
-            ],
+            &[version_policy(RetainPolicy::KeepLatest { count: 1 })],
         );
-        (v1, v2, v3, retained_sequence)
+        assert_eq!(
+            set_retention(&store, Some(RetentionPolicy::KeepLatest { count: 1 })),
+            Some(last)
+        );
+
+        assert!(get_value(&store, &v1).is_none());
+        assert!(get_value(&store, &v2).is_none());
+        assert_eq!(get_value(&store, &v3).as_deref(), Some(b"v3".as_slice()));
+        assert!(!has_batch(&store, last - 2));
+        assert!(!has_batch(&store, last - 1));
+        assert!(has_batch(&store, last));
+        assert_eq!(store.current_sequence(), last);
+        (v1, v2, v3, last)
     };
 
-    // Reopening (which replays retained log rows above the state floor) must not
-    // resurrect pruned current keys or pruned log rows.
+    // Reopening replays retained log rows above the state floor; it must resurrect neither the
+    // key-pruned rows nor the retention-evicted log rows, and must not regress the frontier.
     let store = RocksStore::open(dir.path(), None).expect("reopen db");
-    assert_eq!(store.current_sequence(), retained_sequence);
+    assert_eq!(store.current_sequence(), last);
     assert!(get_value(&store, &v1).is_none());
     assert!(get_value(&store, &v2).is_none());
     assert_eq!(get_value(&store, &v3).as_deref(), Some(b"v3".as_slice()));
-    assert!(block_on(store.get_batch(retained_sequence - 1))
-        .expect("get batch")
-        .is_none());
-    assert!(block_on(store.get_batch(retained_sequence))
-        .expect("get batch")
-        .is_some());
+    assert!(!has_batch(&store, last - 1));
+    assert!(has_batch(&store, last));
 }
 
 #[test]
-fn sequence_survives_reopen_after_drop_all_prune() {
+fn retention_drop_all_survives_reopen() {
     let dir = tempdir().expect("tempdir");
     let last = {
         let store = RocksStore::open(dir.path(), None).expect("open db");
@@ -303,7 +421,7 @@ fn sequence_survives_reopen_after_drop_all_prune() {
             &store,
             vec![(versioned_key(b"row", 2), Bytes::from_static(b"v2"))],
         );
-        apply_prune(&store, &[sequence_policy(RetainPolicy::DropAll)]);
+        set_retention(&store, Some(RetentionPolicy::DropAll));
         assert!(block_on(store.oldest_retained_batch())
             .expect("oldest")
             .is_none());
@@ -319,6 +437,8 @@ fn sequence_survives_reopen_after_drop_all_prune() {
         vec![(versioned_key(b"row", 3), Bytes::from_static(b"v3"))],
     );
     assert_eq!(next, last + 1);
+    // The restored rule keeps evicting, so the new batch never lingers in the log.
+    assert_eq!(oldest_retained(&store), None);
 }
 
 #[test]
@@ -355,59 +475,4 @@ fn key_pruned_state_survives_reopen_when_versions_share_a_batch() {
     assert!(get_value(&store, &v1).is_none());
     assert!(get_value(&store, &v2).is_none());
     assert_eq!(get_value(&store, &v3).as_deref(), Some(b"v3".as_slice()));
-}
-
-#[test]
-fn overlapping_prune_policies_apply_in_input_order() {
-    let sequence_then_keys_dir = tempdir().expect("tempdir");
-    let sequence_then_keys =
-        RocksStore::open(sequence_then_keys_dir.path(), None).expect("open db");
-    let key = versioned_key(b"row", 1);
-    let initial_sequence = put_batch(
-        &sequence_then_keys,
-        vec![(key.clone(), Bytes::from_static(b"v1"))],
-    );
-
-    apply_prune(
-        &sequence_then_keys,
-        &[
-            sequence_policy(RetainPolicy::DropAll),
-            version_policy(RetainPolicy::DropAll),
-        ],
-    );
-
-    assert_eq!(sequence_then_keys.current_sequence(), initial_sequence);
-    assert!(get_value(&sequence_then_keys, &key).is_none());
-    assert!(block_on(sequence_then_keys.get_batch(initial_sequence))
-        .expect("get batch")
-        .is_none());
-    assert!(block_on(sequence_then_keys.get_batch(initial_sequence + 1))
-        .expect("get batch")
-        .is_none());
-
-    let keys_then_sequence_dir = tempdir().expect("tempdir");
-    let keys_then_sequence =
-        RocksStore::open(keys_then_sequence_dir.path(), None).expect("open db");
-    let key = versioned_key(b"row", 1);
-    let initial_sequence = put_batch(
-        &keys_then_sequence,
-        vec![(key.clone(), Bytes::from_static(b"v1"))],
-    );
-
-    apply_prune(
-        &keys_then_sequence,
-        &[
-            version_policy(RetainPolicy::DropAll),
-            sequence_policy(RetainPolicy::DropAll),
-        ],
-    );
-
-    assert_eq!(keys_then_sequence.current_sequence(), initial_sequence);
-    assert!(get_value(&keys_then_sequence, &key).is_none());
-    assert!(block_on(keys_then_sequence.get_batch(initial_sequence))
-        .expect("get batch")
-        .is_none());
-    assert!(block_on(keys_then_sequence.get_batch(initial_sequence + 1))
-        .expect("get batch")
-        .is_none());
 }

--- a/integration/tests/multi_instance.rs
+++ b/integration/tests/multi_instance.rs
@@ -19,7 +19,7 @@ use exoware_sdk::keys::Key;
 use exoware_sdk::kv_codec::Utf8;
 use exoware_sdk::proto::PreferZstdHttpClient;
 use exoware_sdk::prune_policy::{
-    GroupBy, KeysScope, OrderBy, OrderEncoding, PolicyScope, PrunePolicy, RetainPolicy,
+    GroupBy, KeysScope, OrderBy, OrderEncoding, PrunePolicy, RetainPolicy,
 };
 use exoware_sdk::selector::Selector;
 use exoware_sdk::stream_filter::StreamFilter;
@@ -791,7 +791,7 @@ async fn prefixed_prune_composes_selector_and_prunes_cleanly() {
     // NOT the composed bytes. Scope/group_by/order_by/retain mirror
     // prune_contract.rs's version_policy_with_encoding.
     let policy = PrunePolicy {
-        scope: PolicyScope::Keys(KeysScope {
+        scope: KeysScope {
             selector: Selector {
                 prefix: Bytes::from(vec![0x07]),
                 payload_regex: Utf8::from(
@@ -805,7 +805,7 @@ async fn prefixed_prune_composes_selector_and_prunes_cleanly() {
                 capture_group: Utf8::from("version"),
                 encoding: OrderEncoding::U64Be,
             }),
-        }),
+        },
         retain: RetainPolicy::KeepLatest { count: 1 },
     };
 

--- a/proto/log/v1/stream.proto
+++ b/proto/log/v1/stream.proto
@@ -17,6 +17,9 @@ import "common/v1/kv.proto";
 service Service {
   rpc Subscribe(SubscribeRequest) returns (stream SubscribeResponse);
   rpc Get(GetRequest) returns (GetResponse);
+  // Install (or clear) the sequence-log retention rule. The rule is persistent
+  // and continuously enforced as the log grows — see `SetRetentionRequest`.
+  rpc SetRetention(SetRetentionRequest) returns (SetRetentionResponse);
 }
 
 // Live (and optionally replayed) subscription request.
@@ -64,4 +67,56 @@ message SubscribeResponse {
 message GetResponse {
   uint64 sequence_number = 1;
   repeated common.kv.v1.Entry entries = 2;
+}
+
+// Keep the newest `count` batches. Continuous: as new batches are appended the
+// retained window slides forward with the live frontier, evicting whatever
+// falls below it.
+message RetentionKeepLatest {
+  uint64 count = 1 [(buf.validate.field).uint64.gt = 0];
+}
+
+// Retain sequence numbers strictly greater than `threshold`; evict the rest.
+message RetentionGreaterThan {
+  uint64 threshold = 1;
+}
+
+// Retain sequence numbers greater than or equal to `threshold`; evict the rest.
+message RetentionGreaterThanOrEqual {
+  uint64 threshold = 1;
+}
+
+// Retain nothing: evict up to the live frontier and keep doing so as the log
+// grows.
+message RetentionDropAll {}
+
+// The retention rule to enforce over the sequence log.
+message RetentionPolicy {
+  oneof kind {
+    RetentionKeepLatest keep_latest = 1;
+    RetentionGreaterThan greater_than = 2;
+    RetentionGreaterThanOrEqual greater_than_or_equal = 3;
+    RetentionDropAll drop_all = 4;
+  }
+}
+
+// Install or clear the sequence-log retention rule.
+//
+// Retention is a persistent, continuously-enforced rule owned by the stream
+// service (not a one-shot prune): once installed it keeps tracking the live
+// frontier as batches are appended, evicting whatever falls below the rule's
+// floor. Evicted batches surface to subscribers/point-lookups as
+// `OUT_OF_RANGE` with an `ErrorInfo { reason: "BATCH_EVICTED", metadata: {
+// "oldest_retained": ... } }` detail.
+message SetRetentionRequest {
+  // The rule to install. Absent -> clear the rule: enforcement stops and no
+  // further eviction happens.
+  RetentionPolicy policy = 1;
+}
+
+// Result of applying the rule change once, synchronously.
+message SetRetentionResponse {
+  // Lowest sequence number still retained after that application. Absent when
+  // the log is empty / no floor exists yet.
+  optional uint64 oldest_retained_sequence = 1;
 }

--- a/proto/log/v1/stream.proto
+++ b/proto/log/v1/stream.proto
@@ -17,8 +17,6 @@ import "common/v1/kv.proto";
 service Service {
   rpc Subscribe(SubscribeRequest) returns (stream SubscribeResponse);
   rpc Get(GetRequest) returns (GetResponse);
-  // Install (or clear) the sequence-log retention rule. The rule is persistent
-  // and continuously enforced as the log grows — see `SetRetentionRequest`.
   rpc SetRetention(SetRetentionRequest) returns (SetRetentionResponse);
 }
 

--- a/proto/store/v1/compact.proto
+++ b/proto/store/v1/compact.proto
@@ -82,25 +82,10 @@ message KeysScope {
   optional PolicyOrderBy order_by = 3;
 }
 
-// Sequence-number scope: prune the per-batch sequence log served by the
-// store's `Stream` service. `selector` / `group_by` / `order_by` are not
-// meaningful here — the log has a single implicit ordering by sequence
-// number. The `retain` rule on the parent `Policy` is interpreted directly
-// over sequence numbers:
-//
-//   - `keep_latest { count: N }`        -> keep the last N batches
-//   - `greater_than { threshold: T }`   -> keep sequence numbers > T
-//   - `greater_than_or_equal { .. T }`  -> keep sequence numbers >= T
-//   - `drop_all`                        -> clear the log entirely
-message SequenceScope {}
-
-// A single prune policy. `scope` discriminates the keyspace the rule applies
-// to; `retain` is shared between scopes.
+// A single prune policy: group keys via `keys`, then apply `retain` to decide
+// which of them survive. `keys` is required.
 message Policy {
-  oneof scope {
-    KeysScope keys = 1;
-    SequenceScope sequence = 2;
-  }
+  KeysScope keys = 1;
   PolicyRetain retain = 3;
 }
 

--- a/qmdb/rs/src/prune.rs
+++ b/qmdb/rs/src/prune.rs
@@ -1,6 +1,6 @@
 use exoware_sdk::kv_codec::Utf8;
 use exoware_sdk::prune_policy::{
-    GroupBy, KeysScope, OrderBy, OrderEncoding, PolicyScope, PrunePolicy, RetainPolicy,
+    GroupBy, KeysScope, OrderBy, OrderEncoding, PrunePolicy, RetainPolicy,
 };
 use exoware_sdk::selector::Selector;
 
@@ -28,7 +28,7 @@ fn base_keys_scope() -> KeysScope {
 /// key in the standard qmdb update family.
 pub fn keep_latest_updates(count: usize) -> PrunePolicy {
     PrunePolicy {
-        scope: PolicyScope::Keys(base_keys_scope()),
+        scope: base_keys_scope(),
         retain: RetainPolicy::KeepLatest { count },
     }
 }
@@ -37,27 +37,10 @@ pub fn keep_latest_updates(count: usize) -> PrunePolicy {
 /// greater than or equal to `min_location`.
 pub fn keep_positions_gte(min_location: u64) -> PrunePolicy {
     PrunePolicy {
-        scope: PolicyScope::Keys(base_keys_scope()),
+        scope: base_keys_scope(),
         retain: RetainPolicy::GreaterThanOrEqual {
             threshold: min_location,
         },
-    }
-}
-
-/// Prune the store's log to the last `count` batches. Use with the
-/// store's `stream.v1` service when you want to bound replay history.
-pub fn keep_latest_batches(count: usize) -> PrunePolicy {
-    PrunePolicy {
-        scope: PolicyScope::Sequence,
-        retain: RetainPolicy::KeepLatest { count },
-    }
-}
-
-/// Drop every retained batch. Disables replay + GetBatch entirely.
-pub fn drop_all_batches() -> PrunePolicy {
-    PrunePolicy {
-        scope: PolicyScope::Sequence,
-        retain: RetainPolicy::DropAll,
     }
 }
 
@@ -65,21 +48,19 @@ pub fn drop_all_batches() -> PrunePolicy {
 mod tests {
     use std::collections::HashSet;
 
-    use super::{drop_all_batches, keep_latest_batches, keep_latest_updates, keep_positions_gte};
+    use super::{keep_latest_updates, keep_positions_gte};
     use crate::codec::{
         encode_ordered_key_bytes, encode_update_key, ORDERED_KEY_TERMINATOR_LEN, UPDATE_FAMILY,
         UPDATE_PREFIX,
     };
     use commonware_storage::merkle::{mmr, Location};
     use exoware_sdk::kv_codec::Utf8;
-    use exoware_sdk::prune_policy::{validate_policy, OrderEncoding, PolicyScope, RetainPolicy};
+    use exoware_sdk::prune_policy::{validate_policy, OrderEncoding, RetainPolicy};
     use exoware_sdk::selector::compile_payload_regex;
 
     fn compiled_update_regex() -> regex::bytes::Regex {
         let policy = keep_latest_updates(1);
-        let PolicyScope::Keys(scope) = &policy.scope else {
-            panic!("expected Keys scope");
-        };
+        let scope = &policy.scope;
         validate_policy(&policy).expect("policy should validate");
         compile_payload_regex(&scope.selector.payload_regex).expect("regex")
     }
@@ -87,9 +68,7 @@ mod tests {
     #[test]
     fn keep_latest_updates_matches_update_key_layout() {
         let policy = keep_latest_updates(3);
-        let PolicyScope::Keys(scope) = &policy.scope else {
-            panic!("expected UserKeys scope");
-        };
+        let scope = &policy.scope;
         assert_eq!(scope.selector.prefix.as_ref(), &[UPDATE_FAMILY]);
         assert_eq!(
             &*scope.selector.payload_regex,
@@ -188,9 +167,7 @@ mod tests {
     #[test]
     fn keep_positions_gte_uses_threshold_retention() {
         let policy = keep_positions_gte(42);
-        let PolicyScope::Keys(scope) = &policy.scope else {
-            panic!("expected UserKeys scope");
-        };
+        let scope = &policy.scope;
         assert_eq!(
             policy.retain,
             RetainPolicy::GreaterThanOrEqual { threshold: 42 }
@@ -199,19 +176,5 @@ mod tests {
             &*scope.order_by.as_ref().expect("order_by").capture_group,
             "version"
         );
-    }
-
-    #[test]
-    fn keep_latest_batches_uses_log_scope() {
-        let policy = keep_latest_batches(10);
-        assert!(matches!(policy.scope, PolicyScope::Sequence));
-        assert_eq!(policy.retain, RetainPolicy::KeepLatest { count: 10 });
-    }
-
-    #[test]
-    fn drop_all_batches_uses_log_scope() {
-        let policy = drop_all_batches();
-        assert!(matches!(policy.scope, PolicyScope::Sequence));
-        assert_eq!(policy.retain, RetainPolicy::DropAll);
     }
 }

--- a/sdk/rs/src/gen/log.stream.v1.rs
+++ b/sdk/rs/src/gen/log.stream.v1.rs
@@ -741,6 +741,1257 @@ pub const __GET_RESPONSE_JSON_ANY: ::buffa::type_registry::JsonAnyEntry = ::buff
     from_json: ::buffa::type_registry::any_from_json::<GetResponse>,
     is_wkt: false,
 };
+/// Keep the newest `count` batches. Continuous: as new batches are appended the
+/// retained window slides forward with the live frontier, evicting whatever
+/// falls below it.
+#[derive(Clone, PartialEq, Default)]
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[serde(default)]
+pub struct RetentionKeepLatest {
+    /// Field 1: `count`
+    #[serde(
+        rename = "count",
+        with = "::buffa::json_helpers::uint64",
+        skip_serializing_if = "::buffa::json_helpers::skip_if::is_zero_u64"
+    )]
+    pub count: u64,
+    #[serde(skip)]
+    #[doc(hidden)]
+    pub __buffa_unknown_fields: ::buffa::UnknownFields,
+}
+impl ::core::fmt::Debug for RetentionKeepLatest {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+        f.debug_struct("RetentionKeepLatest").field("count", &self.count).finish()
+    }
+}
+impl RetentionKeepLatest {
+    /// Protobuf type URL for this message, for use with `Any::pack` and
+    /// `Any::unpack_if`.
+    ///
+    /// Format: `type.googleapis.com/<fully.qualified.TypeName>`
+    pub const TYPE_URL: &'static str = "type.googleapis.com/log.stream.v1.RetentionKeepLatest";
+}
+impl ::buffa::DefaultInstance for RetentionKeepLatest {
+    fn default_instance() -> &'static Self {
+        static VALUE: ::buffa::__private::OnceBox<RetentionKeepLatest> = ::buffa::__private::OnceBox::new();
+        VALUE.get_or_init(|| ::buffa::alloc::boxed::Box::new(Self::default()))
+    }
+}
+impl ::buffa::MessageName for RetentionKeepLatest {
+    const PACKAGE: &'static str = "log.stream.v1";
+    const NAME: &'static str = "RetentionKeepLatest";
+    const FULL_NAME: &'static str = "log.stream.v1.RetentionKeepLatest";
+    const TYPE_URL: &'static str = "type.googleapis.com/log.stream.v1.RetentionKeepLatest";
+}
+impl ::buffa::Message for RetentionKeepLatest {
+    /// Returns the total encoded size in bytes.
+    ///
+    /// The result is a `u32`; the protobuf specification requires all
+    /// messages to fit within 2 GiB (2,147,483,647 bytes), so a
+    /// compliant message will never overflow this type.
+    #[allow(clippy::let_and_return)]
+    fn compute_size(&self, _cache: &mut ::buffa::SizeCache) -> u32 {
+        #[allow(unused_imports)]
+        use ::buffa::Enumeration as _;
+        let mut size = 0u32;
+        if self.count != 0u64 {
+            size += 1u32 + ::buffa::types::uint64_encoded_len(self.count) as u32;
+        }
+        size += self.__buffa_unknown_fields.encoded_len() as u32;
+        size
+    }
+    fn write_to(
+        &self,
+        _cache: &mut ::buffa::SizeCache,
+        buf: &mut impl ::buffa::bytes::BufMut,
+    ) {
+        #[allow(unused_imports)]
+        use ::buffa::Enumeration as _;
+        if self.count != 0u64 {
+            ::buffa::encoding::Tag::new(1u32, ::buffa::encoding::WireType::Varint)
+                .encode(buf);
+            ::buffa::types::encode_uint64(self.count, buf);
+        }
+        self.__buffa_unknown_fields.write_to(buf);
+    }
+    fn merge_field(
+        &mut self,
+        tag: ::buffa::encoding::Tag,
+        buf: &mut impl ::buffa::bytes::Buf,
+        depth: u32,
+    ) -> ::core::result::Result<(), ::buffa::DecodeError> {
+        #[allow(unused_imports)]
+        use ::buffa::bytes::Buf as _;
+        #[allow(unused_imports)]
+        use ::buffa::Enumeration as _;
+        match tag.field_number() {
+            1u32 => {
+                if tag.wire_type() != ::buffa::encoding::WireType::Varint {
+                    return ::core::result::Result::Err(::buffa::DecodeError::WireTypeMismatch {
+                        field_number: 1u32,
+                        expected: 0u8,
+                        actual: tag.wire_type() as u8,
+                    });
+                }
+                self.count = ::buffa::types::decode_uint64(buf)?;
+            }
+            _ => {
+                self.__buffa_unknown_fields
+                    .push(::buffa::encoding::decode_unknown_field(tag, buf, depth)?);
+            }
+        }
+        ::core::result::Result::Ok(())
+    }
+    fn clear(&mut self) {
+        self.count = 0u64;
+        self.__buffa_unknown_fields.clear();
+    }
+}
+impl ::buffa::ExtensionSet for RetentionKeepLatest {
+    const PROTO_FQN: &'static str = "log.stream.v1.RetentionKeepLatest";
+    fn unknown_fields(&self) -> &::buffa::UnknownFields {
+        &self.__buffa_unknown_fields
+    }
+    fn unknown_fields_mut(&mut self) -> &mut ::buffa::UnknownFields {
+        &mut self.__buffa_unknown_fields
+    }
+}
+impl ::buffa::json_helpers::ProtoElemJson for RetentionKeepLatest {
+    fn serialize_proto_json<S: ::serde::Serializer>(
+        v: &Self,
+        s: S,
+    ) -> ::core::result::Result<S::Ok, S::Error> {
+        ::serde::Serialize::serialize(v, s)
+    }
+    fn deserialize_proto_json<'de, D: ::serde::Deserializer<'de>>(
+        d: D,
+    ) -> ::core::result::Result<Self, D::Error> {
+        <Self as ::serde::Deserialize>::deserialize(d)
+    }
+}
+#[doc(hidden)]
+pub const __RETENTION_KEEP_LATEST_JSON_ANY: ::buffa::type_registry::JsonAnyEntry = ::buffa::type_registry::JsonAnyEntry {
+    type_url: "type.googleapis.com/log.stream.v1.RetentionKeepLatest",
+    to_json: ::buffa::type_registry::any_to_json::<RetentionKeepLatest>,
+    from_json: ::buffa::type_registry::any_from_json::<RetentionKeepLatest>,
+    is_wkt: false,
+};
+/// Retain sequence numbers strictly greater than `threshold`; evict the rest.
+#[derive(Clone, PartialEq, Default)]
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[serde(default)]
+pub struct RetentionGreaterThan {
+    /// Field 1: `threshold`
+    #[serde(
+        rename = "threshold",
+        with = "::buffa::json_helpers::uint64",
+        skip_serializing_if = "::buffa::json_helpers::skip_if::is_zero_u64"
+    )]
+    pub threshold: u64,
+    #[serde(skip)]
+    #[doc(hidden)]
+    pub __buffa_unknown_fields: ::buffa::UnknownFields,
+}
+impl ::core::fmt::Debug for RetentionGreaterThan {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+        f.debug_struct("RetentionGreaterThan")
+            .field("threshold", &self.threshold)
+            .finish()
+    }
+}
+impl RetentionGreaterThan {
+    /// Protobuf type URL for this message, for use with `Any::pack` and
+    /// `Any::unpack_if`.
+    ///
+    /// Format: `type.googleapis.com/<fully.qualified.TypeName>`
+    pub const TYPE_URL: &'static str = "type.googleapis.com/log.stream.v1.RetentionGreaterThan";
+}
+impl ::buffa::DefaultInstance for RetentionGreaterThan {
+    fn default_instance() -> &'static Self {
+        static VALUE: ::buffa::__private::OnceBox<RetentionGreaterThan> = ::buffa::__private::OnceBox::new();
+        VALUE.get_or_init(|| ::buffa::alloc::boxed::Box::new(Self::default()))
+    }
+}
+impl ::buffa::MessageName for RetentionGreaterThan {
+    const PACKAGE: &'static str = "log.stream.v1";
+    const NAME: &'static str = "RetentionGreaterThan";
+    const FULL_NAME: &'static str = "log.stream.v1.RetentionGreaterThan";
+    const TYPE_URL: &'static str = "type.googleapis.com/log.stream.v1.RetentionGreaterThan";
+}
+impl ::buffa::Message for RetentionGreaterThan {
+    /// Returns the total encoded size in bytes.
+    ///
+    /// The result is a `u32`; the protobuf specification requires all
+    /// messages to fit within 2 GiB (2,147,483,647 bytes), so a
+    /// compliant message will never overflow this type.
+    #[allow(clippy::let_and_return)]
+    fn compute_size(&self, _cache: &mut ::buffa::SizeCache) -> u32 {
+        #[allow(unused_imports)]
+        use ::buffa::Enumeration as _;
+        let mut size = 0u32;
+        if self.threshold != 0u64 {
+            size += 1u32 + ::buffa::types::uint64_encoded_len(self.threshold) as u32;
+        }
+        size += self.__buffa_unknown_fields.encoded_len() as u32;
+        size
+    }
+    fn write_to(
+        &self,
+        _cache: &mut ::buffa::SizeCache,
+        buf: &mut impl ::buffa::bytes::BufMut,
+    ) {
+        #[allow(unused_imports)]
+        use ::buffa::Enumeration as _;
+        if self.threshold != 0u64 {
+            ::buffa::encoding::Tag::new(1u32, ::buffa::encoding::WireType::Varint)
+                .encode(buf);
+            ::buffa::types::encode_uint64(self.threshold, buf);
+        }
+        self.__buffa_unknown_fields.write_to(buf);
+    }
+    fn merge_field(
+        &mut self,
+        tag: ::buffa::encoding::Tag,
+        buf: &mut impl ::buffa::bytes::Buf,
+        depth: u32,
+    ) -> ::core::result::Result<(), ::buffa::DecodeError> {
+        #[allow(unused_imports)]
+        use ::buffa::bytes::Buf as _;
+        #[allow(unused_imports)]
+        use ::buffa::Enumeration as _;
+        match tag.field_number() {
+            1u32 => {
+                if tag.wire_type() != ::buffa::encoding::WireType::Varint {
+                    return ::core::result::Result::Err(::buffa::DecodeError::WireTypeMismatch {
+                        field_number: 1u32,
+                        expected: 0u8,
+                        actual: tag.wire_type() as u8,
+                    });
+                }
+                self.threshold = ::buffa::types::decode_uint64(buf)?;
+            }
+            _ => {
+                self.__buffa_unknown_fields
+                    .push(::buffa::encoding::decode_unknown_field(tag, buf, depth)?);
+            }
+        }
+        ::core::result::Result::Ok(())
+    }
+    fn clear(&mut self) {
+        self.threshold = 0u64;
+        self.__buffa_unknown_fields.clear();
+    }
+}
+impl ::buffa::ExtensionSet for RetentionGreaterThan {
+    const PROTO_FQN: &'static str = "log.stream.v1.RetentionGreaterThan";
+    fn unknown_fields(&self) -> &::buffa::UnknownFields {
+        &self.__buffa_unknown_fields
+    }
+    fn unknown_fields_mut(&mut self) -> &mut ::buffa::UnknownFields {
+        &mut self.__buffa_unknown_fields
+    }
+}
+impl ::buffa::json_helpers::ProtoElemJson for RetentionGreaterThan {
+    fn serialize_proto_json<S: ::serde::Serializer>(
+        v: &Self,
+        s: S,
+    ) -> ::core::result::Result<S::Ok, S::Error> {
+        ::serde::Serialize::serialize(v, s)
+    }
+    fn deserialize_proto_json<'de, D: ::serde::Deserializer<'de>>(
+        d: D,
+    ) -> ::core::result::Result<Self, D::Error> {
+        <Self as ::serde::Deserialize>::deserialize(d)
+    }
+}
+#[doc(hidden)]
+pub const __RETENTION_GREATER_THAN_JSON_ANY: ::buffa::type_registry::JsonAnyEntry = ::buffa::type_registry::JsonAnyEntry {
+    type_url: "type.googleapis.com/log.stream.v1.RetentionGreaterThan",
+    to_json: ::buffa::type_registry::any_to_json::<RetentionGreaterThan>,
+    from_json: ::buffa::type_registry::any_from_json::<RetentionGreaterThan>,
+    is_wkt: false,
+};
+/// Retain sequence numbers greater than or equal to `threshold`; evict the rest.
+#[derive(Clone, PartialEq, Default)]
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[serde(default)]
+pub struct RetentionGreaterThanOrEqual {
+    /// Field 1: `threshold`
+    #[serde(
+        rename = "threshold",
+        with = "::buffa::json_helpers::uint64",
+        skip_serializing_if = "::buffa::json_helpers::skip_if::is_zero_u64"
+    )]
+    pub threshold: u64,
+    #[serde(skip)]
+    #[doc(hidden)]
+    pub __buffa_unknown_fields: ::buffa::UnknownFields,
+}
+impl ::core::fmt::Debug for RetentionGreaterThanOrEqual {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+        f.debug_struct("RetentionGreaterThanOrEqual")
+            .field("threshold", &self.threshold)
+            .finish()
+    }
+}
+impl RetentionGreaterThanOrEqual {
+    /// Protobuf type URL for this message, for use with `Any::pack` and
+    /// `Any::unpack_if`.
+    ///
+    /// Format: `type.googleapis.com/<fully.qualified.TypeName>`
+    pub const TYPE_URL: &'static str = "type.googleapis.com/log.stream.v1.RetentionGreaterThanOrEqual";
+}
+impl ::buffa::DefaultInstance for RetentionGreaterThanOrEqual {
+    fn default_instance() -> &'static Self {
+        static VALUE: ::buffa::__private::OnceBox<RetentionGreaterThanOrEqual> = ::buffa::__private::OnceBox::new();
+        VALUE.get_or_init(|| ::buffa::alloc::boxed::Box::new(Self::default()))
+    }
+}
+impl ::buffa::MessageName for RetentionGreaterThanOrEqual {
+    const PACKAGE: &'static str = "log.stream.v1";
+    const NAME: &'static str = "RetentionGreaterThanOrEqual";
+    const FULL_NAME: &'static str = "log.stream.v1.RetentionGreaterThanOrEqual";
+    const TYPE_URL: &'static str = "type.googleapis.com/log.stream.v1.RetentionGreaterThanOrEqual";
+}
+impl ::buffa::Message for RetentionGreaterThanOrEqual {
+    /// Returns the total encoded size in bytes.
+    ///
+    /// The result is a `u32`; the protobuf specification requires all
+    /// messages to fit within 2 GiB (2,147,483,647 bytes), so a
+    /// compliant message will never overflow this type.
+    #[allow(clippy::let_and_return)]
+    fn compute_size(&self, _cache: &mut ::buffa::SizeCache) -> u32 {
+        #[allow(unused_imports)]
+        use ::buffa::Enumeration as _;
+        let mut size = 0u32;
+        if self.threshold != 0u64 {
+            size += 1u32 + ::buffa::types::uint64_encoded_len(self.threshold) as u32;
+        }
+        size += self.__buffa_unknown_fields.encoded_len() as u32;
+        size
+    }
+    fn write_to(
+        &self,
+        _cache: &mut ::buffa::SizeCache,
+        buf: &mut impl ::buffa::bytes::BufMut,
+    ) {
+        #[allow(unused_imports)]
+        use ::buffa::Enumeration as _;
+        if self.threshold != 0u64 {
+            ::buffa::encoding::Tag::new(1u32, ::buffa::encoding::WireType::Varint)
+                .encode(buf);
+            ::buffa::types::encode_uint64(self.threshold, buf);
+        }
+        self.__buffa_unknown_fields.write_to(buf);
+    }
+    fn merge_field(
+        &mut self,
+        tag: ::buffa::encoding::Tag,
+        buf: &mut impl ::buffa::bytes::Buf,
+        depth: u32,
+    ) -> ::core::result::Result<(), ::buffa::DecodeError> {
+        #[allow(unused_imports)]
+        use ::buffa::bytes::Buf as _;
+        #[allow(unused_imports)]
+        use ::buffa::Enumeration as _;
+        match tag.field_number() {
+            1u32 => {
+                if tag.wire_type() != ::buffa::encoding::WireType::Varint {
+                    return ::core::result::Result::Err(::buffa::DecodeError::WireTypeMismatch {
+                        field_number: 1u32,
+                        expected: 0u8,
+                        actual: tag.wire_type() as u8,
+                    });
+                }
+                self.threshold = ::buffa::types::decode_uint64(buf)?;
+            }
+            _ => {
+                self.__buffa_unknown_fields
+                    .push(::buffa::encoding::decode_unknown_field(tag, buf, depth)?);
+            }
+        }
+        ::core::result::Result::Ok(())
+    }
+    fn clear(&mut self) {
+        self.threshold = 0u64;
+        self.__buffa_unknown_fields.clear();
+    }
+}
+impl ::buffa::ExtensionSet for RetentionGreaterThanOrEqual {
+    const PROTO_FQN: &'static str = "log.stream.v1.RetentionGreaterThanOrEqual";
+    fn unknown_fields(&self) -> &::buffa::UnknownFields {
+        &self.__buffa_unknown_fields
+    }
+    fn unknown_fields_mut(&mut self) -> &mut ::buffa::UnknownFields {
+        &mut self.__buffa_unknown_fields
+    }
+}
+impl ::buffa::json_helpers::ProtoElemJson for RetentionGreaterThanOrEqual {
+    fn serialize_proto_json<S: ::serde::Serializer>(
+        v: &Self,
+        s: S,
+    ) -> ::core::result::Result<S::Ok, S::Error> {
+        ::serde::Serialize::serialize(v, s)
+    }
+    fn deserialize_proto_json<'de, D: ::serde::Deserializer<'de>>(
+        d: D,
+    ) -> ::core::result::Result<Self, D::Error> {
+        <Self as ::serde::Deserialize>::deserialize(d)
+    }
+}
+#[doc(hidden)]
+pub const __RETENTION_GREATER_THAN_OR_EQUAL_JSON_ANY: ::buffa::type_registry::JsonAnyEntry = ::buffa::type_registry::JsonAnyEntry {
+    type_url: "type.googleapis.com/log.stream.v1.RetentionGreaterThanOrEqual",
+    to_json: ::buffa::type_registry::any_to_json::<RetentionGreaterThanOrEqual>,
+    from_json: ::buffa::type_registry::any_from_json::<RetentionGreaterThanOrEqual>,
+    is_wkt: false,
+};
+/// Retain nothing: evict up to the live frontier and keep doing so as the log
+/// grows.
+#[derive(Clone, PartialEq, Default)]
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[serde(default)]
+pub struct RetentionDropAll {
+    #[serde(skip)]
+    #[doc(hidden)]
+    pub __buffa_unknown_fields: ::buffa::UnknownFields,
+}
+impl ::core::fmt::Debug for RetentionDropAll {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+        f.debug_struct("RetentionDropAll").finish()
+    }
+}
+impl RetentionDropAll {
+    /// Protobuf type URL for this message, for use with `Any::pack` and
+    /// `Any::unpack_if`.
+    ///
+    /// Format: `type.googleapis.com/<fully.qualified.TypeName>`
+    pub const TYPE_URL: &'static str = "type.googleapis.com/log.stream.v1.RetentionDropAll";
+}
+impl ::buffa::DefaultInstance for RetentionDropAll {
+    fn default_instance() -> &'static Self {
+        static VALUE: ::buffa::__private::OnceBox<RetentionDropAll> = ::buffa::__private::OnceBox::new();
+        VALUE.get_or_init(|| ::buffa::alloc::boxed::Box::new(Self::default()))
+    }
+}
+impl ::buffa::MessageName for RetentionDropAll {
+    const PACKAGE: &'static str = "log.stream.v1";
+    const NAME: &'static str = "RetentionDropAll";
+    const FULL_NAME: &'static str = "log.stream.v1.RetentionDropAll";
+    const TYPE_URL: &'static str = "type.googleapis.com/log.stream.v1.RetentionDropAll";
+}
+impl ::buffa::Message for RetentionDropAll {
+    /// Returns the total encoded size in bytes.
+    ///
+    /// The result is a `u32`; the protobuf specification requires all
+    /// messages to fit within 2 GiB (2,147,483,647 bytes), so a
+    /// compliant message will never overflow this type.
+    #[allow(clippy::let_and_return)]
+    fn compute_size(&self, _cache: &mut ::buffa::SizeCache) -> u32 {
+        #[allow(unused_imports)]
+        use ::buffa::Enumeration as _;
+        let mut size = 0u32;
+        size += self.__buffa_unknown_fields.encoded_len() as u32;
+        size
+    }
+    fn write_to(
+        &self,
+        _cache: &mut ::buffa::SizeCache,
+        buf: &mut impl ::buffa::bytes::BufMut,
+    ) {
+        #[allow(unused_imports)]
+        use ::buffa::Enumeration as _;
+        self.__buffa_unknown_fields.write_to(buf);
+    }
+    fn merge_field(
+        &mut self,
+        tag: ::buffa::encoding::Tag,
+        buf: &mut impl ::buffa::bytes::Buf,
+        depth: u32,
+    ) -> ::core::result::Result<(), ::buffa::DecodeError> {
+        #[allow(unused_imports)]
+        use ::buffa::bytes::Buf as _;
+        #[allow(unused_imports)]
+        use ::buffa::Enumeration as _;
+        match tag.field_number() {
+            _ => {
+                self.__buffa_unknown_fields
+                    .push(::buffa::encoding::decode_unknown_field(tag, buf, depth)?);
+            }
+        }
+        ::core::result::Result::Ok(())
+    }
+    fn clear(&mut self) {
+        self.__buffa_unknown_fields.clear();
+    }
+}
+impl ::buffa::ExtensionSet for RetentionDropAll {
+    const PROTO_FQN: &'static str = "log.stream.v1.RetentionDropAll";
+    fn unknown_fields(&self) -> &::buffa::UnknownFields {
+        &self.__buffa_unknown_fields
+    }
+    fn unknown_fields_mut(&mut self) -> &mut ::buffa::UnknownFields {
+        &mut self.__buffa_unknown_fields
+    }
+}
+impl ::buffa::json_helpers::ProtoElemJson for RetentionDropAll {
+    fn serialize_proto_json<S: ::serde::Serializer>(
+        v: &Self,
+        s: S,
+    ) -> ::core::result::Result<S::Ok, S::Error> {
+        ::serde::Serialize::serialize(v, s)
+    }
+    fn deserialize_proto_json<'de, D: ::serde::Deserializer<'de>>(
+        d: D,
+    ) -> ::core::result::Result<Self, D::Error> {
+        <Self as ::serde::Deserialize>::deserialize(d)
+    }
+}
+#[doc(hidden)]
+pub const __RETENTION_DROP_ALL_JSON_ANY: ::buffa::type_registry::JsonAnyEntry = ::buffa::type_registry::JsonAnyEntry {
+    type_url: "type.googleapis.com/log.stream.v1.RetentionDropAll",
+    to_json: ::buffa::type_registry::any_to_json::<RetentionDropAll>,
+    from_json: ::buffa::type_registry::any_from_json::<RetentionDropAll>,
+    is_wkt: false,
+};
+/// The retention rule to enforce over the sequence log.
+#[derive(Clone, PartialEq, Default)]
+#[derive(::serde::Serialize)]
+#[serde(default)]
+pub struct RetentionPolicy {
+    #[serde(flatten)]
+    pub kind: ::core::option::Option<__buffa::oneof::retention_policy::Kind>,
+    #[serde(skip)]
+    #[doc(hidden)]
+    pub __buffa_unknown_fields: ::buffa::UnknownFields,
+}
+impl ::core::fmt::Debug for RetentionPolicy {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+        f.debug_struct("RetentionPolicy").field("kind", &self.kind).finish()
+    }
+}
+impl RetentionPolicy {
+    /// Protobuf type URL for this message, for use with `Any::pack` and
+    /// `Any::unpack_if`.
+    ///
+    /// Format: `type.googleapis.com/<fully.qualified.TypeName>`
+    pub const TYPE_URL: &'static str = "type.googleapis.com/log.stream.v1.RetentionPolicy";
+}
+impl ::buffa::DefaultInstance for RetentionPolicy {
+    fn default_instance() -> &'static Self {
+        static VALUE: ::buffa::__private::OnceBox<RetentionPolicy> = ::buffa::__private::OnceBox::new();
+        VALUE.get_or_init(|| ::buffa::alloc::boxed::Box::new(Self::default()))
+    }
+}
+impl ::buffa::MessageName for RetentionPolicy {
+    const PACKAGE: &'static str = "log.stream.v1";
+    const NAME: &'static str = "RetentionPolicy";
+    const FULL_NAME: &'static str = "log.stream.v1.RetentionPolicy";
+    const TYPE_URL: &'static str = "type.googleapis.com/log.stream.v1.RetentionPolicy";
+}
+impl ::buffa::Message for RetentionPolicy {
+    /// Returns the total encoded size in bytes.
+    ///
+    /// The result is a `u32`; the protobuf specification requires all
+    /// messages to fit within 2 GiB (2,147,483,647 bytes), so a
+    /// compliant message will never overflow this type.
+    #[allow(clippy::let_and_return)]
+    fn compute_size(&self, __cache: &mut ::buffa::SizeCache) -> u32 {
+        #[allow(unused_imports)]
+        use ::buffa::Enumeration as _;
+        let mut size = 0u32;
+        if let ::core::option::Option::Some(ref v) = self.kind {
+            match v {
+                __buffa::oneof::retention_policy::Kind::KeepLatest(x) => {
+                    let __slot = __cache.reserve();
+                    let inner = x.compute_size(__cache);
+                    __cache.set(__slot, inner);
+                    size
+                        += 1u32 + ::buffa::encoding::varint_len(inner as u64) as u32
+                            + inner;
+                }
+                __buffa::oneof::retention_policy::Kind::GreaterThan(x) => {
+                    let __slot = __cache.reserve();
+                    let inner = x.compute_size(__cache);
+                    __cache.set(__slot, inner);
+                    size
+                        += 1u32 + ::buffa::encoding::varint_len(inner as u64) as u32
+                            + inner;
+                }
+                __buffa::oneof::retention_policy::Kind::GreaterThanOrEqual(x) => {
+                    let __slot = __cache.reserve();
+                    let inner = x.compute_size(__cache);
+                    __cache.set(__slot, inner);
+                    size
+                        += 1u32 + ::buffa::encoding::varint_len(inner as u64) as u32
+                            + inner;
+                }
+                __buffa::oneof::retention_policy::Kind::DropAll(x) => {
+                    let __slot = __cache.reserve();
+                    let inner = x.compute_size(__cache);
+                    __cache.set(__slot, inner);
+                    size
+                        += 1u32 + ::buffa::encoding::varint_len(inner as u64) as u32
+                            + inner;
+                }
+            }
+        }
+        size += self.__buffa_unknown_fields.encoded_len() as u32;
+        size
+    }
+    fn write_to(
+        &self,
+        __cache: &mut ::buffa::SizeCache,
+        buf: &mut impl ::buffa::bytes::BufMut,
+    ) {
+        #[allow(unused_imports)]
+        use ::buffa::Enumeration as _;
+        if let ::core::option::Option::Some(ref v) = self.kind {
+            match v {
+                __buffa::oneof::retention_policy::Kind::KeepLatest(x) => {
+                    ::buffa::encoding::Tag::new(
+                            1u32,
+                            ::buffa::encoding::WireType::LengthDelimited,
+                        )
+                        .encode(buf);
+                    ::buffa::encoding::encode_varint(__cache.consume_next() as u64, buf);
+                    x.write_to(__cache, buf);
+                }
+                __buffa::oneof::retention_policy::Kind::GreaterThan(x) => {
+                    ::buffa::encoding::Tag::new(
+                            2u32,
+                            ::buffa::encoding::WireType::LengthDelimited,
+                        )
+                        .encode(buf);
+                    ::buffa::encoding::encode_varint(__cache.consume_next() as u64, buf);
+                    x.write_to(__cache, buf);
+                }
+                __buffa::oneof::retention_policy::Kind::GreaterThanOrEqual(x) => {
+                    ::buffa::encoding::Tag::new(
+                            3u32,
+                            ::buffa::encoding::WireType::LengthDelimited,
+                        )
+                        .encode(buf);
+                    ::buffa::encoding::encode_varint(__cache.consume_next() as u64, buf);
+                    x.write_to(__cache, buf);
+                }
+                __buffa::oneof::retention_policy::Kind::DropAll(x) => {
+                    ::buffa::encoding::Tag::new(
+                            4u32,
+                            ::buffa::encoding::WireType::LengthDelimited,
+                        )
+                        .encode(buf);
+                    ::buffa::encoding::encode_varint(__cache.consume_next() as u64, buf);
+                    x.write_to(__cache, buf);
+                }
+            }
+        }
+        self.__buffa_unknown_fields.write_to(buf);
+    }
+    fn merge_field(
+        &mut self,
+        tag: ::buffa::encoding::Tag,
+        buf: &mut impl ::buffa::bytes::Buf,
+        depth: u32,
+    ) -> ::core::result::Result<(), ::buffa::DecodeError> {
+        #[allow(unused_imports)]
+        use ::buffa::bytes::Buf as _;
+        #[allow(unused_imports)]
+        use ::buffa::Enumeration as _;
+        match tag.field_number() {
+            1u32 => {
+                if tag.wire_type() != ::buffa::encoding::WireType::LengthDelimited {
+                    return ::core::result::Result::Err(::buffa::DecodeError::WireTypeMismatch {
+                        field_number: 1u32,
+                        expected: 2u8,
+                        actual: tag.wire_type() as u8,
+                    });
+                }
+                if let ::core::option::Option::Some(
+                    __buffa::oneof::retention_policy::Kind::KeepLatest(ref mut existing),
+                ) = self.kind
+                {
+                    ::buffa::Message::merge_length_delimited(
+                        &mut **existing,
+                        buf,
+                        depth,
+                    )?;
+                } else {
+                    let mut val = ::core::default::Default::default();
+                    ::buffa::Message::merge_length_delimited(&mut val, buf, depth)?;
+                    self.kind = ::core::option::Option::Some(
+                        __buffa::oneof::retention_policy::Kind::KeepLatest(
+                            ::buffa::alloc::boxed::Box::new(val),
+                        ),
+                    );
+                }
+            }
+            2u32 => {
+                if tag.wire_type() != ::buffa::encoding::WireType::LengthDelimited {
+                    return ::core::result::Result::Err(::buffa::DecodeError::WireTypeMismatch {
+                        field_number: 2u32,
+                        expected: 2u8,
+                        actual: tag.wire_type() as u8,
+                    });
+                }
+                if let ::core::option::Option::Some(
+                    __buffa::oneof::retention_policy::Kind::GreaterThan(ref mut existing),
+                ) = self.kind
+                {
+                    ::buffa::Message::merge_length_delimited(
+                        &mut **existing,
+                        buf,
+                        depth,
+                    )?;
+                } else {
+                    let mut val = ::core::default::Default::default();
+                    ::buffa::Message::merge_length_delimited(&mut val, buf, depth)?;
+                    self.kind = ::core::option::Option::Some(
+                        __buffa::oneof::retention_policy::Kind::GreaterThan(
+                            ::buffa::alloc::boxed::Box::new(val),
+                        ),
+                    );
+                }
+            }
+            3u32 => {
+                if tag.wire_type() != ::buffa::encoding::WireType::LengthDelimited {
+                    return ::core::result::Result::Err(::buffa::DecodeError::WireTypeMismatch {
+                        field_number: 3u32,
+                        expected: 2u8,
+                        actual: tag.wire_type() as u8,
+                    });
+                }
+                if let ::core::option::Option::Some(
+                    __buffa::oneof::retention_policy::Kind::GreaterThanOrEqual(
+                        ref mut existing,
+                    ),
+                ) = self.kind
+                {
+                    ::buffa::Message::merge_length_delimited(
+                        &mut **existing,
+                        buf,
+                        depth,
+                    )?;
+                } else {
+                    let mut val = ::core::default::Default::default();
+                    ::buffa::Message::merge_length_delimited(&mut val, buf, depth)?;
+                    self.kind = ::core::option::Option::Some(
+                        __buffa::oneof::retention_policy::Kind::GreaterThanOrEqual(
+                            ::buffa::alloc::boxed::Box::new(val),
+                        ),
+                    );
+                }
+            }
+            4u32 => {
+                if tag.wire_type() != ::buffa::encoding::WireType::LengthDelimited {
+                    return ::core::result::Result::Err(::buffa::DecodeError::WireTypeMismatch {
+                        field_number: 4u32,
+                        expected: 2u8,
+                        actual: tag.wire_type() as u8,
+                    });
+                }
+                if let ::core::option::Option::Some(
+                    __buffa::oneof::retention_policy::Kind::DropAll(ref mut existing),
+                ) = self.kind
+                {
+                    ::buffa::Message::merge_length_delimited(
+                        &mut **existing,
+                        buf,
+                        depth,
+                    )?;
+                } else {
+                    let mut val = ::core::default::Default::default();
+                    ::buffa::Message::merge_length_delimited(&mut val, buf, depth)?;
+                    self.kind = ::core::option::Option::Some(
+                        __buffa::oneof::retention_policy::Kind::DropAll(
+                            ::buffa::alloc::boxed::Box::new(val),
+                        ),
+                    );
+                }
+            }
+            _ => {
+                self.__buffa_unknown_fields
+                    .push(::buffa::encoding::decode_unknown_field(tag, buf, depth)?);
+            }
+        }
+        ::core::result::Result::Ok(())
+    }
+    fn clear(&mut self) {
+        self.kind = ::core::option::Option::None;
+        self.__buffa_unknown_fields.clear();
+    }
+}
+impl ::buffa::ExtensionSet for RetentionPolicy {
+    const PROTO_FQN: &'static str = "log.stream.v1.RetentionPolicy";
+    fn unknown_fields(&self) -> &::buffa::UnknownFields {
+        &self.__buffa_unknown_fields
+    }
+    fn unknown_fields_mut(&mut self) -> &mut ::buffa::UnknownFields {
+        &mut self.__buffa_unknown_fields
+    }
+}
+impl<'de> serde::Deserialize<'de> for RetentionPolicy {
+    fn deserialize<D: serde::Deserializer<'de>>(
+        d: D,
+    ) -> ::core::result::Result<Self, D::Error> {
+        struct _V;
+        impl<'de> serde::de::Visitor<'de> for _V {
+            type Value = RetentionPolicy;
+            fn expecting(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                f.write_str("struct RetentionPolicy")
+            }
+            #[allow(clippy::field_reassign_with_default)]
+            fn visit_map<A: serde::de::MapAccess<'de>>(
+                self,
+                mut map: A,
+            ) -> ::core::result::Result<RetentionPolicy, A::Error> {
+                let mut __oneof_kind: ::core::option::Option<
+                    __buffa::oneof::retention_policy::Kind,
+                > = None;
+                while let Some(key) = map.next_key::<::buffa::alloc::string::String>()? {
+                    match key.as_str() {
+                        "keepLatest" | "keep_latest" => {
+                            let v: ::core::option::Option<RetentionKeepLatest> = map
+                                .next_value_seed(
+                                    ::buffa::json_helpers::NullableDeserializeSeed(
+                                        ::buffa::json_helpers::DefaultDeserializeSeed::<
+                                            RetentionKeepLatest,
+                                        >::new(),
+                                    ),
+                                )?;
+                            if let Some(v) = v {
+                                if __oneof_kind.is_some() {
+                                    return Err(
+                                        serde::de::Error::custom(
+                                            "multiple oneof fields set for 'kind'",
+                                        ),
+                                    );
+                                }
+                                __oneof_kind = Some(
+                                    __buffa::oneof::retention_policy::Kind::KeepLatest(
+                                        ::buffa::alloc::boxed::Box::new(v),
+                                    ),
+                                );
+                            }
+                        }
+                        "greaterThan" | "greater_than" => {
+                            let v: ::core::option::Option<RetentionGreaterThan> = map
+                                .next_value_seed(
+                                    ::buffa::json_helpers::NullableDeserializeSeed(
+                                        ::buffa::json_helpers::DefaultDeserializeSeed::<
+                                            RetentionGreaterThan,
+                                        >::new(),
+                                    ),
+                                )?;
+                            if let Some(v) = v {
+                                if __oneof_kind.is_some() {
+                                    return Err(
+                                        serde::de::Error::custom(
+                                            "multiple oneof fields set for 'kind'",
+                                        ),
+                                    );
+                                }
+                                __oneof_kind = Some(
+                                    __buffa::oneof::retention_policy::Kind::GreaterThan(
+                                        ::buffa::alloc::boxed::Box::new(v),
+                                    ),
+                                );
+                            }
+                        }
+                        "greaterThanOrEqual" | "greater_than_or_equal" => {
+                            let v: ::core::option::Option<RetentionGreaterThanOrEqual> = map
+                                .next_value_seed(
+                                    ::buffa::json_helpers::NullableDeserializeSeed(
+                                        ::buffa::json_helpers::DefaultDeserializeSeed::<
+                                            RetentionGreaterThanOrEqual,
+                                        >::new(),
+                                    ),
+                                )?;
+                            if let Some(v) = v {
+                                if __oneof_kind.is_some() {
+                                    return Err(
+                                        serde::de::Error::custom(
+                                            "multiple oneof fields set for 'kind'",
+                                        ),
+                                    );
+                                }
+                                __oneof_kind = Some(
+                                    __buffa::oneof::retention_policy::Kind::GreaterThanOrEqual(
+                                        ::buffa::alloc::boxed::Box::new(v),
+                                    ),
+                                );
+                            }
+                        }
+                        "dropAll" | "drop_all" => {
+                            let v: ::core::option::Option<RetentionDropAll> = map
+                                .next_value_seed(
+                                    ::buffa::json_helpers::NullableDeserializeSeed(
+                                        ::buffa::json_helpers::DefaultDeserializeSeed::<
+                                            RetentionDropAll,
+                                        >::new(),
+                                    ),
+                                )?;
+                            if let Some(v) = v {
+                                if __oneof_kind.is_some() {
+                                    return Err(
+                                        serde::de::Error::custom(
+                                            "multiple oneof fields set for 'kind'",
+                                        ),
+                                    );
+                                }
+                                __oneof_kind = Some(
+                                    __buffa::oneof::retention_policy::Kind::DropAll(
+                                        ::buffa::alloc::boxed::Box::new(v),
+                                    ),
+                                );
+                            }
+                        }
+                        _ => {
+                            map.next_value::<serde::de::IgnoredAny>()?;
+                        }
+                    }
+                }
+                let mut __r = <RetentionPolicy as ::core::default::Default>::default();
+                __r.kind = __oneof_kind;
+                Ok(__r)
+            }
+        }
+        d.deserialize_map(_V)
+    }
+}
+impl ::buffa::json_helpers::ProtoElemJson for RetentionPolicy {
+    fn serialize_proto_json<S: ::serde::Serializer>(
+        v: &Self,
+        s: S,
+    ) -> ::core::result::Result<S::Ok, S::Error> {
+        ::serde::Serialize::serialize(v, s)
+    }
+    fn deserialize_proto_json<'de, D: ::serde::Deserializer<'de>>(
+        d: D,
+    ) -> ::core::result::Result<Self, D::Error> {
+        <Self as ::serde::Deserialize>::deserialize(d)
+    }
+}
+#[doc(hidden)]
+pub const __RETENTION_POLICY_JSON_ANY: ::buffa::type_registry::JsonAnyEntry = ::buffa::type_registry::JsonAnyEntry {
+    type_url: "type.googleapis.com/log.stream.v1.RetentionPolicy",
+    to_json: ::buffa::type_registry::any_to_json::<RetentionPolicy>,
+    from_json: ::buffa::type_registry::any_from_json::<RetentionPolicy>,
+    is_wkt: false,
+};
+pub mod retention_policy {
+    #[allow(unused_imports)]
+    use super::*;
+    #[doc(inline)]
+    pub use super::__buffa::oneof::retention_policy::Kind;
+    #[doc(inline)]
+    pub use super::__buffa::view::oneof::retention_policy::Kind as KindView;
+}
+/// Install or clear the sequence-log retention rule.
+///
+/// Retention is a persistent, continuously-enforced rule owned by the stream
+/// service (not a one-shot prune): once installed it keeps tracking the live
+/// frontier as batches are appended, evicting whatever falls below the rule's
+/// floor. Evicted batches surface to subscribers/point-lookups as
+/// `OUT_OF_RANGE` with an `ErrorInfo { reason: "BATCH_EVICTED", metadata: {
+/// "oldest_retained": ... } }` detail.
+#[derive(Clone, PartialEq, Default)]
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[serde(default)]
+pub struct SetRetentionRequest {
+    /// The rule to install. Absent -\> clear the rule: enforcement stops and no
+    /// further eviction happens.
+    ///
+    /// Field 1: `policy`
+    #[serde(
+        rename = "policy",
+        skip_serializing_if = "::buffa::json_helpers::skip_if::is_unset_message_field"
+    )]
+    pub policy: ::buffa::MessageField<RetentionPolicy>,
+    #[serde(skip)]
+    #[doc(hidden)]
+    pub __buffa_unknown_fields: ::buffa::UnknownFields,
+}
+impl ::core::fmt::Debug for SetRetentionRequest {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+        f.debug_struct("SetRetentionRequest").field("policy", &self.policy).finish()
+    }
+}
+impl SetRetentionRequest {
+    /// Protobuf type URL for this message, for use with `Any::pack` and
+    /// `Any::unpack_if`.
+    ///
+    /// Format: `type.googleapis.com/<fully.qualified.TypeName>`
+    pub const TYPE_URL: &'static str = "type.googleapis.com/log.stream.v1.SetRetentionRequest";
+}
+impl ::buffa::DefaultInstance for SetRetentionRequest {
+    fn default_instance() -> &'static Self {
+        static VALUE: ::buffa::__private::OnceBox<SetRetentionRequest> = ::buffa::__private::OnceBox::new();
+        VALUE.get_or_init(|| ::buffa::alloc::boxed::Box::new(Self::default()))
+    }
+}
+impl ::buffa::MessageName for SetRetentionRequest {
+    const PACKAGE: &'static str = "log.stream.v1";
+    const NAME: &'static str = "SetRetentionRequest";
+    const FULL_NAME: &'static str = "log.stream.v1.SetRetentionRequest";
+    const TYPE_URL: &'static str = "type.googleapis.com/log.stream.v1.SetRetentionRequest";
+}
+impl ::buffa::Message for SetRetentionRequest {
+    /// Returns the total encoded size in bytes.
+    ///
+    /// The result is a `u32`; the protobuf specification requires all
+    /// messages to fit within 2 GiB (2,147,483,647 bytes), so a
+    /// compliant message will never overflow this type.
+    #[allow(clippy::let_and_return)]
+    fn compute_size(&self, __cache: &mut ::buffa::SizeCache) -> u32 {
+        #[allow(unused_imports)]
+        use ::buffa::Enumeration as _;
+        let mut size = 0u32;
+        if self.policy.is_set() {
+            let __slot = __cache.reserve();
+            let inner_size = self.policy.compute_size(__cache);
+            __cache.set(__slot, inner_size);
+            size
+                += 1u32 + ::buffa::encoding::varint_len(inner_size as u64) as u32
+                    + inner_size;
+        }
+        size += self.__buffa_unknown_fields.encoded_len() as u32;
+        size
+    }
+    fn write_to(
+        &self,
+        __cache: &mut ::buffa::SizeCache,
+        buf: &mut impl ::buffa::bytes::BufMut,
+    ) {
+        #[allow(unused_imports)]
+        use ::buffa::Enumeration as _;
+        if self.policy.is_set() {
+            ::buffa::encoding::Tag::new(
+                    1u32,
+                    ::buffa::encoding::WireType::LengthDelimited,
+                )
+                .encode(buf);
+            ::buffa::encoding::encode_varint(__cache.consume_next() as u64, buf);
+            self.policy.write_to(__cache, buf);
+        }
+        self.__buffa_unknown_fields.write_to(buf);
+    }
+    fn merge_field(
+        &mut self,
+        tag: ::buffa::encoding::Tag,
+        buf: &mut impl ::buffa::bytes::Buf,
+        depth: u32,
+    ) -> ::core::result::Result<(), ::buffa::DecodeError> {
+        #[allow(unused_imports)]
+        use ::buffa::bytes::Buf as _;
+        #[allow(unused_imports)]
+        use ::buffa::Enumeration as _;
+        match tag.field_number() {
+            1u32 => {
+                if tag.wire_type() != ::buffa::encoding::WireType::LengthDelimited {
+                    return ::core::result::Result::Err(::buffa::DecodeError::WireTypeMismatch {
+                        field_number: 1u32,
+                        expected: 2u8,
+                        actual: tag.wire_type() as u8,
+                    });
+                }
+                ::buffa::Message::merge_length_delimited(
+                    self.policy.get_or_insert_default(),
+                    buf,
+                    depth,
+                )?;
+            }
+            _ => {
+                self.__buffa_unknown_fields
+                    .push(::buffa::encoding::decode_unknown_field(tag, buf, depth)?);
+            }
+        }
+        ::core::result::Result::Ok(())
+    }
+    fn clear(&mut self) {
+        self.policy = ::buffa::MessageField::none();
+        self.__buffa_unknown_fields.clear();
+    }
+}
+impl ::buffa::ExtensionSet for SetRetentionRequest {
+    const PROTO_FQN: &'static str = "log.stream.v1.SetRetentionRequest";
+    fn unknown_fields(&self) -> &::buffa::UnknownFields {
+        &self.__buffa_unknown_fields
+    }
+    fn unknown_fields_mut(&mut self) -> &mut ::buffa::UnknownFields {
+        &mut self.__buffa_unknown_fields
+    }
+}
+impl ::buffa::json_helpers::ProtoElemJson for SetRetentionRequest {
+    fn serialize_proto_json<S: ::serde::Serializer>(
+        v: &Self,
+        s: S,
+    ) -> ::core::result::Result<S::Ok, S::Error> {
+        ::serde::Serialize::serialize(v, s)
+    }
+    fn deserialize_proto_json<'de, D: ::serde::Deserializer<'de>>(
+        d: D,
+    ) -> ::core::result::Result<Self, D::Error> {
+        <Self as ::serde::Deserialize>::deserialize(d)
+    }
+}
+#[doc(hidden)]
+pub const __SET_RETENTION_REQUEST_JSON_ANY: ::buffa::type_registry::JsonAnyEntry = ::buffa::type_registry::JsonAnyEntry {
+    type_url: "type.googleapis.com/log.stream.v1.SetRetentionRequest",
+    to_json: ::buffa::type_registry::any_to_json::<SetRetentionRequest>,
+    from_json: ::buffa::type_registry::any_from_json::<SetRetentionRequest>,
+    is_wkt: false,
+};
+/// Result of applying the rule change once, synchronously.
+#[derive(Clone, PartialEq, Default)]
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[serde(default)]
+pub struct SetRetentionResponse {
+    /// Lowest sequence number still retained after that application. Absent when
+    /// the log is empty / no floor exists yet.
+    ///
+    /// Field 1: `oldest_retained_sequence`
+    #[serde(
+        rename = "oldestRetainedSequence",
+        alias = "oldest_retained_sequence",
+        with = "::buffa::json_helpers::opt_uint64",
+        skip_serializing_if = "::core::option::Option::is_none"
+    )]
+    pub oldest_retained_sequence: ::core::option::Option<u64>,
+    #[serde(skip)]
+    #[doc(hidden)]
+    pub __buffa_unknown_fields: ::buffa::UnknownFields,
+}
+impl ::core::fmt::Debug for SetRetentionResponse {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+        f.debug_struct("SetRetentionResponse")
+            .field("oldest_retained_sequence", &self.oldest_retained_sequence)
+            .finish()
+    }
+}
+impl SetRetentionResponse {
+    /// Protobuf type URL for this message, for use with `Any::pack` and
+    /// `Any::unpack_if`.
+    ///
+    /// Format: `type.googleapis.com/<fully.qualified.TypeName>`
+    pub const TYPE_URL: &'static str = "type.googleapis.com/log.stream.v1.SetRetentionResponse";
+}
+impl SetRetentionResponse {
+    #[must_use = "with_* setters return `self` by value; assign or chain the result"]
+    #[inline]
+    ///Sets [`Self::oldest_retained_sequence`] to `Some(value)`, consuming and returning `self`.
+    pub fn with_oldest_retained_sequence(mut self, value: u64) -> Self {
+        self.oldest_retained_sequence = Some(value);
+        self
+    }
+}
+impl ::buffa::DefaultInstance for SetRetentionResponse {
+    fn default_instance() -> &'static Self {
+        static VALUE: ::buffa::__private::OnceBox<SetRetentionResponse> = ::buffa::__private::OnceBox::new();
+        VALUE.get_or_init(|| ::buffa::alloc::boxed::Box::new(Self::default()))
+    }
+}
+impl ::buffa::MessageName for SetRetentionResponse {
+    const PACKAGE: &'static str = "log.stream.v1";
+    const NAME: &'static str = "SetRetentionResponse";
+    const FULL_NAME: &'static str = "log.stream.v1.SetRetentionResponse";
+    const TYPE_URL: &'static str = "type.googleapis.com/log.stream.v1.SetRetentionResponse";
+}
+impl ::buffa::Message for SetRetentionResponse {
+    /// Returns the total encoded size in bytes.
+    ///
+    /// The result is a `u32`; the protobuf specification requires all
+    /// messages to fit within 2 GiB (2,147,483,647 bytes), so a
+    /// compliant message will never overflow this type.
+    #[allow(clippy::let_and_return)]
+    fn compute_size(&self, _cache: &mut ::buffa::SizeCache) -> u32 {
+        #[allow(unused_imports)]
+        use ::buffa::Enumeration as _;
+        let mut size = 0u32;
+        if let Some(v) = self.oldest_retained_sequence {
+            size += 1u32 + ::buffa::types::uint64_encoded_len(v) as u32;
+        }
+        size += self.__buffa_unknown_fields.encoded_len() as u32;
+        size
+    }
+    fn write_to(
+        &self,
+        _cache: &mut ::buffa::SizeCache,
+        buf: &mut impl ::buffa::bytes::BufMut,
+    ) {
+        #[allow(unused_imports)]
+        use ::buffa::Enumeration as _;
+        if let Some(v) = self.oldest_retained_sequence {
+            ::buffa::encoding::Tag::new(1u32, ::buffa::encoding::WireType::Varint)
+                .encode(buf);
+            ::buffa::types::encode_uint64(v, buf);
+        }
+        self.__buffa_unknown_fields.write_to(buf);
+    }
+    fn merge_field(
+        &mut self,
+        tag: ::buffa::encoding::Tag,
+        buf: &mut impl ::buffa::bytes::Buf,
+        depth: u32,
+    ) -> ::core::result::Result<(), ::buffa::DecodeError> {
+        #[allow(unused_imports)]
+        use ::buffa::bytes::Buf as _;
+        #[allow(unused_imports)]
+        use ::buffa::Enumeration as _;
+        match tag.field_number() {
+            1u32 => {
+                if tag.wire_type() != ::buffa::encoding::WireType::Varint {
+                    return ::core::result::Result::Err(::buffa::DecodeError::WireTypeMismatch {
+                        field_number: 1u32,
+                        expected: 0u8,
+                        actual: tag.wire_type() as u8,
+                    });
+                }
+                self.oldest_retained_sequence = ::core::option::Option::Some(
+                    ::buffa::types::decode_uint64(buf)?,
+                );
+            }
+            _ => {
+                self.__buffa_unknown_fields
+                    .push(::buffa::encoding::decode_unknown_field(tag, buf, depth)?);
+            }
+        }
+        ::core::result::Result::Ok(())
+    }
+    fn clear(&mut self) {
+        self.oldest_retained_sequence = ::core::option::Option::None;
+        self.__buffa_unknown_fields.clear();
+    }
+}
+impl ::buffa::ExtensionSet for SetRetentionResponse {
+    const PROTO_FQN: &'static str = "log.stream.v1.SetRetentionResponse";
+    fn unknown_fields(&self) -> &::buffa::UnknownFields {
+        &self.__buffa_unknown_fields
+    }
+    fn unknown_fields_mut(&mut self) -> &mut ::buffa::UnknownFields {
+        &mut self.__buffa_unknown_fields
+    }
+}
+impl ::buffa::json_helpers::ProtoElemJson for SetRetentionResponse {
+    fn serialize_proto_json<S: ::serde::Serializer>(
+        v: &Self,
+        s: S,
+    ) -> ::core::result::Result<S::Ok, S::Error> {
+        ::serde::Serialize::serialize(v, s)
+    }
+    fn deserialize_proto_json<'de, D: ::serde::Deserializer<'de>>(
+        d: D,
+    ) -> ::core::result::Result<Self, D::Error> {
+        <Self as ::serde::Deserialize>::deserialize(d)
+    }
+}
+#[doc(hidden)]
+pub const __SET_RETENTION_RESPONSE_JSON_ANY: ::buffa::type_registry::JsonAnyEntry = ::buffa::type_registry::JsonAnyEntry {
+    type_url: "type.googleapis.com/log.stream.v1.SetRetentionResponse",
+    to_json: ::buffa::type_registry::any_to_json::<SetRetentionResponse>,
+    from_json: ::buffa::type_registry::any_from_json::<SetRetentionResponse>,
+    is_wkt: false,
+};
 #[allow(
     non_camel_case_types,
     dead_code,
@@ -1774,6 +3025,1759 @@ pub mod __buffa {
                 this
             }
         }
+        /// Keep the newest `count` batches. Continuous: as new batches are appended the
+        /// retained window slides forward with the live frontier, evicting whatever
+        /// falls below it.
+        #[derive(Clone, Debug, Default)]
+        pub struct RetentionKeepLatestView<'a> {
+            /// Field 1: `count`
+            pub count: u64,
+            pub __buffa_unknown_fields: ::buffa::UnknownFieldsView<'a>,
+        }
+        impl<'a> RetentionKeepLatestView<'a> {
+            /// Decode from `buf`, enforcing a recursion depth limit for nested messages.
+            ///
+            /// Called by [`::buffa::MessageView::decode_view`] with [`::buffa::RECURSION_LIMIT`]
+            /// and by generated sub-message decode arms with `depth - 1`.
+            ///
+            /// **Not part of the public API.** Named with a leading underscore to
+            /// signal that it is for generated-code use only.
+            #[doc(hidden)]
+            pub fn _decode_depth(
+                buf: &'a [u8],
+                depth: u32,
+            ) -> ::core::result::Result<Self, ::buffa::DecodeError> {
+                let mut view = Self::default();
+                view._merge_into_view(buf, depth)?;
+                ::core::result::Result::Ok(view)
+            }
+            /// Merge fields from `buf` into this view (proto merge semantics).
+            ///
+            /// Repeated fields append; singular fields last-wins; singular
+            /// MESSAGE fields merge recursively. Used by sub-message decode
+            /// arms when the same field appears multiple times on the wire.
+            ///
+            /// **Not part of the public API.**
+            #[doc(hidden)]
+            pub fn _merge_into_view(
+                &mut self,
+                buf: &'a [u8],
+                depth: u32,
+            ) -> ::core::result::Result<(), ::buffa::DecodeError> {
+                let _ = depth;
+                #[allow(unused_variables)]
+                let view = self;
+                let mut cur: &'a [u8] = buf;
+                while !cur.is_empty() {
+                    let before_tag = cur;
+                    let tag = ::buffa::encoding::Tag::decode(&mut cur)?;
+                    match tag.field_number() {
+                        1u32 => {
+                            if tag.wire_type() != ::buffa::encoding::WireType::Varint {
+                                return ::core::result::Result::Err(::buffa::DecodeError::WireTypeMismatch {
+                                    field_number: 1u32,
+                                    expected: 0u8,
+                                    actual: tag.wire_type() as u8,
+                                });
+                            }
+                            view.count = ::buffa::types::decode_uint64(&mut cur)?;
+                        }
+                        _ => {
+                            ::buffa::encoding::skip_field_depth(tag, &mut cur, depth)?;
+                            let span_len = before_tag.len() - cur.len();
+                            view.__buffa_unknown_fields
+                                .push_raw(&before_tag[..span_len]);
+                        }
+                    }
+                }
+                ::core::result::Result::Ok(())
+            }
+        }
+        impl<'a> ::buffa::MessageView<'a> for RetentionKeepLatestView<'a> {
+            type Owned = super::super::RetentionKeepLatest;
+            fn decode_view(
+                buf: &'a [u8],
+            ) -> ::core::result::Result<Self, ::buffa::DecodeError> {
+                Self::_decode_depth(buf, ::buffa::RECURSION_LIMIT)
+            }
+            fn decode_view_with_limit(
+                buf: &'a [u8],
+                depth: u32,
+            ) -> ::core::result::Result<Self, ::buffa::DecodeError> {
+                Self::_decode_depth(buf, depth)
+            }
+            fn to_owned_message(&self) -> super::super::RetentionKeepLatest {
+                self.to_owned_from_source(None)
+            }
+            #[allow(clippy::useless_conversion, clippy::needless_update)]
+            fn to_owned_from_source(
+                &self,
+                __buffa_src: ::core::option::Option<&::buffa::bytes::Bytes>,
+            ) -> super::super::RetentionKeepLatest {
+                #[allow(unused_imports)]
+                use ::buffa::alloc::string::ToString as _;
+                let _ = __buffa_src;
+                super::super::RetentionKeepLatest {
+                    count: self.count,
+                    __buffa_unknown_fields: self
+                        .__buffa_unknown_fields
+                        .to_owned()
+                        .unwrap_or_default()
+                        .into(),
+                    ..::core::default::Default::default()
+                }
+            }
+        }
+        impl<'a> ::buffa::ViewEncode<'a> for RetentionKeepLatestView<'a> {
+            #[allow(clippy::needless_borrow, clippy::let_and_return)]
+            fn compute_size(&self, _cache: &mut ::buffa::SizeCache) -> u32 {
+                #[allow(unused_imports)]
+                use ::buffa::Enumeration as _;
+                let mut size = 0u32;
+                if self.count != 0u64 {
+                    size += 1u32 + ::buffa::types::uint64_encoded_len(self.count) as u32;
+                }
+                size += self.__buffa_unknown_fields.encoded_len() as u32;
+                size
+            }
+            #[allow(clippy::needless_borrow)]
+            fn write_to(
+                &self,
+                _cache: &mut ::buffa::SizeCache,
+                buf: &mut impl ::buffa::bytes::BufMut,
+            ) {
+                #[allow(unused_imports)]
+                use ::buffa::Enumeration as _;
+                if self.count != 0u64 {
+                    ::buffa::encoding::Tag::new(
+                            1u32,
+                            ::buffa::encoding::WireType::Varint,
+                        )
+                        .encode(buf);
+                    ::buffa::types::encode_uint64(self.count, buf);
+                }
+                self.__buffa_unknown_fields.write_to(buf);
+            }
+        }
+        /// Serializes this view as protobuf JSON.
+        ///
+        /// Implicit-presence fields with default values are omitted, `required`
+        /// fields are always emitted, explicit-presence (`optional`) fields are
+        /// emitted only when set, bytes fields are base64-encoded, and enum
+        /// values are their proto name strings.
+        ///
+        /// This impl uses `serialize_map(None)` because the number of emitted
+        /// fields depends on default-omission rules; serializers that require
+        /// known map lengths (e.g. `bincode`) will return a runtime error.
+        /// Use the owned message type for those formats.
+        impl<'__a> ::serde::Serialize for RetentionKeepLatestView<'__a> {
+            fn serialize<__S: ::serde::Serializer>(
+                &self,
+                __s: __S,
+            ) -> ::core::result::Result<__S::Ok, __S::Error> {
+                use ::serde::ser::SerializeMap as _;
+                let mut __map = __s.serialize_map(::core::option::Option::None)?;
+                if !::buffa::json_helpers::skip_if::is_zero_u64(&self.count) {
+                    struct _W(u64);
+                    impl ::serde::Serialize for _W {
+                        fn serialize<__S: ::serde::Serializer>(
+                            &self,
+                            __s: __S,
+                        ) -> ::core::result::Result<__S::Ok, __S::Error> {
+                            ::buffa::json_helpers::uint64::serialize(&self.0, __s)
+                        }
+                    }
+                    __map.serialize_entry("count", &_W(self.count))?;
+                }
+                __map.end()
+            }
+        }
+        impl<'a> ::buffa::MessageName for RetentionKeepLatestView<'a> {
+            const PACKAGE: &'static str = "log.stream.v1";
+            const NAME: &'static str = "RetentionKeepLatest";
+            const FULL_NAME: &'static str = "log.stream.v1.RetentionKeepLatest";
+            const TYPE_URL: &'static str = "type.googleapis.com/log.stream.v1.RetentionKeepLatest";
+        }
+        impl<'v> ::buffa::DefaultViewInstance for RetentionKeepLatestView<'v> {
+            fn default_view_instance<'a>() -> &'a Self
+            where
+                Self: 'a,
+            {
+                static VALUE: ::buffa::__private::OnceBox<
+                    RetentionKeepLatestView<'static>,
+                > = ::buffa::__private::OnceBox::new();
+                VALUE
+                    .get_or_init(|| ::buffa::alloc::boxed::Box::new(
+                        <RetentionKeepLatestView<'static>>::default(),
+                    ))
+            }
+        }
+        impl ::buffa::ViewReborrow for RetentionKeepLatestView<'static> {
+            type Reborrowed<'b> = RetentionKeepLatestView<'b>;
+            fn reborrow<'b>(this: &'b Self) -> &'b Self::Reborrowed<'b> {
+                this
+            }
+        }
+        /// Retain sequence numbers strictly greater than `threshold`; evict the rest.
+        #[derive(Clone, Debug, Default)]
+        pub struct RetentionGreaterThanView<'a> {
+            /// Field 1: `threshold`
+            pub threshold: u64,
+            pub __buffa_unknown_fields: ::buffa::UnknownFieldsView<'a>,
+        }
+        impl<'a> RetentionGreaterThanView<'a> {
+            /// Decode from `buf`, enforcing a recursion depth limit for nested messages.
+            ///
+            /// Called by [`::buffa::MessageView::decode_view`] with [`::buffa::RECURSION_LIMIT`]
+            /// and by generated sub-message decode arms with `depth - 1`.
+            ///
+            /// **Not part of the public API.** Named with a leading underscore to
+            /// signal that it is for generated-code use only.
+            #[doc(hidden)]
+            pub fn _decode_depth(
+                buf: &'a [u8],
+                depth: u32,
+            ) -> ::core::result::Result<Self, ::buffa::DecodeError> {
+                let mut view = Self::default();
+                view._merge_into_view(buf, depth)?;
+                ::core::result::Result::Ok(view)
+            }
+            /// Merge fields from `buf` into this view (proto merge semantics).
+            ///
+            /// Repeated fields append; singular fields last-wins; singular
+            /// MESSAGE fields merge recursively. Used by sub-message decode
+            /// arms when the same field appears multiple times on the wire.
+            ///
+            /// **Not part of the public API.**
+            #[doc(hidden)]
+            pub fn _merge_into_view(
+                &mut self,
+                buf: &'a [u8],
+                depth: u32,
+            ) -> ::core::result::Result<(), ::buffa::DecodeError> {
+                let _ = depth;
+                #[allow(unused_variables)]
+                let view = self;
+                let mut cur: &'a [u8] = buf;
+                while !cur.is_empty() {
+                    let before_tag = cur;
+                    let tag = ::buffa::encoding::Tag::decode(&mut cur)?;
+                    match tag.field_number() {
+                        1u32 => {
+                            if tag.wire_type() != ::buffa::encoding::WireType::Varint {
+                                return ::core::result::Result::Err(::buffa::DecodeError::WireTypeMismatch {
+                                    field_number: 1u32,
+                                    expected: 0u8,
+                                    actual: tag.wire_type() as u8,
+                                });
+                            }
+                            view.threshold = ::buffa::types::decode_uint64(&mut cur)?;
+                        }
+                        _ => {
+                            ::buffa::encoding::skip_field_depth(tag, &mut cur, depth)?;
+                            let span_len = before_tag.len() - cur.len();
+                            view.__buffa_unknown_fields
+                                .push_raw(&before_tag[..span_len]);
+                        }
+                    }
+                }
+                ::core::result::Result::Ok(())
+            }
+        }
+        impl<'a> ::buffa::MessageView<'a> for RetentionGreaterThanView<'a> {
+            type Owned = super::super::RetentionGreaterThan;
+            fn decode_view(
+                buf: &'a [u8],
+            ) -> ::core::result::Result<Self, ::buffa::DecodeError> {
+                Self::_decode_depth(buf, ::buffa::RECURSION_LIMIT)
+            }
+            fn decode_view_with_limit(
+                buf: &'a [u8],
+                depth: u32,
+            ) -> ::core::result::Result<Self, ::buffa::DecodeError> {
+                Self::_decode_depth(buf, depth)
+            }
+            fn to_owned_message(&self) -> super::super::RetentionGreaterThan {
+                self.to_owned_from_source(None)
+            }
+            #[allow(clippy::useless_conversion, clippy::needless_update)]
+            fn to_owned_from_source(
+                &self,
+                __buffa_src: ::core::option::Option<&::buffa::bytes::Bytes>,
+            ) -> super::super::RetentionGreaterThan {
+                #[allow(unused_imports)]
+                use ::buffa::alloc::string::ToString as _;
+                let _ = __buffa_src;
+                super::super::RetentionGreaterThan {
+                    threshold: self.threshold,
+                    __buffa_unknown_fields: self
+                        .__buffa_unknown_fields
+                        .to_owned()
+                        .unwrap_or_default()
+                        .into(),
+                    ..::core::default::Default::default()
+                }
+            }
+        }
+        impl<'a> ::buffa::ViewEncode<'a> for RetentionGreaterThanView<'a> {
+            #[allow(clippy::needless_borrow, clippy::let_and_return)]
+            fn compute_size(&self, _cache: &mut ::buffa::SizeCache) -> u32 {
+                #[allow(unused_imports)]
+                use ::buffa::Enumeration as _;
+                let mut size = 0u32;
+                if self.threshold != 0u64 {
+                    size
+                        += 1u32
+                            + ::buffa::types::uint64_encoded_len(self.threshold) as u32;
+                }
+                size += self.__buffa_unknown_fields.encoded_len() as u32;
+                size
+            }
+            #[allow(clippy::needless_borrow)]
+            fn write_to(
+                &self,
+                _cache: &mut ::buffa::SizeCache,
+                buf: &mut impl ::buffa::bytes::BufMut,
+            ) {
+                #[allow(unused_imports)]
+                use ::buffa::Enumeration as _;
+                if self.threshold != 0u64 {
+                    ::buffa::encoding::Tag::new(
+                            1u32,
+                            ::buffa::encoding::WireType::Varint,
+                        )
+                        .encode(buf);
+                    ::buffa::types::encode_uint64(self.threshold, buf);
+                }
+                self.__buffa_unknown_fields.write_to(buf);
+            }
+        }
+        /// Serializes this view as protobuf JSON.
+        ///
+        /// Implicit-presence fields with default values are omitted, `required`
+        /// fields are always emitted, explicit-presence (`optional`) fields are
+        /// emitted only when set, bytes fields are base64-encoded, and enum
+        /// values are their proto name strings.
+        ///
+        /// This impl uses `serialize_map(None)` because the number of emitted
+        /// fields depends on default-omission rules; serializers that require
+        /// known map lengths (e.g. `bincode`) will return a runtime error.
+        /// Use the owned message type for those formats.
+        impl<'__a> ::serde::Serialize for RetentionGreaterThanView<'__a> {
+            fn serialize<__S: ::serde::Serializer>(
+                &self,
+                __s: __S,
+            ) -> ::core::result::Result<__S::Ok, __S::Error> {
+                use ::serde::ser::SerializeMap as _;
+                let mut __map = __s.serialize_map(::core::option::Option::None)?;
+                if !::buffa::json_helpers::skip_if::is_zero_u64(&self.threshold) {
+                    struct _W(u64);
+                    impl ::serde::Serialize for _W {
+                        fn serialize<__S: ::serde::Serializer>(
+                            &self,
+                            __s: __S,
+                        ) -> ::core::result::Result<__S::Ok, __S::Error> {
+                            ::buffa::json_helpers::uint64::serialize(&self.0, __s)
+                        }
+                    }
+                    __map.serialize_entry("threshold", &_W(self.threshold))?;
+                }
+                __map.end()
+            }
+        }
+        impl<'a> ::buffa::MessageName for RetentionGreaterThanView<'a> {
+            const PACKAGE: &'static str = "log.stream.v1";
+            const NAME: &'static str = "RetentionGreaterThan";
+            const FULL_NAME: &'static str = "log.stream.v1.RetentionGreaterThan";
+            const TYPE_URL: &'static str = "type.googleapis.com/log.stream.v1.RetentionGreaterThan";
+        }
+        impl<'v> ::buffa::DefaultViewInstance for RetentionGreaterThanView<'v> {
+            fn default_view_instance<'a>() -> &'a Self
+            where
+                Self: 'a,
+            {
+                static VALUE: ::buffa::__private::OnceBox<
+                    RetentionGreaterThanView<'static>,
+                > = ::buffa::__private::OnceBox::new();
+                VALUE
+                    .get_or_init(|| ::buffa::alloc::boxed::Box::new(
+                        <RetentionGreaterThanView<'static>>::default(),
+                    ))
+            }
+        }
+        impl ::buffa::ViewReborrow for RetentionGreaterThanView<'static> {
+            type Reborrowed<'b> = RetentionGreaterThanView<'b>;
+            fn reborrow<'b>(this: &'b Self) -> &'b Self::Reborrowed<'b> {
+                this
+            }
+        }
+        /// Retain sequence numbers greater than or equal to `threshold`; evict the rest.
+        #[derive(Clone, Debug, Default)]
+        pub struct RetentionGreaterThanOrEqualView<'a> {
+            /// Field 1: `threshold`
+            pub threshold: u64,
+            pub __buffa_unknown_fields: ::buffa::UnknownFieldsView<'a>,
+        }
+        impl<'a> RetentionGreaterThanOrEqualView<'a> {
+            /// Decode from `buf`, enforcing a recursion depth limit for nested messages.
+            ///
+            /// Called by [`::buffa::MessageView::decode_view`] with [`::buffa::RECURSION_LIMIT`]
+            /// and by generated sub-message decode arms with `depth - 1`.
+            ///
+            /// **Not part of the public API.** Named with a leading underscore to
+            /// signal that it is for generated-code use only.
+            #[doc(hidden)]
+            pub fn _decode_depth(
+                buf: &'a [u8],
+                depth: u32,
+            ) -> ::core::result::Result<Self, ::buffa::DecodeError> {
+                let mut view = Self::default();
+                view._merge_into_view(buf, depth)?;
+                ::core::result::Result::Ok(view)
+            }
+            /// Merge fields from `buf` into this view (proto merge semantics).
+            ///
+            /// Repeated fields append; singular fields last-wins; singular
+            /// MESSAGE fields merge recursively. Used by sub-message decode
+            /// arms when the same field appears multiple times on the wire.
+            ///
+            /// **Not part of the public API.**
+            #[doc(hidden)]
+            pub fn _merge_into_view(
+                &mut self,
+                buf: &'a [u8],
+                depth: u32,
+            ) -> ::core::result::Result<(), ::buffa::DecodeError> {
+                let _ = depth;
+                #[allow(unused_variables)]
+                let view = self;
+                let mut cur: &'a [u8] = buf;
+                while !cur.is_empty() {
+                    let before_tag = cur;
+                    let tag = ::buffa::encoding::Tag::decode(&mut cur)?;
+                    match tag.field_number() {
+                        1u32 => {
+                            if tag.wire_type() != ::buffa::encoding::WireType::Varint {
+                                return ::core::result::Result::Err(::buffa::DecodeError::WireTypeMismatch {
+                                    field_number: 1u32,
+                                    expected: 0u8,
+                                    actual: tag.wire_type() as u8,
+                                });
+                            }
+                            view.threshold = ::buffa::types::decode_uint64(&mut cur)?;
+                        }
+                        _ => {
+                            ::buffa::encoding::skip_field_depth(tag, &mut cur, depth)?;
+                            let span_len = before_tag.len() - cur.len();
+                            view.__buffa_unknown_fields
+                                .push_raw(&before_tag[..span_len]);
+                        }
+                    }
+                }
+                ::core::result::Result::Ok(())
+            }
+        }
+        impl<'a> ::buffa::MessageView<'a> for RetentionGreaterThanOrEqualView<'a> {
+            type Owned = super::super::RetentionGreaterThanOrEqual;
+            fn decode_view(
+                buf: &'a [u8],
+            ) -> ::core::result::Result<Self, ::buffa::DecodeError> {
+                Self::_decode_depth(buf, ::buffa::RECURSION_LIMIT)
+            }
+            fn decode_view_with_limit(
+                buf: &'a [u8],
+                depth: u32,
+            ) -> ::core::result::Result<Self, ::buffa::DecodeError> {
+                Self::_decode_depth(buf, depth)
+            }
+            fn to_owned_message(&self) -> super::super::RetentionGreaterThanOrEqual {
+                self.to_owned_from_source(None)
+            }
+            #[allow(clippy::useless_conversion, clippy::needless_update)]
+            fn to_owned_from_source(
+                &self,
+                __buffa_src: ::core::option::Option<&::buffa::bytes::Bytes>,
+            ) -> super::super::RetentionGreaterThanOrEqual {
+                #[allow(unused_imports)]
+                use ::buffa::alloc::string::ToString as _;
+                let _ = __buffa_src;
+                super::super::RetentionGreaterThanOrEqual {
+                    threshold: self.threshold,
+                    __buffa_unknown_fields: self
+                        .__buffa_unknown_fields
+                        .to_owned()
+                        .unwrap_or_default()
+                        .into(),
+                    ..::core::default::Default::default()
+                }
+            }
+        }
+        impl<'a> ::buffa::ViewEncode<'a> for RetentionGreaterThanOrEqualView<'a> {
+            #[allow(clippy::needless_borrow, clippy::let_and_return)]
+            fn compute_size(&self, _cache: &mut ::buffa::SizeCache) -> u32 {
+                #[allow(unused_imports)]
+                use ::buffa::Enumeration as _;
+                let mut size = 0u32;
+                if self.threshold != 0u64 {
+                    size
+                        += 1u32
+                            + ::buffa::types::uint64_encoded_len(self.threshold) as u32;
+                }
+                size += self.__buffa_unknown_fields.encoded_len() as u32;
+                size
+            }
+            #[allow(clippy::needless_borrow)]
+            fn write_to(
+                &self,
+                _cache: &mut ::buffa::SizeCache,
+                buf: &mut impl ::buffa::bytes::BufMut,
+            ) {
+                #[allow(unused_imports)]
+                use ::buffa::Enumeration as _;
+                if self.threshold != 0u64 {
+                    ::buffa::encoding::Tag::new(
+                            1u32,
+                            ::buffa::encoding::WireType::Varint,
+                        )
+                        .encode(buf);
+                    ::buffa::types::encode_uint64(self.threshold, buf);
+                }
+                self.__buffa_unknown_fields.write_to(buf);
+            }
+        }
+        /// Serializes this view as protobuf JSON.
+        ///
+        /// Implicit-presence fields with default values are omitted, `required`
+        /// fields are always emitted, explicit-presence (`optional`) fields are
+        /// emitted only when set, bytes fields are base64-encoded, and enum
+        /// values are their proto name strings.
+        ///
+        /// This impl uses `serialize_map(None)` because the number of emitted
+        /// fields depends on default-omission rules; serializers that require
+        /// known map lengths (e.g. `bincode`) will return a runtime error.
+        /// Use the owned message type for those formats.
+        impl<'__a> ::serde::Serialize for RetentionGreaterThanOrEqualView<'__a> {
+            fn serialize<__S: ::serde::Serializer>(
+                &self,
+                __s: __S,
+            ) -> ::core::result::Result<__S::Ok, __S::Error> {
+                use ::serde::ser::SerializeMap as _;
+                let mut __map = __s.serialize_map(::core::option::Option::None)?;
+                if !::buffa::json_helpers::skip_if::is_zero_u64(&self.threshold) {
+                    struct _W(u64);
+                    impl ::serde::Serialize for _W {
+                        fn serialize<__S: ::serde::Serializer>(
+                            &self,
+                            __s: __S,
+                        ) -> ::core::result::Result<__S::Ok, __S::Error> {
+                            ::buffa::json_helpers::uint64::serialize(&self.0, __s)
+                        }
+                    }
+                    __map.serialize_entry("threshold", &_W(self.threshold))?;
+                }
+                __map.end()
+            }
+        }
+        impl<'a> ::buffa::MessageName for RetentionGreaterThanOrEqualView<'a> {
+            const PACKAGE: &'static str = "log.stream.v1";
+            const NAME: &'static str = "RetentionGreaterThanOrEqual";
+            const FULL_NAME: &'static str = "log.stream.v1.RetentionGreaterThanOrEqual";
+            const TYPE_URL: &'static str = "type.googleapis.com/log.stream.v1.RetentionGreaterThanOrEqual";
+        }
+        impl<'v> ::buffa::DefaultViewInstance for RetentionGreaterThanOrEqualView<'v> {
+            fn default_view_instance<'a>() -> &'a Self
+            where
+                Self: 'a,
+            {
+                static VALUE: ::buffa::__private::OnceBox<
+                    RetentionGreaterThanOrEqualView<'static>,
+                > = ::buffa::__private::OnceBox::new();
+                VALUE
+                    .get_or_init(|| ::buffa::alloc::boxed::Box::new(
+                        <RetentionGreaterThanOrEqualView<'static>>::default(),
+                    ))
+            }
+        }
+        impl ::buffa::ViewReborrow for RetentionGreaterThanOrEqualView<'static> {
+            type Reborrowed<'b> = RetentionGreaterThanOrEqualView<'b>;
+            fn reborrow<'b>(this: &'b Self) -> &'b Self::Reborrowed<'b> {
+                this
+            }
+        }
+        /// Retain nothing: evict up to the live frontier and keep doing so as the log
+        /// grows.
+        #[derive(Clone, Debug, Default)]
+        pub struct RetentionDropAllView<'a> {
+            pub __buffa_unknown_fields: ::buffa::UnknownFieldsView<'a>,
+        }
+        impl<'a> RetentionDropAllView<'a> {
+            /// Decode from `buf`, enforcing a recursion depth limit for nested messages.
+            ///
+            /// Called by [`::buffa::MessageView::decode_view`] with [`::buffa::RECURSION_LIMIT`]
+            /// and by generated sub-message decode arms with `depth - 1`.
+            ///
+            /// **Not part of the public API.** Named with a leading underscore to
+            /// signal that it is for generated-code use only.
+            #[doc(hidden)]
+            pub fn _decode_depth(
+                buf: &'a [u8],
+                depth: u32,
+            ) -> ::core::result::Result<Self, ::buffa::DecodeError> {
+                let mut view = Self::default();
+                view._merge_into_view(buf, depth)?;
+                ::core::result::Result::Ok(view)
+            }
+            /// Merge fields from `buf` into this view (proto merge semantics).
+            ///
+            /// Repeated fields append; singular fields last-wins; singular
+            /// MESSAGE fields merge recursively. Used by sub-message decode
+            /// arms when the same field appears multiple times on the wire.
+            ///
+            /// **Not part of the public API.**
+            #[doc(hidden)]
+            pub fn _merge_into_view(
+                &mut self,
+                buf: &'a [u8],
+                depth: u32,
+            ) -> ::core::result::Result<(), ::buffa::DecodeError> {
+                let _ = depth;
+                #[allow(unused_variables)]
+                let view = self;
+                let mut cur: &'a [u8] = buf;
+                while !cur.is_empty() {
+                    let before_tag = cur;
+                    let tag = ::buffa::encoding::Tag::decode(&mut cur)?;
+                    match tag.field_number() {
+                        _ => {
+                            ::buffa::encoding::skip_field_depth(tag, &mut cur, depth)?;
+                            let span_len = before_tag.len() - cur.len();
+                            view.__buffa_unknown_fields
+                                .push_raw(&before_tag[..span_len]);
+                        }
+                    }
+                }
+                ::core::result::Result::Ok(())
+            }
+        }
+        impl<'a> ::buffa::MessageView<'a> for RetentionDropAllView<'a> {
+            type Owned = super::super::RetentionDropAll;
+            fn decode_view(
+                buf: &'a [u8],
+            ) -> ::core::result::Result<Self, ::buffa::DecodeError> {
+                Self::_decode_depth(buf, ::buffa::RECURSION_LIMIT)
+            }
+            fn decode_view_with_limit(
+                buf: &'a [u8],
+                depth: u32,
+            ) -> ::core::result::Result<Self, ::buffa::DecodeError> {
+                Self::_decode_depth(buf, depth)
+            }
+            fn to_owned_message(&self) -> super::super::RetentionDropAll {
+                self.to_owned_from_source(None)
+            }
+            #[allow(clippy::useless_conversion, clippy::needless_update)]
+            fn to_owned_from_source(
+                &self,
+                __buffa_src: ::core::option::Option<&::buffa::bytes::Bytes>,
+            ) -> super::super::RetentionDropAll {
+                #[allow(unused_imports)]
+                use ::buffa::alloc::string::ToString as _;
+                let _ = __buffa_src;
+                super::super::RetentionDropAll {
+                    __buffa_unknown_fields: self
+                        .__buffa_unknown_fields
+                        .to_owned()
+                        .unwrap_or_default()
+                        .into(),
+                    ..::core::default::Default::default()
+                }
+            }
+        }
+        impl<'a> ::buffa::ViewEncode<'a> for RetentionDropAllView<'a> {
+            #[allow(clippy::needless_borrow, clippy::let_and_return)]
+            fn compute_size(&self, _cache: &mut ::buffa::SizeCache) -> u32 {
+                #[allow(unused_imports)]
+                use ::buffa::Enumeration as _;
+                let mut size = 0u32;
+                size += self.__buffa_unknown_fields.encoded_len() as u32;
+                size
+            }
+            #[allow(clippy::needless_borrow)]
+            fn write_to(
+                &self,
+                _cache: &mut ::buffa::SizeCache,
+                buf: &mut impl ::buffa::bytes::BufMut,
+            ) {
+                #[allow(unused_imports)]
+                use ::buffa::Enumeration as _;
+                self.__buffa_unknown_fields.write_to(buf);
+            }
+        }
+        /// Serializes this view as protobuf JSON.
+        ///
+        /// Implicit-presence fields with default values are omitted, `required`
+        /// fields are always emitted, explicit-presence (`optional`) fields are
+        /// emitted only when set, bytes fields are base64-encoded, and enum
+        /// values are their proto name strings.
+        ///
+        /// This impl uses `serialize_map(None)` because the number of emitted
+        /// fields depends on default-omission rules; serializers that require
+        /// known map lengths (e.g. `bincode`) will return a runtime error.
+        /// Use the owned message type for those formats.
+        impl<'__a> ::serde::Serialize for RetentionDropAllView<'__a> {
+            fn serialize<__S: ::serde::Serializer>(
+                &self,
+                __s: __S,
+            ) -> ::core::result::Result<__S::Ok, __S::Error> {
+                use ::serde::ser::SerializeMap as _;
+                let mut __map = __s.serialize_map(::core::option::Option::None)?;
+                __map.end()
+            }
+        }
+        impl<'a> ::buffa::MessageName for RetentionDropAllView<'a> {
+            const PACKAGE: &'static str = "log.stream.v1";
+            const NAME: &'static str = "RetentionDropAll";
+            const FULL_NAME: &'static str = "log.stream.v1.RetentionDropAll";
+            const TYPE_URL: &'static str = "type.googleapis.com/log.stream.v1.RetentionDropAll";
+        }
+        impl<'v> ::buffa::DefaultViewInstance for RetentionDropAllView<'v> {
+            fn default_view_instance<'a>() -> &'a Self
+            where
+                Self: 'a,
+            {
+                static VALUE: ::buffa::__private::OnceBox<
+                    RetentionDropAllView<'static>,
+                > = ::buffa::__private::OnceBox::new();
+                VALUE
+                    .get_or_init(|| ::buffa::alloc::boxed::Box::new(
+                        <RetentionDropAllView<'static>>::default(),
+                    ))
+            }
+        }
+        impl ::buffa::ViewReborrow for RetentionDropAllView<'static> {
+            type Reborrowed<'b> = RetentionDropAllView<'b>;
+            fn reborrow<'b>(this: &'b Self) -> &'b Self::Reborrowed<'b> {
+                this
+            }
+        }
+        /// The retention rule to enforce over the sequence log.
+        #[derive(Clone, Debug, Default)]
+        pub struct RetentionPolicyView<'a> {
+            pub kind: ::core::option::Option<
+                super::super::__buffa::view::oneof::retention_policy::Kind<'a>,
+            >,
+            pub __buffa_unknown_fields: ::buffa::UnknownFieldsView<'a>,
+        }
+        impl<'a> RetentionPolicyView<'a> {
+            /// Decode from `buf`, enforcing a recursion depth limit for nested messages.
+            ///
+            /// Called by [`::buffa::MessageView::decode_view`] with [`::buffa::RECURSION_LIMIT`]
+            /// and by generated sub-message decode arms with `depth - 1`.
+            ///
+            /// **Not part of the public API.** Named with a leading underscore to
+            /// signal that it is for generated-code use only.
+            #[doc(hidden)]
+            pub fn _decode_depth(
+                buf: &'a [u8],
+                depth: u32,
+            ) -> ::core::result::Result<Self, ::buffa::DecodeError> {
+                let mut view = Self::default();
+                view._merge_into_view(buf, depth)?;
+                ::core::result::Result::Ok(view)
+            }
+            /// Merge fields from `buf` into this view (proto merge semantics).
+            ///
+            /// Repeated fields append; singular fields last-wins; singular
+            /// MESSAGE fields merge recursively. Used by sub-message decode
+            /// arms when the same field appears multiple times on the wire.
+            ///
+            /// **Not part of the public API.**
+            #[doc(hidden)]
+            pub fn _merge_into_view(
+                &mut self,
+                buf: &'a [u8],
+                depth: u32,
+            ) -> ::core::result::Result<(), ::buffa::DecodeError> {
+                let _ = depth;
+                #[allow(unused_variables)]
+                let view = self;
+                let mut cur: &'a [u8] = buf;
+                while !cur.is_empty() {
+                    let before_tag = cur;
+                    let tag = ::buffa::encoding::Tag::decode(&mut cur)?;
+                    match tag.field_number() {
+                        1u32 => {
+                            if tag.wire_type()
+                                != ::buffa::encoding::WireType::LengthDelimited
+                            {
+                                return ::core::result::Result::Err(::buffa::DecodeError::WireTypeMismatch {
+                                    field_number: 1u32,
+                                    expected: 2u8,
+                                    actual: tag.wire_type() as u8,
+                                });
+                            }
+                            if depth == 0 {
+                                return Err(::buffa::DecodeError::RecursionLimitExceeded);
+                            }
+                            let sub = ::buffa::types::borrow_bytes(&mut cur)?;
+                            if let Some(
+                                super::super::__buffa::view::oneof::retention_policy::Kind::KeepLatest(
+                                    ref mut existing,
+                                ),
+                            ) = view.kind
+                            {
+                                existing._merge_into_view(sub, depth - 1)?;
+                            } else {
+                                view.kind = Some(
+                                    super::super::__buffa::view::oneof::retention_policy::Kind::KeepLatest(
+                                        ::buffa::alloc::boxed::Box::new(
+                                            super::super::__buffa::view::RetentionKeepLatestView::_decode_depth(
+                                                sub,
+                                                depth - 1,
+                                            )?,
+                                        ),
+                                    ),
+                                );
+                            }
+                        }
+                        2u32 => {
+                            if tag.wire_type()
+                                != ::buffa::encoding::WireType::LengthDelimited
+                            {
+                                return ::core::result::Result::Err(::buffa::DecodeError::WireTypeMismatch {
+                                    field_number: 2u32,
+                                    expected: 2u8,
+                                    actual: tag.wire_type() as u8,
+                                });
+                            }
+                            if depth == 0 {
+                                return Err(::buffa::DecodeError::RecursionLimitExceeded);
+                            }
+                            let sub = ::buffa::types::borrow_bytes(&mut cur)?;
+                            if let Some(
+                                super::super::__buffa::view::oneof::retention_policy::Kind::GreaterThan(
+                                    ref mut existing,
+                                ),
+                            ) = view.kind
+                            {
+                                existing._merge_into_view(sub, depth - 1)?;
+                            } else {
+                                view.kind = Some(
+                                    super::super::__buffa::view::oneof::retention_policy::Kind::GreaterThan(
+                                        ::buffa::alloc::boxed::Box::new(
+                                            super::super::__buffa::view::RetentionGreaterThanView::_decode_depth(
+                                                sub,
+                                                depth - 1,
+                                            )?,
+                                        ),
+                                    ),
+                                );
+                            }
+                        }
+                        3u32 => {
+                            if tag.wire_type()
+                                != ::buffa::encoding::WireType::LengthDelimited
+                            {
+                                return ::core::result::Result::Err(::buffa::DecodeError::WireTypeMismatch {
+                                    field_number: 3u32,
+                                    expected: 2u8,
+                                    actual: tag.wire_type() as u8,
+                                });
+                            }
+                            if depth == 0 {
+                                return Err(::buffa::DecodeError::RecursionLimitExceeded);
+                            }
+                            let sub = ::buffa::types::borrow_bytes(&mut cur)?;
+                            if let Some(
+                                super::super::__buffa::view::oneof::retention_policy::Kind::GreaterThanOrEqual(
+                                    ref mut existing,
+                                ),
+                            ) = view.kind
+                            {
+                                existing._merge_into_view(sub, depth - 1)?;
+                            } else {
+                                view.kind = Some(
+                                    super::super::__buffa::view::oneof::retention_policy::Kind::GreaterThanOrEqual(
+                                        ::buffa::alloc::boxed::Box::new(
+                                            super::super::__buffa::view::RetentionGreaterThanOrEqualView::_decode_depth(
+                                                sub,
+                                                depth - 1,
+                                            )?,
+                                        ),
+                                    ),
+                                );
+                            }
+                        }
+                        4u32 => {
+                            if tag.wire_type()
+                                != ::buffa::encoding::WireType::LengthDelimited
+                            {
+                                return ::core::result::Result::Err(::buffa::DecodeError::WireTypeMismatch {
+                                    field_number: 4u32,
+                                    expected: 2u8,
+                                    actual: tag.wire_type() as u8,
+                                });
+                            }
+                            if depth == 0 {
+                                return Err(::buffa::DecodeError::RecursionLimitExceeded);
+                            }
+                            let sub = ::buffa::types::borrow_bytes(&mut cur)?;
+                            if let Some(
+                                super::super::__buffa::view::oneof::retention_policy::Kind::DropAll(
+                                    ref mut existing,
+                                ),
+                            ) = view.kind
+                            {
+                                existing._merge_into_view(sub, depth - 1)?;
+                            } else {
+                                view.kind = Some(
+                                    super::super::__buffa::view::oneof::retention_policy::Kind::DropAll(
+                                        ::buffa::alloc::boxed::Box::new(
+                                            super::super::__buffa::view::RetentionDropAllView::_decode_depth(
+                                                sub,
+                                                depth - 1,
+                                            )?,
+                                        ),
+                                    ),
+                                );
+                            }
+                        }
+                        _ => {
+                            ::buffa::encoding::skip_field_depth(tag, &mut cur, depth)?;
+                            let span_len = before_tag.len() - cur.len();
+                            view.__buffa_unknown_fields
+                                .push_raw(&before_tag[..span_len]);
+                        }
+                    }
+                }
+                ::core::result::Result::Ok(())
+            }
+        }
+        impl<'a> ::buffa::MessageView<'a> for RetentionPolicyView<'a> {
+            type Owned = super::super::RetentionPolicy;
+            fn decode_view(
+                buf: &'a [u8],
+            ) -> ::core::result::Result<Self, ::buffa::DecodeError> {
+                Self::_decode_depth(buf, ::buffa::RECURSION_LIMIT)
+            }
+            fn decode_view_with_limit(
+                buf: &'a [u8],
+                depth: u32,
+            ) -> ::core::result::Result<Self, ::buffa::DecodeError> {
+                Self::_decode_depth(buf, depth)
+            }
+            fn to_owned_message(&self) -> super::super::RetentionPolicy {
+                self.to_owned_from_source(None)
+            }
+            #[allow(clippy::useless_conversion, clippy::needless_update)]
+            fn to_owned_from_source(
+                &self,
+                __buffa_src: ::core::option::Option<&::buffa::bytes::Bytes>,
+            ) -> super::super::RetentionPolicy {
+                #[allow(unused_imports)]
+                use ::buffa::alloc::string::ToString as _;
+                let _ = __buffa_src;
+                super::super::RetentionPolicy {
+                    kind: self
+                        .kind
+                        .as_ref()
+                        .map(|v| match v {
+                            super::super::__buffa::view::oneof::retention_policy::Kind::KeepLatest(
+                                v,
+                            ) => {
+                                super::super::__buffa::oneof::retention_policy::Kind::KeepLatest(
+                                    ::buffa::alloc::boxed::Box::new(
+                                        v.to_owned_from_source(__buffa_src),
+                                    ),
+                                )
+                            }
+                            super::super::__buffa::view::oneof::retention_policy::Kind::GreaterThan(
+                                v,
+                            ) => {
+                                super::super::__buffa::oneof::retention_policy::Kind::GreaterThan(
+                                    ::buffa::alloc::boxed::Box::new(
+                                        v.to_owned_from_source(__buffa_src),
+                                    ),
+                                )
+                            }
+                            super::super::__buffa::view::oneof::retention_policy::Kind::GreaterThanOrEqual(
+                                v,
+                            ) => {
+                                super::super::__buffa::oneof::retention_policy::Kind::GreaterThanOrEqual(
+                                    ::buffa::alloc::boxed::Box::new(
+                                        v.to_owned_from_source(__buffa_src),
+                                    ),
+                                )
+                            }
+                            super::super::__buffa::view::oneof::retention_policy::Kind::DropAll(
+                                v,
+                            ) => {
+                                super::super::__buffa::oneof::retention_policy::Kind::DropAll(
+                                    ::buffa::alloc::boxed::Box::new(
+                                        v.to_owned_from_source(__buffa_src),
+                                    ),
+                                )
+                            }
+                        }),
+                    __buffa_unknown_fields: self
+                        .__buffa_unknown_fields
+                        .to_owned()
+                        .unwrap_or_default()
+                        .into(),
+                    ..::core::default::Default::default()
+                }
+            }
+        }
+        impl<'a> ::buffa::ViewEncode<'a> for RetentionPolicyView<'a> {
+            #[allow(clippy::needless_borrow, clippy::let_and_return)]
+            fn compute_size(&self, __cache: &mut ::buffa::SizeCache) -> u32 {
+                #[allow(unused_imports)]
+                use ::buffa::Enumeration as _;
+                let mut size = 0u32;
+                if let ::core::option::Option::Some(ref v) = self.kind {
+                    match v {
+                        super::super::__buffa::view::oneof::retention_policy::Kind::KeepLatest(
+                            x,
+                        ) => {
+                            let __slot = __cache.reserve();
+                            let inner = x.compute_size(__cache);
+                            __cache.set(__slot, inner);
+                            size
+                                += 1u32 + ::buffa::encoding::varint_len(inner as u64) as u32
+                                    + inner;
+                        }
+                        super::super::__buffa::view::oneof::retention_policy::Kind::GreaterThan(
+                            x,
+                        ) => {
+                            let __slot = __cache.reserve();
+                            let inner = x.compute_size(__cache);
+                            __cache.set(__slot, inner);
+                            size
+                                += 1u32 + ::buffa::encoding::varint_len(inner as u64) as u32
+                                    + inner;
+                        }
+                        super::super::__buffa::view::oneof::retention_policy::Kind::GreaterThanOrEqual(
+                            x,
+                        ) => {
+                            let __slot = __cache.reserve();
+                            let inner = x.compute_size(__cache);
+                            __cache.set(__slot, inner);
+                            size
+                                += 1u32 + ::buffa::encoding::varint_len(inner as u64) as u32
+                                    + inner;
+                        }
+                        super::super::__buffa::view::oneof::retention_policy::Kind::DropAll(
+                            x,
+                        ) => {
+                            let __slot = __cache.reserve();
+                            let inner = x.compute_size(__cache);
+                            __cache.set(__slot, inner);
+                            size
+                                += 1u32 + ::buffa::encoding::varint_len(inner as u64) as u32
+                                    + inner;
+                        }
+                    }
+                }
+                size += self.__buffa_unknown_fields.encoded_len() as u32;
+                size
+            }
+            #[allow(clippy::needless_borrow)]
+            fn write_to(
+                &self,
+                __cache: &mut ::buffa::SizeCache,
+                buf: &mut impl ::buffa::bytes::BufMut,
+            ) {
+                #[allow(unused_imports)]
+                use ::buffa::Enumeration as _;
+                if let ::core::option::Option::Some(ref v) = self.kind {
+                    match v {
+                        super::super::__buffa::view::oneof::retention_policy::Kind::KeepLatest(
+                            x,
+                        ) => {
+                            ::buffa::encoding::Tag::new(
+                                    1u32,
+                                    ::buffa::encoding::WireType::LengthDelimited,
+                                )
+                                .encode(buf);
+                            ::buffa::encoding::encode_varint(
+                                __cache.consume_next() as u64,
+                                buf,
+                            );
+                            x.write_to(__cache, buf);
+                        }
+                        super::super::__buffa::view::oneof::retention_policy::Kind::GreaterThan(
+                            x,
+                        ) => {
+                            ::buffa::encoding::Tag::new(
+                                    2u32,
+                                    ::buffa::encoding::WireType::LengthDelimited,
+                                )
+                                .encode(buf);
+                            ::buffa::encoding::encode_varint(
+                                __cache.consume_next() as u64,
+                                buf,
+                            );
+                            x.write_to(__cache, buf);
+                        }
+                        super::super::__buffa::view::oneof::retention_policy::Kind::GreaterThanOrEqual(
+                            x,
+                        ) => {
+                            ::buffa::encoding::Tag::new(
+                                    3u32,
+                                    ::buffa::encoding::WireType::LengthDelimited,
+                                )
+                                .encode(buf);
+                            ::buffa::encoding::encode_varint(
+                                __cache.consume_next() as u64,
+                                buf,
+                            );
+                            x.write_to(__cache, buf);
+                        }
+                        super::super::__buffa::view::oneof::retention_policy::Kind::DropAll(
+                            x,
+                        ) => {
+                            ::buffa::encoding::Tag::new(
+                                    4u32,
+                                    ::buffa::encoding::WireType::LengthDelimited,
+                                )
+                                .encode(buf);
+                            ::buffa::encoding::encode_varint(
+                                __cache.consume_next() as u64,
+                                buf,
+                            );
+                            x.write_to(__cache, buf);
+                        }
+                    }
+                }
+                self.__buffa_unknown_fields.write_to(buf);
+            }
+        }
+        /// Serializes this view as protobuf JSON.
+        ///
+        /// Implicit-presence fields with default values are omitted, `required`
+        /// fields are always emitted, explicit-presence (`optional`) fields are
+        /// emitted only when set, bytes fields are base64-encoded, and enum
+        /// values are their proto name strings.
+        ///
+        /// This impl uses `serialize_map(None)` because the number of emitted
+        /// fields depends on default-omission rules; serializers that require
+        /// known map lengths (e.g. `bincode`) will return a runtime error.
+        /// Use the owned message type for those formats.
+        impl<'__a> ::serde::Serialize for RetentionPolicyView<'__a> {
+            fn serialize<__S: ::serde::Serializer>(
+                &self,
+                __s: __S,
+            ) -> ::core::result::Result<__S::Ok, __S::Error> {
+                use ::serde::ser::SerializeMap as _;
+                let mut __map = __s.serialize_map(::core::option::Option::None)?;
+                if let ::core::option::Option::Some(ref __ov) = self.kind {
+                    match __ov {
+                        super::super::__buffa::view::oneof::retention_policy::Kind::KeepLatest(
+                            v,
+                        ) => {
+                            __map.serialize_entry("keepLatest", v)?;
+                        }
+                        super::super::__buffa::view::oneof::retention_policy::Kind::GreaterThan(
+                            v,
+                        ) => {
+                            __map.serialize_entry("greaterThan", v)?;
+                        }
+                        super::super::__buffa::view::oneof::retention_policy::Kind::GreaterThanOrEqual(
+                            v,
+                        ) => {
+                            __map.serialize_entry("greaterThanOrEqual", v)?;
+                        }
+                        super::super::__buffa::view::oneof::retention_policy::Kind::DropAll(
+                            v,
+                        ) => {
+                            __map.serialize_entry("dropAll", v)?;
+                        }
+                    }
+                }
+                __map.end()
+            }
+        }
+        impl<'a> ::buffa::MessageName for RetentionPolicyView<'a> {
+            const PACKAGE: &'static str = "log.stream.v1";
+            const NAME: &'static str = "RetentionPolicy";
+            const FULL_NAME: &'static str = "log.stream.v1.RetentionPolicy";
+            const TYPE_URL: &'static str = "type.googleapis.com/log.stream.v1.RetentionPolicy";
+        }
+        impl<'v> ::buffa::DefaultViewInstance for RetentionPolicyView<'v> {
+            fn default_view_instance<'a>() -> &'a Self
+            where
+                Self: 'a,
+            {
+                static VALUE: ::buffa::__private::OnceBox<
+                    RetentionPolicyView<'static>,
+                > = ::buffa::__private::OnceBox::new();
+                VALUE
+                    .get_or_init(|| ::buffa::alloc::boxed::Box::new(
+                        <RetentionPolicyView<'static>>::default(),
+                    ))
+            }
+        }
+        impl ::buffa::ViewReborrow for RetentionPolicyView<'static> {
+            type Reborrowed<'b> = RetentionPolicyView<'b>;
+            fn reborrow<'b>(this: &'b Self) -> &'b Self::Reborrowed<'b> {
+                this
+            }
+        }
+        /// Install or clear the sequence-log retention rule.
+        ///
+        /// Retention is a persistent, continuously-enforced rule owned by the stream
+        /// service (not a one-shot prune): once installed it keeps tracking the live
+        /// frontier as batches are appended, evicting whatever falls below the rule's
+        /// floor. Evicted batches surface to subscribers/point-lookups as
+        /// `OUT_OF_RANGE` with an `ErrorInfo { reason: "BATCH_EVICTED", metadata: {
+        /// "oldest_retained": ... } }` detail.
+        #[derive(Clone, Debug, Default)]
+        pub struct SetRetentionRequestView<'a> {
+            /// The rule to install. Absent -\> clear the rule: enforcement stops and no
+            /// further eviction happens.
+            ///
+            /// Field 1: `policy`
+            pub policy: ::buffa::MessageFieldView<
+                super::super::__buffa::view::RetentionPolicyView<'a>,
+            >,
+            pub __buffa_unknown_fields: ::buffa::UnknownFieldsView<'a>,
+        }
+        impl<'a> SetRetentionRequestView<'a> {
+            /// Decode from `buf`, enforcing a recursion depth limit for nested messages.
+            ///
+            /// Called by [`::buffa::MessageView::decode_view`] with [`::buffa::RECURSION_LIMIT`]
+            /// and by generated sub-message decode arms with `depth - 1`.
+            ///
+            /// **Not part of the public API.** Named with a leading underscore to
+            /// signal that it is for generated-code use only.
+            #[doc(hidden)]
+            pub fn _decode_depth(
+                buf: &'a [u8],
+                depth: u32,
+            ) -> ::core::result::Result<Self, ::buffa::DecodeError> {
+                let mut view = Self::default();
+                view._merge_into_view(buf, depth)?;
+                ::core::result::Result::Ok(view)
+            }
+            /// Merge fields from `buf` into this view (proto merge semantics).
+            ///
+            /// Repeated fields append; singular fields last-wins; singular
+            /// MESSAGE fields merge recursively. Used by sub-message decode
+            /// arms when the same field appears multiple times on the wire.
+            ///
+            /// **Not part of the public API.**
+            #[doc(hidden)]
+            pub fn _merge_into_view(
+                &mut self,
+                buf: &'a [u8],
+                depth: u32,
+            ) -> ::core::result::Result<(), ::buffa::DecodeError> {
+                let _ = depth;
+                #[allow(unused_variables)]
+                let view = self;
+                let mut cur: &'a [u8] = buf;
+                while !cur.is_empty() {
+                    let before_tag = cur;
+                    let tag = ::buffa::encoding::Tag::decode(&mut cur)?;
+                    match tag.field_number() {
+                        1u32 => {
+                            if tag.wire_type()
+                                != ::buffa::encoding::WireType::LengthDelimited
+                            {
+                                return ::core::result::Result::Err(::buffa::DecodeError::WireTypeMismatch {
+                                    field_number: 1u32,
+                                    expected: 2u8,
+                                    actual: tag.wire_type() as u8,
+                                });
+                            }
+                            if depth == 0 {
+                                return Err(::buffa::DecodeError::RecursionLimitExceeded);
+                            }
+                            let sub = ::buffa::types::borrow_bytes(&mut cur)?;
+                            match view.policy.as_mut() {
+                                Some(existing) => existing._merge_into_view(sub, depth - 1)?,
+                                None => {
+                                    view.policy = ::buffa::MessageFieldView::set(
+                                        super::super::__buffa::view::RetentionPolicyView::_decode_depth(
+                                            sub,
+                                            depth - 1,
+                                        )?,
+                                    );
+                                }
+                            }
+                        }
+                        _ => {
+                            ::buffa::encoding::skip_field_depth(tag, &mut cur, depth)?;
+                            let span_len = before_tag.len() - cur.len();
+                            view.__buffa_unknown_fields
+                                .push_raw(&before_tag[..span_len]);
+                        }
+                    }
+                }
+                ::core::result::Result::Ok(())
+            }
+        }
+        impl<'a> ::buffa::MessageView<'a> for SetRetentionRequestView<'a> {
+            type Owned = super::super::SetRetentionRequest;
+            fn decode_view(
+                buf: &'a [u8],
+            ) -> ::core::result::Result<Self, ::buffa::DecodeError> {
+                Self::_decode_depth(buf, ::buffa::RECURSION_LIMIT)
+            }
+            fn decode_view_with_limit(
+                buf: &'a [u8],
+                depth: u32,
+            ) -> ::core::result::Result<Self, ::buffa::DecodeError> {
+                Self::_decode_depth(buf, depth)
+            }
+            fn to_owned_message(&self) -> super::super::SetRetentionRequest {
+                self.to_owned_from_source(None)
+            }
+            #[allow(clippy::useless_conversion, clippy::needless_update)]
+            fn to_owned_from_source(
+                &self,
+                __buffa_src: ::core::option::Option<&::buffa::bytes::Bytes>,
+            ) -> super::super::SetRetentionRequest {
+                #[allow(unused_imports)]
+                use ::buffa::alloc::string::ToString as _;
+                let _ = __buffa_src;
+                super::super::SetRetentionRequest {
+                    policy: match self.policy.as_option() {
+                        Some(v) => {
+                            ::buffa::MessageField::<
+                                super::super::RetentionPolicy,
+                            >::some(v.to_owned_from_source(__buffa_src))
+                        }
+                        None => ::buffa::MessageField::none(),
+                    },
+                    __buffa_unknown_fields: self
+                        .__buffa_unknown_fields
+                        .to_owned()
+                        .unwrap_or_default()
+                        .into(),
+                    ..::core::default::Default::default()
+                }
+            }
+        }
+        impl<'a> ::buffa::ViewEncode<'a> for SetRetentionRequestView<'a> {
+            #[allow(clippy::needless_borrow, clippy::let_and_return)]
+            fn compute_size(&self, __cache: &mut ::buffa::SizeCache) -> u32 {
+                #[allow(unused_imports)]
+                use ::buffa::Enumeration as _;
+                let mut size = 0u32;
+                if self.policy.is_set() {
+                    let __slot = __cache.reserve();
+                    let inner_size = self.policy.compute_size(__cache);
+                    __cache.set(__slot, inner_size);
+                    size
+                        += 1u32 + ::buffa::encoding::varint_len(inner_size as u64) as u32
+                            + inner_size;
+                }
+                size += self.__buffa_unknown_fields.encoded_len() as u32;
+                size
+            }
+            #[allow(clippy::needless_borrow)]
+            fn write_to(
+                &self,
+                __cache: &mut ::buffa::SizeCache,
+                buf: &mut impl ::buffa::bytes::BufMut,
+            ) {
+                #[allow(unused_imports)]
+                use ::buffa::Enumeration as _;
+                if self.policy.is_set() {
+                    ::buffa::encoding::Tag::new(
+                            1u32,
+                            ::buffa::encoding::WireType::LengthDelimited,
+                        )
+                        .encode(buf);
+                    ::buffa::encoding::encode_varint(__cache.consume_next() as u64, buf);
+                    self.policy.write_to(__cache, buf);
+                }
+                self.__buffa_unknown_fields.write_to(buf);
+            }
+        }
+        /// Serializes this view as protobuf JSON.
+        ///
+        /// Implicit-presence fields with default values are omitted, `required`
+        /// fields are always emitted, explicit-presence (`optional`) fields are
+        /// emitted only when set, bytes fields are base64-encoded, and enum
+        /// values are their proto name strings.
+        ///
+        /// This impl uses `serialize_map(None)` because the number of emitted
+        /// fields depends on default-omission rules; serializers that require
+        /// known map lengths (e.g. `bincode`) will return a runtime error.
+        /// Use the owned message type for those formats.
+        impl<'__a> ::serde::Serialize for SetRetentionRequestView<'__a> {
+            fn serialize<__S: ::serde::Serializer>(
+                &self,
+                __s: __S,
+            ) -> ::core::result::Result<__S::Ok, __S::Error> {
+                use ::serde::ser::SerializeMap as _;
+                let mut __map = __s.serialize_map(::core::option::Option::None)?;
+                {
+                    if let ::core::option::Option::Some(__v) = self.policy.as_option() {
+                        __map.serialize_entry("policy", __v)?;
+                    }
+                }
+                __map.end()
+            }
+        }
+        impl<'a> ::buffa::MessageName for SetRetentionRequestView<'a> {
+            const PACKAGE: &'static str = "log.stream.v1";
+            const NAME: &'static str = "SetRetentionRequest";
+            const FULL_NAME: &'static str = "log.stream.v1.SetRetentionRequest";
+            const TYPE_URL: &'static str = "type.googleapis.com/log.stream.v1.SetRetentionRequest";
+        }
+        impl<'v> ::buffa::DefaultViewInstance for SetRetentionRequestView<'v> {
+            fn default_view_instance<'a>() -> &'a Self
+            where
+                Self: 'a,
+            {
+                static VALUE: ::buffa::__private::OnceBox<
+                    SetRetentionRequestView<'static>,
+                > = ::buffa::__private::OnceBox::new();
+                VALUE
+                    .get_or_init(|| ::buffa::alloc::boxed::Box::new(
+                        <SetRetentionRequestView<'static>>::default(),
+                    ))
+            }
+        }
+        impl ::buffa::ViewReborrow for SetRetentionRequestView<'static> {
+            type Reborrowed<'b> = SetRetentionRequestView<'b>;
+            fn reborrow<'b>(this: &'b Self) -> &'b Self::Reborrowed<'b> {
+                this
+            }
+        }
+        /// Result of applying the rule change once, synchronously.
+        #[derive(Clone, Debug, Default)]
+        pub struct SetRetentionResponseView<'a> {
+            /// Lowest sequence number still retained after that application. Absent when
+            /// the log is empty / no floor exists yet.
+            ///
+            /// Field 1: `oldest_retained_sequence`
+            pub oldest_retained_sequence: ::core::option::Option<u64>,
+            pub __buffa_unknown_fields: ::buffa::UnknownFieldsView<'a>,
+        }
+        impl<'a> SetRetentionResponseView<'a> {
+            /// Decode from `buf`, enforcing a recursion depth limit for nested messages.
+            ///
+            /// Called by [`::buffa::MessageView::decode_view`] with [`::buffa::RECURSION_LIMIT`]
+            /// and by generated sub-message decode arms with `depth - 1`.
+            ///
+            /// **Not part of the public API.** Named with a leading underscore to
+            /// signal that it is for generated-code use only.
+            #[doc(hidden)]
+            pub fn _decode_depth(
+                buf: &'a [u8],
+                depth: u32,
+            ) -> ::core::result::Result<Self, ::buffa::DecodeError> {
+                let mut view = Self::default();
+                view._merge_into_view(buf, depth)?;
+                ::core::result::Result::Ok(view)
+            }
+            /// Merge fields from `buf` into this view (proto merge semantics).
+            ///
+            /// Repeated fields append; singular fields last-wins; singular
+            /// MESSAGE fields merge recursively. Used by sub-message decode
+            /// arms when the same field appears multiple times on the wire.
+            ///
+            /// **Not part of the public API.**
+            #[doc(hidden)]
+            pub fn _merge_into_view(
+                &mut self,
+                buf: &'a [u8],
+                depth: u32,
+            ) -> ::core::result::Result<(), ::buffa::DecodeError> {
+                let _ = depth;
+                #[allow(unused_variables)]
+                let view = self;
+                let mut cur: &'a [u8] = buf;
+                while !cur.is_empty() {
+                    let before_tag = cur;
+                    let tag = ::buffa::encoding::Tag::decode(&mut cur)?;
+                    match tag.field_number() {
+                        1u32 => {
+                            if tag.wire_type() != ::buffa::encoding::WireType::Varint {
+                                return ::core::result::Result::Err(::buffa::DecodeError::WireTypeMismatch {
+                                    field_number: 1u32,
+                                    expected: 0u8,
+                                    actual: tag.wire_type() as u8,
+                                });
+                            }
+                            view.oldest_retained_sequence = Some(
+                                ::buffa::types::decode_uint64(&mut cur)?,
+                            );
+                        }
+                        _ => {
+                            ::buffa::encoding::skip_field_depth(tag, &mut cur, depth)?;
+                            let span_len = before_tag.len() - cur.len();
+                            view.__buffa_unknown_fields
+                                .push_raw(&before_tag[..span_len]);
+                        }
+                    }
+                }
+                ::core::result::Result::Ok(())
+            }
+        }
+        impl<'a> ::buffa::MessageView<'a> for SetRetentionResponseView<'a> {
+            type Owned = super::super::SetRetentionResponse;
+            fn decode_view(
+                buf: &'a [u8],
+            ) -> ::core::result::Result<Self, ::buffa::DecodeError> {
+                Self::_decode_depth(buf, ::buffa::RECURSION_LIMIT)
+            }
+            fn decode_view_with_limit(
+                buf: &'a [u8],
+                depth: u32,
+            ) -> ::core::result::Result<Self, ::buffa::DecodeError> {
+                Self::_decode_depth(buf, depth)
+            }
+            fn to_owned_message(&self) -> super::super::SetRetentionResponse {
+                self.to_owned_from_source(None)
+            }
+            #[allow(clippy::useless_conversion, clippy::needless_update)]
+            fn to_owned_from_source(
+                &self,
+                __buffa_src: ::core::option::Option<&::buffa::bytes::Bytes>,
+            ) -> super::super::SetRetentionResponse {
+                #[allow(unused_imports)]
+                use ::buffa::alloc::string::ToString as _;
+                let _ = __buffa_src;
+                super::super::SetRetentionResponse {
+                    oldest_retained_sequence: self.oldest_retained_sequence,
+                    __buffa_unknown_fields: self
+                        .__buffa_unknown_fields
+                        .to_owned()
+                        .unwrap_or_default()
+                        .into(),
+                    ..::core::default::Default::default()
+                }
+            }
+        }
+        impl<'a> ::buffa::ViewEncode<'a> for SetRetentionResponseView<'a> {
+            #[allow(clippy::needless_borrow, clippy::let_and_return)]
+            fn compute_size(&self, _cache: &mut ::buffa::SizeCache) -> u32 {
+                #[allow(unused_imports)]
+                use ::buffa::Enumeration as _;
+                let mut size = 0u32;
+                if let Some(v) = self.oldest_retained_sequence {
+                    size += 1u32 + ::buffa::types::uint64_encoded_len(v) as u32;
+                }
+                size += self.__buffa_unknown_fields.encoded_len() as u32;
+                size
+            }
+            #[allow(clippy::needless_borrow)]
+            fn write_to(
+                &self,
+                _cache: &mut ::buffa::SizeCache,
+                buf: &mut impl ::buffa::bytes::BufMut,
+            ) {
+                #[allow(unused_imports)]
+                use ::buffa::Enumeration as _;
+                if let Some(v) = self.oldest_retained_sequence {
+                    ::buffa::encoding::Tag::new(
+                            1u32,
+                            ::buffa::encoding::WireType::Varint,
+                        )
+                        .encode(buf);
+                    ::buffa::types::encode_uint64(v, buf);
+                }
+                self.__buffa_unknown_fields.write_to(buf);
+            }
+        }
+        /// Serializes this view as protobuf JSON.
+        ///
+        /// Implicit-presence fields with default values are omitted, `required`
+        /// fields are always emitted, explicit-presence (`optional`) fields are
+        /// emitted only when set, bytes fields are base64-encoded, and enum
+        /// values are their proto name strings.
+        ///
+        /// This impl uses `serialize_map(None)` because the number of emitted
+        /// fields depends on default-omission rules; serializers that require
+        /// known map lengths (e.g. `bincode`) will return a runtime error.
+        /// Use the owned message type for those formats.
+        impl<'__a> ::serde::Serialize for SetRetentionResponseView<'__a> {
+            fn serialize<__S: ::serde::Serializer>(
+                &self,
+                __s: __S,
+            ) -> ::core::result::Result<__S::Ok, __S::Error> {
+                use ::serde::ser::SerializeMap as _;
+                let mut __map = __s.serialize_map(::core::option::Option::None)?;
+                if let ::core::option::Option::Some(__v) = self.oldest_retained_sequence
+                {
+                    struct _W(u64);
+                    impl ::serde::Serialize for _W {
+                        fn serialize<__S: ::serde::Serializer>(
+                            &self,
+                            __s: __S,
+                        ) -> ::core::result::Result<__S::Ok, __S::Error> {
+                            ::buffa::json_helpers::uint64::serialize(&self.0, __s)
+                        }
+                    }
+                    __map.serialize_entry("oldestRetainedSequence", &_W(__v))?;
+                }
+                __map.end()
+            }
+        }
+        impl<'a> ::buffa::MessageName for SetRetentionResponseView<'a> {
+            const PACKAGE: &'static str = "log.stream.v1";
+            const NAME: &'static str = "SetRetentionResponse";
+            const FULL_NAME: &'static str = "log.stream.v1.SetRetentionResponse";
+            const TYPE_URL: &'static str = "type.googleapis.com/log.stream.v1.SetRetentionResponse";
+        }
+        impl<'v> ::buffa::DefaultViewInstance for SetRetentionResponseView<'v> {
+            fn default_view_instance<'a>() -> &'a Self
+            where
+                Self: 'a,
+            {
+                static VALUE: ::buffa::__private::OnceBox<
+                    SetRetentionResponseView<'static>,
+                > = ::buffa::__private::OnceBox::new();
+                VALUE
+                    .get_or_init(|| ::buffa::alloc::boxed::Box::new(
+                        <SetRetentionResponseView<'static>>::default(),
+                    ))
+            }
+        }
+        impl ::buffa::ViewReborrow for SetRetentionResponseView<'static> {
+            type Reborrowed<'b> = SetRetentionResponseView<'b>;
+            fn reborrow<'b>(this: &'b Self) -> &'b Self::Reborrowed<'b> {
+                this
+            }
+        }
+        pub mod oneof {
+            #[allow(unused_imports)]
+            use super::*;
+            pub mod retention_policy {
+                #[allow(unused_imports)]
+                use super::*;
+                #[derive(Clone, Debug)]
+                pub enum Kind<'a> {
+                    KeepLatest(
+                        ::buffa::alloc::boxed::Box<
+                            super::super::super::super::__buffa::view::RetentionKeepLatestView<
+                                'a,
+                            >,
+                        >,
+                    ),
+                    GreaterThan(
+                        ::buffa::alloc::boxed::Box<
+                            super::super::super::super::__buffa::view::RetentionGreaterThanView<
+                                'a,
+                            >,
+                        >,
+                    ),
+                    GreaterThanOrEqual(
+                        ::buffa::alloc::boxed::Box<
+                            super::super::super::super::__buffa::view::RetentionGreaterThanOrEqualView<
+                                'a,
+                            >,
+                        >,
+                    ),
+                    DropAll(
+                        ::buffa::alloc::boxed::Box<
+                            super::super::super::super::__buffa::view::RetentionDropAllView<
+                                'a,
+                            >,
+                        >,
+                    ),
+                }
+            }
+        }
+    }
+    pub mod oneof {
+        #[allow(unused_imports)]
+        use super::*;
+        pub mod retention_policy {
+            #[allow(unused_imports)]
+            use super::*;
+            #[derive(Clone, PartialEq, Debug)]
+            pub enum Kind {
+                KeepLatest(
+                    ::buffa::alloc::boxed::Box<super::super::super::RetentionKeepLatest>,
+                ),
+                GreaterThan(
+                    ::buffa::alloc::boxed::Box<super::super::super::RetentionGreaterThan>,
+                ),
+                GreaterThanOrEqual(
+                    ::buffa::alloc::boxed::Box<
+                        super::super::super::RetentionGreaterThanOrEqual,
+                    >,
+                ),
+                DropAll(
+                    ::buffa::alloc::boxed::Box<super::super::super::RetentionDropAll>,
+                ),
+            }
+            impl ::buffa::Oneof for Kind {}
+            impl From<super::super::super::RetentionKeepLatest> for Kind {
+                fn from(v: super::super::super::RetentionKeepLatest) -> Self {
+                    Self::KeepLatest(::buffa::alloc::boxed::Box::new(v))
+                }
+            }
+            impl From<super::super::super::RetentionKeepLatest>
+            for ::core::option::Option<Kind> {
+                fn from(v: super::super::super::RetentionKeepLatest) -> Self {
+                    Self::Some(Kind::from(v))
+                }
+            }
+            impl From<super::super::super::RetentionGreaterThan> for Kind {
+                fn from(v: super::super::super::RetentionGreaterThan) -> Self {
+                    Self::GreaterThan(::buffa::alloc::boxed::Box::new(v))
+                }
+            }
+            impl From<super::super::super::RetentionGreaterThan>
+            for ::core::option::Option<Kind> {
+                fn from(v: super::super::super::RetentionGreaterThan) -> Self {
+                    Self::Some(Kind::from(v))
+                }
+            }
+            impl From<super::super::super::RetentionGreaterThanOrEqual> for Kind {
+                fn from(v: super::super::super::RetentionGreaterThanOrEqual) -> Self {
+                    Self::GreaterThanOrEqual(::buffa::alloc::boxed::Box::new(v))
+                }
+            }
+            impl From<super::super::super::RetentionGreaterThanOrEqual>
+            for ::core::option::Option<Kind> {
+                fn from(v: super::super::super::RetentionGreaterThanOrEqual) -> Self {
+                    Self::Some(Kind::from(v))
+                }
+            }
+            impl From<super::super::super::RetentionDropAll> for Kind {
+                fn from(v: super::super::super::RetentionDropAll) -> Self {
+                    Self::DropAll(::buffa::alloc::boxed::Box::new(v))
+                }
+            }
+            impl From<super::super::super::RetentionDropAll>
+            for ::core::option::Option<Kind> {
+                fn from(v: super::super::super::RetentionDropAll) -> Self {
+                    Self::Some(Kind::from(v))
+                }
+            }
+            impl serde::Serialize for Kind {
+                fn serialize<S: serde::Serializer>(
+                    &self,
+                    s: S,
+                ) -> ::core::result::Result<S::Ok, S::Error> {
+                    use serde::ser::SerializeMap;
+                    let mut map = s.serialize_map(Some(1))?;
+                    match self {
+                        Self::KeepLatest(v) => {
+                            map.serialize_entry("keepLatest", v)?;
+                        }
+                        Self::GreaterThan(v) => {
+                            map.serialize_entry("greaterThan", v)?;
+                        }
+                        Self::GreaterThanOrEqual(v) => {
+                            map.serialize_entry("greaterThanOrEqual", v)?;
+                        }
+                        Self::DropAll(v) => {
+                            map.serialize_entry("dropAll", v)?;
+                        }
+                    }
+                    map.end()
+                }
+            }
+        }
     }
 }
 #[doc(inline)]
@@ -1784,6 +4788,20 @@ pub use self::__buffa::view::GetRequestView;
 pub use self::__buffa::view::SubscribeResponseView;
 #[doc(inline)]
 pub use self::__buffa::view::GetResponseView;
+#[doc(inline)]
+pub use self::__buffa::view::RetentionKeepLatestView;
+#[doc(inline)]
+pub use self::__buffa::view::RetentionGreaterThanView;
+#[doc(inline)]
+pub use self::__buffa::view::RetentionGreaterThanOrEqualView;
+#[doc(inline)]
+pub use self::__buffa::view::RetentionDropAllView;
+#[doc(inline)]
+pub use self::__buffa::view::RetentionPolicyView;
+#[doc(inline)]
+pub use self::__buffa::view::SetRetentionRequestView;
+#[doc(inline)]
+pub use self::__buffa::view::SetRetentionResponseView;
 
 ///Shorthand for `OwnedView<SubscribeRequestView<'static>>`.
 pub type OwnedSubscribeRequestView = ::buffa::view::OwnedView<
@@ -1800,6 +4818,14 @@ pub type OwnedGetRequestView = ::buffa::view::OwnedView<
 ///Shorthand for `OwnedView<GetResponseView<'static>>`.
 pub type OwnedGetResponseView = ::buffa::view::OwnedView<
     __buffa::view::GetResponseView<'static>,
+>;
+///Shorthand for `OwnedView<SetRetentionRequestView<'static>>`.
+pub type OwnedSetRetentionRequestView = ::buffa::view::OwnedView<
+    __buffa::view::SetRetentionRequestView<'static>,
+>;
+///Shorthand for `OwnedView<SetRetentionResponseView<'static>>`.
+pub type OwnedSetRetentionResponseView = ::buffa::view::OwnedView<
+    __buffa::view::SetRetentionResponseView<'static>,
 >;
 impl ::connectrpc::Encodable<SubscribeResponse>
 for __buffa::view::SubscribeResponseView<'_> {
@@ -1836,6 +4862,24 @@ for ::buffa::view::OwnedView<__buffa::view::GetResponseView<'static>> {
         ::connectrpc::__codegen::encode_view_body(&**self, codec)
     }
 }
+impl ::connectrpc::Encodable<SetRetentionResponse>
+for __buffa::view::SetRetentionResponseView<'_> {
+    fn encode(
+        &self,
+        codec: ::connectrpc::CodecFormat,
+    ) -> ::std::result::Result<::buffa::bytes::Bytes, ::connectrpc::ConnectError> {
+        ::connectrpc::__codegen::encode_view_body(self, codec)
+    }
+}
+impl ::connectrpc::Encodable<SetRetentionResponse>
+for ::buffa::view::OwnedView<__buffa::view::SetRetentionResponseView<'static>> {
+    fn encode(
+        &self,
+        codec: ::connectrpc::CodecFormat,
+    ) -> ::std::result::Result<::buffa::bytes::Bytes, ::connectrpc::ConnectError> {
+        ::connectrpc::__codegen::encode_view_body(&**self, codec)
+    }
+}
 /// Full service name for this service.
 pub const SERVICE_SERVICE_NAME: &str = "log.stream.v1.Service";
 /// Static [`Spec`](::connectrpc::Spec) for the server-side `Subscribe` RPC.
@@ -1853,6 +4897,15 @@ pub const SERVICE_SUBSCRIBE_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::serve
 /// [`RequestContext::spec`](::connectrpc::RequestContext::spec).
 pub const SERVICE_GET_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
         "/log.stream.v1.Service/Get",
+        ::connectrpc::StreamType::Unary,
+    )
+    .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
+/// Static [`Spec`](::connectrpc::Spec) for the server-side `SetRetention` RPC.
+///
+/// The dispatcher surfaces this on
+/// [`RequestContext::spec`](::connectrpc::RequestContext::spec).
+pub const SERVICE_SET_RETENTION_SPEC: ::connectrpc::Spec = ::connectrpc::Spec::server(
+        "/log.stream.v1.Service/SetRetention",
         ::connectrpc::StreamType::Unary,
     )
     .with_idempotency_level(::connectrpc::IdempotencyLevel::Unknown);
@@ -1923,6 +4976,19 @@ pub trait Service: Send + Sync + 'static {
             impl ::connectrpc::Encodable<GetResponse> + Send + use<'a, Self>,
         >,
     > + Send;
+    /// Install (or clear) the sequence-log retention rule. The rule is persistent
+    /// and continuously enforced as the log grows — see `SetRetentionRequest`.
+    ///
+    /// `'a` lets the response body borrow from `&self` (e.g. server-resident state).
+    fn set_retention<'a>(
+        &'a self,
+        ctx: ::connectrpc::RequestContext,
+        request: OwnedSetRetentionRequestView,
+    ) -> impl ::std::future::Future<
+        Output = ::connectrpc::ServiceResult<
+            impl ::connectrpc::Encodable<SetRetentionResponse> + Send + use<'a, Self>,
+        >,
+    > + Send;
 }
 /// Extension trait for registering a service implementation with a Router.
 ///
@@ -1982,6 +5048,22 @@ impl<S: Service> ServiceExt for S {
                 },
             )
             .with_spec(SERVICE_GET_SPEC)
+            .route_view(
+                SERVICE_SERVICE_NAME,
+                "SetRetention",
+                {
+                    let svc = ::std::sync::Arc::clone(&self);
+                    ::connectrpc::view_handler_fn(move |ctx, req, format| {
+                        let svc = ::std::sync::Arc::clone(&svc);
+                        async move {
+                            svc.set_retention(ctx, req)
+                                .await?
+                                .encode::<SetRetentionResponse>(format)
+                        }
+                    })
+                },
+            )
+            .with_spec(SERVICE_SET_RETENTION_SPEC)
     }
 }
 /// Monomorphic dispatcher for `Service`.
@@ -2039,6 +5121,12 @@ impl<T: Service> ::connectrpc::Dispatcher for ServiceServer<T> {
                         .with_spec(SERVICE_GET_SPEC),
                 )
             }
+            "SetRetention" => {
+                Some(
+                    ::connectrpc::dispatcher::codegen::MethodDescriptor::unary(false)
+                        .with_spec(SERVICE_SET_RETENTION_SPEC),
+                )
+            }
             _ => None,
         }
     }
@@ -2061,6 +5149,17 @@ impl<T: Service> ::connectrpc::Dispatcher for ServiceServer<T> {
                         __buffa::view::GetRequestView,
                     >(request.encoded()?, format)?;
                     svc.get(ctx, req).await?.encode::<GetResponse>(format)
+                })
+            }
+            "SetRetention" => {
+                let svc = ::std::sync::Arc::clone(&self.inner);
+                Box::pin(async move {
+                    let req = ::connectrpc::dispatcher::codegen::decode_request_view::<
+                        __buffa::view::SetRetentionRequestView,
+                    >(request.encoded()?, format)?;
+                    svc.set_retention(ctx, req)
+                        .await?
+                        .encode::<SetRetentionResponse>(format)
                 })
             }
             _ => ::connectrpc::dispatcher::codegen::unimplemented_unary(path),
@@ -2268,6 +5367,43 @@ where
                 &self.config,
                 SERVICE_SERVICE_NAME,
                 "Get",
+                request,
+                options,
+            )
+            .await
+    }
+    /// Call the SetRetention RPC. Sends a request to /log.stream.v1.Service/SetRetention.
+    pub async fn set_retention(
+        &self,
+        request: SetRetentionRequest,
+    ) -> Result<
+        ::connectrpc::client::UnaryResponse<
+            ::buffa::view::OwnedView<__buffa::view::SetRetentionResponseView<'static>>,
+        >,
+        ::connectrpc::ConnectError,
+    > {
+        self.set_retention_with_options(
+                request,
+                ::connectrpc::client::CallOptions::default(),
+            )
+            .await
+    }
+    /// Call the SetRetention RPC with explicit per-call options. Options override [`ClientConfig`](::connectrpc::client::ClientConfig) defaults.
+    pub async fn set_retention_with_options(
+        &self,
+        request: SetRetentionRequest,
+        options: ::connectrpc::client::CallOptions,
+    ) -> Result<
+        ::connectrpc::client::UnaryResponse<
+            ::buffa::view::OwnedView<__buffa::view::SetRetentionResponseView<'static>>,
+        >,
+        ::connectrpc::ConnectError,
+    > {
+        ::connectrpc::client::call_unary(
+                &self.transport,
+                &self.config,
+                SERVICE_SERVICE_NAME,
+                "SetRetention",
                 request,
                 options,
             )

--- a/sdk/rs/src/gen/log.stream.v1.rs
+++ b/sdk/rs/src/gen/log.stream.v1.rs
@@ -4976,8 +4976,7 @@ pub trait Service: Send + Sync + 'static {
             impl ::connectrpc::Encodable<GetResponse> + Send + use<'a, Self>,
         >,
     > + Send;
-    /// Install (or clear) the sequence-log retention rule. The rule is persistent
-    /// and continuously enforced as the log grows — see `SetRetentionRequest`.
+    /// Handle the SetRetention RPC.
     ///
     /// `'a` lets the response body borrow from `&self` (e.g. server-resident state).
     fn set_retention<'a>(

--- a/sdk/rs/src/gen/store.compact.v1.rs
+++ b/sdk/rs/src/gen/store.compact.v1.rs
@@ -1655,136 +1655,24 @@ pub const __KEYS_SCOPE_JSON_ANY: ::buffa::type_registry::JsonAnyEntry = ::buffa:
     from_json: ::buffa::type_registry::any_from_json::<KeysScope>,
     is_wkt: false,
 };
-/// Sequence-number scope: prune the per-batch sequence log served by the
-/// store's `Stream` service. `selector` / `group_by` / `order_by` are not
-/// meaningful here — the log has a single implicit ordering by sequence
-/// number. The `retain` rule on the parent `Policy` is interpreted directly
-/// over sequence numbers:
-///
-///   - `keep_latest { count: N }`        -\> keep the last N batches
-///   - `greater_than { threshold: T }`   -\> keep sequence numbers \> T
-///   - `greater_than_or_equal { .. T }`  -\> keep sequence numbers \>= T
-///   - `drop_all`                        -\> clear the log entirely
+/// A single prune policy: group keys via `keys`, then apply `retain` to decide
+/// which of them survive. `keys` is required.
 #[derive(Clone, PartialEq, Default)]
 #[derive(::serde::Serialize, ::serde::Deserialize)]
 #[serde(default)]
-pub struct SequenceScope {
-    #[serde(skip)]
-    #[doc(hidden)]
-    pub __buffa_unknown_fields: ::buffa::UnknownFields,
-}
-impl ::core::fmt::Debug for SequenceScope {
-    fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_struct("SequenceScope").finish()
-    }
-}
-impl SequenceScope {
-    /// Protobuf type URL for this message, for use with `Any::pack` and
-    /// `Any::unpack_if`.
-    ///
-    /// Format: `type.googleapis.com/<fully.qualified.TypeName>`
-    pub const TYPE_URL: &'static str = "type.googleapis.com/store.compact.v1.SequenceScope";
-}
-impl ::buffa::DefaultInstance for SequenceScope {
-    fn default_instance() -> &'static Self {
-        static VALUE: ::buffa::__private::OnceBox<SequenceScope> = ::buffa::__private::OnceBox::new();
-        VALUE.get_or_init(|| ::buffa::alloc::boxed::Box::new(Self::default()))
-    }
-}
-impl ::buffa::MessageName for SequenceScope {
-    const PACKAGE: &'static str = "store.compact.v1";
-    const NAME: &'static str = "SequenceScope";
-    const FULL_NAME: &'static str = "store.compact.v1.SequenceScope";
-    const TYPE_URL: &'static str = "type.googleapis.com/store.compact.v1.SequenceScope";
-}
-impl ::buffa::Message for SequenceScope {
-    /// Returns the total encoded size in bytes.
-    ///
-    /// The result is a `u32`; the protobuf specification requires all
-    /// messages to fit within 2 GiB (2,147,483,647 bytes), so a
-    /// compliant message will never overflow this type.
-    #[allow(clippy::let_and_return)]
-    fn compute_size(&self, _cache: &mut ::buffa::SizeCache) -> u32 {
-        #[allow(unused_imports)]
-        use ::buffa::Enumeration as _;
-        let mut size = 0u32;
-        size += self.__buffa_unknown_fields.encoded_len() as u32;
-        size
-    }
-    fn write_to(
-        &self,
-        _cache: &mut ::buffa::SizeCache,
-        buf: &mut impl ::buffa::bytes::BufMut,
-    ) {
-        #[allow(unused_imports)]
-        use ::buffa::Enumeration as _;
-        self.__buffa_unknown_fields.write_to(buf);
-    }
-    fn merge_field(
-        &mut self,
-        tag: ::buffa::encoding::Tag,
-        buf: &mut impl ::buffa::bytes::Buf,
-        depth: u32,
-    ) -> ::core::result::Result<(), ::buffa::DecodeError> {
-        #[allow(unused_imports)]
-        use ::buffa::bytes::Buf as _;
-        #[allow(unused_imports)]
-        use ::buffa::Enumeration as _;
-        match tag.field_number() {
-            _ => {
-                self.__buffa_unknown_fields
-                    .push(::buffa::encoding::decode_unknown_field(tag, buf, depth)?);
-            }
-        }
-        ::core::result::Result::Ok(())
-    }
-    fn clear(&mut self) {
-        self.__buffa_unknown_fields.clear();
-    }
-}
-impl ::buffa::ExtensionSet for SequenceScope {
-    const PROTO_FQN: &'static str = "store.compact.v1.SequenceScope";
-    fn unknown_fields(&self) -> &::buffa::UnknownFields {
-        &self.__buffa_unknown_fields
-    }
-    fn unknown_fields_mut(&mut self) -> &mut ::buffa::UnknownFields {
-        &mut self.__buffa_unknown_fields
-    }
-}
-impl ::buffa::json_helpers::ProtoElemJson for SequenceScope {
-    fn serialize_proto_json<S: ::serde::Serializer>(
-        v: &Self,
-        s: S,
-    ) -> ::core::result::Result<S::Ok, S::Error> {
-        ::serde::Serialize::serialize(v, s)
-    }
-    fn deserialize_proto_json<'de, D: ::serde::Deserializer<'de>>(
-        d: D,
-    ) -> ::core::result::Result<Self, D::Error> {
-        <Self as ::serde::Deserialize>::deserialize(d)
-    }
-}
-#[doc(hidden)]
-pub const __SEQUENCE_SCOPE_JSON_ANY: ::buffa::type_registry::JsonAnyEntry = ::buffa::type_registry::JsonAnyEntry {
-    type_url: "type.googleapis.com/store.compact.v1.SequenceScope",
-    to_json: ::buffa::type_registry::any_to_json::<SequenceScope>,
-    from_json: ::buffa::type_registry::any_from_json::<SequenceScope>,
-    is_wkt: false,
-};
-/// A single prune policy. `scope` discriminates the keyspace the rule applies
-/// to; `retain` is shared between scopes.
-#[derive(Clone, PartialEq, Default)]
-#[derive(::serde::Serialize)]
-#[serde(default)]
 pub struct Policy {
+    /// Field 1: `keys`
+    #[serde(
+        rename = "keys",
+        skip_serializing_if = "::buffa::json_helpers::skip_if::is_unset_message_field"
+    )]
+    pub keys: ::buffa::MessageField<KeysScope>,
     /// Field 3: `retain`
     #[serde(
         rename = "retain",
         skip_serializing_if = "::buffa::json_helpers::skip_if::is_unset_message_field"
     )]
     pub retain: ::buffa::MessageField<PolicyRetain>,
-    #[serde(flatten)]
-    pub scope: ::core::option::Option<__buffa::oneof::policy::Scope>,
     #[serde(skip)]
     #[doc(hidden)]
     pub __buffa_unknown_fields: ::buffa::UnknownFields,
@@ -1792,8 +1680,8 @@ pub struct Policy {
 impl ::core::fmt::Debug for Policy {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_struct("Policy")
+            .field("keys", &self.keys)
             .field("retain", &self.retain)
-            .field("scope", &self.scope)
             .finish()
     }
 }
@@ -1827,25 +1715,13 @@ impl ::buffa::Message for Policy {
         #[allow(unused_imports)]
         use ::buffa::Enumeration as _;
         let mut size = 0u32;
-        if let ::core::option::Option::Some(ref v) = self.scope {
-            match v {
-                __buffa::oneof::policy::Scope::Keys(x) => {
-                    let __slot = __cache.reserve();
-                    let inner = x.compute_size(__cache);
-                    __cache.set(__slot, inner);
-                    size
-                        += 1u32 + ::buffa::encoding::varint_len(inner as u64) as u32
-                            + inner;
-                }
-                __buffa::oneof::policy::Scope::Sequence(x) => {
-                    let __slot = __cache.reserve();
-                    let inner = x.compute_size(__cache);
-                    __cache.set(__slot, inner);
-                    size
-                        += 1u32 + ::buffa::encoding::varint_len(inner as u64) as u32
-                            + inner;
-                }
-            }
+        if self.keys.is_set() {
+            let __slot = __cache.reserve();
+            let inner_size = self.keys.compute_size(__cache);
+            __cache.set(__slot, inner_size);
+            size
+                += 1u32 + ::buffa::encoding::varint_len(inner_size as u64) as u32
+                    + inner_size;
         }
         if self.retain.is_set() {
             let __slot = __cache.reserve();
@@ -1865,27 +1741,14 @@ impl ::buffa::Message for Policy {
     ) {
         #[allow(unused_imports)]
         use ::buffa::Enumeration as _;
-        if let ::core::option::Option::Some(ref v) = self.scope {
-            match v {
-                __buffa::oneof::policy::Scope::Keys(x) => {
-                    ::buffa::encoding::Tag::new(
-                            1u32,
-                            ::buffa::encoding::WireType::LengthDelimited,
-                        )
-                        .encode(buf);
-                    ::buffa::encoding::encode_varint(__cache.consume_next() as u64, buf);
-                    x.write_to(__cache, buf);
-                }
-                __buffa::oneof::policy::Scope::Sequence(x) => {
-                    ::buffa::encoding::Tag::new(
-                            2u32,
-                            ::buffa::encoding::WireType::LengthDelimited,
-                        )
-                        .encode(buf);
-                    ::buffa::encoding::encode_varint(__cache.consume_next() as u64, buf);
-                    x.write_to(__cache, buf);
-                }
-            }
+        if self.keys.is_set() {
+            ::buffa::encoding::Tag::new(
+                    1u32,
+                    ::buffa::encoding::WireType::LengthDelimited,
+                )
+                .encode(buf);
+            ::buffa::encoding::encode_varint(__cache.consume_next() as u64, buf);
+            self.keys.write_to(__cache, buf);
         }
         if self.retain.is_set() {
             ::buffa::encoding::Tag::new(
@@ -1917,51 +1780,11 @@ impl ::buffa::Message for Policy {
                         actual: tag.wire_type() as u8,
                     });
                 }
-                if let ::core::option::Option::Some(
-                    __buffa::oneof::policy::Scope::Keys(ref mut existing),
-                ) = self.scope
-                {
-                    ::buffa::Message::merge_length_delimited(
-                        &mut **existing,
-                        buf,
-                        depth,
-                    )?;
-                } else {
-                    let mut val = ::core::default::Default::default();
-                    ::buffa::Message::merge_length_delimited(&mut val, buf, depth)?;
-                    self.scope = ::core::option::Option::Some(
-                        __buffa::oneof::policy::Scope::Keys(
-                            ::buffa::alloc::boxed::Box::new(val),
-                        ),
-                    );
-                }
-            }
-            2u32 => {
-                if tag.wire_type() != ::buffa::encoding::WireType::LengthDelimited {
-                    return ::core::result::Result::Err(::buffa::DecodeError::WireTypeMismatch {
-                        field_number: 2u32,
-                        expected: 2u8,
-                        actual: tag.wire_type() as u8,
-                    });
-                }
-                if let ::core::option::Option::Some(
-                    __buffa::oneof::policy::Scope::Sequence(ref mut existing),
-                ) = self.scope
-                {
-                    ::buffa::Message::merge_length_delimited(
-                        &mut **existing,
-                        buf,
-                        depth,
-                    )?;
-                } else {
-                    let mut val = ::core::default::Default::default();
-                    ::buffa::Message::merge_length_delimited(&mut val, buf, depth)?;
-                    self.scope = ::core::option::Option::Some(
-                        __buffa::oneof::policy::Scope::Sequence(
-                            ::buffa::alloc::boxed::Box::new(val),
-                        ),
-                    );
-                }
+                ::buffa::Message::merge_length_delimited(
+                    self.keys.get_or_insert_default(),
+                    buf,
+                    depth,
+                )?;
             }
             3u32 => {
                 if tag.wire_type() != ::buffa::encoding::WireType::LengthDelimited {
@@ -1985,7 +1808,7 @@ impl ::buffa::Message for Policy {
         ::core::result::Result::Ok(())
     }
     fn clear(&mut self) {
-        self.scope = ::core::option::Option::None;
+        self.keys = ::buffa::MessageField::none();
         self.retain = ::buffa::MessageField::none();
         self.__buffa_unknown_fields.clear();
     }
@@ -1997,98 +1820,6 @@ impl ::buffa::ExtensionSet for Policy {
     }
     fn unknown_fields_mut(&mut self) -> &mut ::buffa::UnknownFields {
         &mut self.__buffa_unknown_fields
-    }
-}
-impl<'de> serde::Deserialize<'de> for Policy {
-    fn deserialize<D: serde::Deserializer<'de>>(
-        d: D,
-    ) -> ::core::result::Result<Self, D::Error> {
-        struct _V;
-        impl<'de> serde::de::Visitor<'de> for _V {
-            type Value = Policy;
-            fn expecting(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-                f.write_str("struct Policy")
-            }
-            #[allow(clippy::field_reassign_with_default)]
-            fn visit_map<A: serde::de::MapAccess<'de>>(
-                self,
-                mut map: A,
-            ) -> ::core::result::Result<Policy, A::Error> {
-                let mut __f_retain: ::core::option::Option<
-                    ::buffa::MessageField<PolicyRetain>,
-                > = None;
-                let mut __oneof_scope: ::core::option::Option<
-                    __buffa::oneof::policy::Scope,
-                > = None;
-                while let Some(key) = map.next_key::<::buffa::alloc::string::String>()? {
-                    match key.as_str() {
-                        "retain" => {
-                            __f_retain = Some(
-                                map.next_value::<::buffa::MessageField<PolicyRetain>>()?,
-                            );
-                        }
-                        "keys" => {
-                            let v: ::core::option::Option<KeysScope> = map
-                                .next_value_seed(
-                                    ::buffa::json_helpers::NullableDeserializeSeed(
-                                        ::buffa::json_helpers::DefaultDeserializeSeed::<
-                                            KeysScope,
-                                        >::new(),
-                                    ),
-                                )?;
-                            if let Some(v) = v {
-                                if __oneof_scope.is_some() {
-                                    return Err(
-                                        serde::de::Error::custom(
-                                            "multiple oneof fields set for 'scope'",
-                                        ),
-                                    );
-                                }
-                                __oneof_scope = Some(
-                                    __buffa::oneof::policy::Scope::Keys(
-                                        ::buffa::alloc::boxed::Box::new(v),
-                                    ),
-                                );
-                            }
-                        }
-                        "sequence" => {
-                            let v: ::core::option::Option<SequenceScope> = map
-                                .next_value_seed(
-                                    ::buffa::json_helpers::NullableDeserializeSeed(
-                                        ::buffa::json_helpers::DefaultDeserializeSeed::<
-                                            SequenceScope,
-                                        >::new(),
-                                    ),
-                                )?;
-                            if let Some(v) = v {
-                                if __oneof_scope.is_some() {
-                                    return Err(
-                                        serde::de::Error::custom(
-                                            "multiple oneof fields set for 'scope'",
-                                        ),
-                                    );
-                                }
-                                __oneof_scope = Some(
-                                    __buffa::oneof::policy::Scope::Sequence(
-                                        ::buffa::alloc::boxed::Box::new(v),
-                                    ),
-                                );
-                            }
-                        }
-                        _ => {
-                            map.next_value::<serde::de::IgnoredAny>()?;
-                        }
-                    }
-                }
-                let mut __r = <Policy as ::core::default::Default>::default();
-                if let ::core::option::Option::Some(v) = __f_retain {
-                    __r.retain = v;
-                }
-                __r.scope = __oneof_scope;
-                Ok(__r)
-            }
-        }
-        d.deserialize_map(_V)
     }
 }
 impl ::buffa::json_helpers::ProtoElemJson for Policy {
@@ -2111,14 +1842,6 @@ pub const __POLICY_JSON_ANY: ::buffa::type_registry::JsonAnyEntry = ::buffa::typ
     from_json: ::buffa::type_registry::any_from_json::<Policy>,
     is_wkt: false,
 };
-pub mod policy {
-    #[allow(unused_imports)]
-    use super::*;
-    #[doc(inline)]
-    pub use super::__buffa::oneof::policy::Scope;
-    #[doc(inline)]
-    pub use super::__buffa::view::oneof::policy::Scope as ScopeView;
-}
 /// Request to execute prune policies.
 #[derive(Clone, PartialEq, Default)]
 #[derive(::serde::Serialize, ::serde::Deserialize)]
@@ -4354,178 +4077,17 @@ pub mod __buffa {
                 this
             }
         }
-        /// Sequence-number scope: prune the per-batch sequence log served by the
-        /// store's `Stream` service. `selector` / `group_by` / `order_by` are not
-        /// meaningful here — the log has a single implicit ordering by sequence
-        /// number. The `retain` rule on the parent `Policy` is interpreted directly
-        /// over sequence numbers:
-        ///
-        ///   - `keep_latest { count: N }`        -\> keep the last N batches
-        ///   - `greater_than { threshold: T }`   -\> keep sequence numbers \> T
-        ///   - `greater_than_or_equal { .. T }`  -\> keep sequence numbers \>= T
-        ///   - `drop_all`                        -\> clear the log entirely
-        #[derive(Clone, Debug, Default)]
-        pub struct SequenceScopeView<'a> {
-            pub __buffa_unknown_fields: ::buffa::UnknownFieldsView<'a>,
-        }
-        impl<'a> SequenceScopeView<'a> {
-            /// Decode from `buf`, enforcing a recursion depth limit for nested messages.
-            ///
-            /// Called by [`::buffa::MessageView::decode_view`] with [`::buffa::RECURSION_LIMIT`]
-            /// and by generated sub-message decode arms with `depth - 1`.
-            ///
-            /// **Not part of the public API.** Named with a leading underscore to
-            /// signal that it is for generated-code use only.
-            #[doc(hidden)]
-            pub fn _decode_depth(
-                buf: &'a [u8],
-                depth: u32,
-            ) -> ::core::result::Result<Self, ::buffa::DecodeError> {
-                let mut view = Self::default();
-                view._merge_into_view(buf, depth)?;
-                ::core::result::Result::Ok(view)
-            }
-            /// Merge fields from `buf` into this view (proto merge semantics).
-            ///
-            /// Repeated fields append; singular fields last-wins; singular
-            /// MESSAGE fields merge recursively. Used by sub-message decode
-            /// arms when the same field appears multiple times on the wire.
-            ///
-            /// **Not part of the public API.**
-            #[doc(hidden)]
-            pub fn _merge_into_view(
-                &mut self,
-                buf: &'a [u8],
-                depth: u32,
-            ) -> ::core::result::Result<(), ::buffa::DecodeError> {
-                let _ = depth;
-                #[allow(unused_variables)]
-                let view = self;
-                let mut cur: &'a [u8] = buf;
-                while !cur.is_empty() {
-                    let before_tag = cur;
-                    let tag = ::buffa::encoding::Tag::decode(&mut cur)?;
-                    match tag.field_number() {
-                        _ => {
-                            ::buffa::encoding::skip_field_depth(tag, &mut cur, depth)?;
-                            let span_len = before_tag.len() - cur.len();
-                            view.__buffa_unknown_fields
-                                .push_raw(&before_tag[..span_len]);
-                        }
-                    }
-                }
-                ::core::result::Result::Ok(())
-            }
-        }
-        impl<'a> ::buffa::MessageView<'a> for SequenceScopeView<'a> {
-            type Owned = super::super::SequenceScope;
-            fn decode_view(
-                buf: &'a [u8],
-            ) -> ::core::result::Result<Self, ::buffa::DecodeError> {
-                Self::_decode_depth(buf, ::buffa::RECURSION_LIMIT)
-            }
-            fn decode_view_with_limit(
-                buf: &'a [u8],
-                depth: u32,
-            ) -> ::core::result::Result<Self, ::buffa::DecodeError> {
-                Self::_decode_depth(buf, depth)
-            }
-            fn to_owned_message(&self) -> super::super::SequenceScope {
-                self.to_owned_from_source(None)
-            }
-            #[allow(clippy::useless_conversion, clippy::needless_update)]
-            fn to_owned_from_source(
-                &self,
-                __buffa_src: ::core::option::Option<&::buffa::bytes::Bytes>,
-            ) -> super::super::SequenceScope {
-                #[allow(unused_imports)]
-                use ::buffa::alloc::string::ToString as _;
-                let _ = __buffa_src;
-                super::super::SequenceScope {
-                    __buffa_unknown_fields: self
-                        .__buffa_unknown_fields
-                        .to_owned()
-                        .unwrap_or_default()
-                        .into(),
-                    ..::core::default::Default::default()
-                }
-            }
-        }
-        impl<'a> ::buffa::ViewEncode<'a> for SequenceScopeView<'a> {
-            #[allow(clippy::needless_borrow, clippy::let_and_return)]
-            fn compute_size(&self, _cache: &mut ::buffa::SizeCache) -> u32 {
-                #[allow(unused_imports)]
-                use ::buffa::Enumeration as _;
-                let mut size = 0u32;
-                size += self.__buffa_unknown_fields.encoded_len() as u32;
-                size
-            }
-            #[allow(clippy::needless_borrow)]
-            fn write_to(
-                &self,
-                _cache: &mut ::buffa::SizeCache,
-                buf: &mut impl ::buffa::bytes::BufMut,
-            ) {
-                #[allow(unused_imports)]
-                use ::buffa::Enumeration as _;
-                self.__buffa_unknown_fields.write_to(buf);
-            }
-        }
-        /// Serializes this view as protobuf JSON.
-        ///
-        /// Implicit-presence fields with default values are omitted, `required`
-        /// fields are always emitted, explicit-presence (`optional`) fields are
-        /// emitted only when set, bytes fields are base64-encoded, and enum
-        /// values are their proto name strings.
-        ///
-        /// This impl uses `serialize_map(None)` because the number of emitted
-        /// fields depends on default-omission rules; serializers that require
-        /// known map lengths (e.g. `bincode`) will return a runtime error.
-        /// Use the owned message type for those formats.
-        impl<'__a> ::serde::Serialize for SequenceScopeView<'__a> {
-            fn serialize<__S: ::serde::Serializer>(
-                &self,
-                __s: __S,
-            ) -> ::core::result::Result<__S::Ok, __S::Error> {
-                use ::serde::ser::SerializeMap as _;
-                let mut __map = __s.serialize_map(::core::option::Option::None)?;
-                __map.end()
-            }
-        }
-        impl<'a> ::buffa::MessageName for SequenceScopeView<'a> {
-            const PACKAGE: &'static str = "store.compact.v1";
-            const NAME: &'static str = "SequenceScope";
-            const FULL_NAME: &'static str = "store.compact.v1.SequenceScope";
-            const TYPE_URL: &'static str = "type.googleapis.com/store.compact.v1.SequenceScope";
-        }
-        impl<'v> ::buffa::DefaultViewInstance for SequenceScopeView<'v> {
-            fn default_view_instance<'a>() -> &'a Self
-            where
-                Self: 'a,
-            {
-                static VALUE: ::buffa::__private::OnceBox<SequenceScopeView<'static>> = ::buffa::__private::OnceBox::new();
-                VALUE
-                    .get_or_init(|| ::buffa::alloc::boxed::Box::new(
-                        <SequenceScopeView<'static>>::default(),
-                    ))
-            }
-        }
-        impl ::buffa::ViewReborrow for SequenceScopeView<'static> {
-            type Reborrowed<'b> = SequenceScopeView<'b>;
-            fn reborrow<'b>(this: &'b Self) -> &'b Self::Reborrowed<'b> {
-                this
-            }
-        }
-        /// A single prune policy. `scope` discriminates the keyspace the rule applies
-        /// to; `retain` is shared between scopes.
+        /// A single prune policy: group keys via `keys`, then apply `retain` to decide
+        /// which of them survive. `keys` is required.
         #[derive(Clone, Debug, Default)]
         pub struct PolicyView<'a> {
+            /// Field 1: `keys`
+            pub keys: ::buffa::MessageFieldView<
+                super::super::__buffa::view::KeysScopeView<'a>,
+            >,
             /// Field 3: `retain`
             pub retain: ::buffa::MessageFieldView<
                 super::super::__buffa::view::PolicyRetainView<'a>,
-            >,
-            pub scope: ::core::option::Option<
-                super::super::__buffa::view::oneof::policy::Scope<'a>,
             >,
             pub __buffa_unknown_fields: ::buffa::UnknownFieldsView<'a>,
         }
@@ -4567,6 +4129,32 @@ pub mod __buffa {
                     let before_tag = cur;
                     let tag = ::buffa::encoding::Tag::decode(&mut cur)?;
                     match tag.field_number() {
+                        1u32 => {
+                            if tag.wire_type()
+                                != ::buffa::encoding::WireType::LengthDelimited
+                            {
+                                return ::core::result::Result::Err(::buffa::DecodeError::WireTypeMismatch {
+                                    field_number: 1u32,
+                                    expected: 2u8,
+                                    actual: tag.wire_type() as u8,
+                                });
+                            }
+                            if depth == 0 {
+                                return Err(::buffa::DecodeError::RecursionLimitExceeded);
+                            }
+                            let sub = ::buffa::types::borrow_bytes(&mut cur)?;
+                            match view.keys.as_mut() {
+                                Some(existing) => existing._merge_into_view(sub, depth - 1)?,
+                                None => {
+                                    view.keys = ::buffa::MessageFieldView::set(
+                                        super::super::__buffa::view::KeysScopeView::_decode_depth(
+                                            sub,
+                                            depth - 1,
+                                        )?,
+                                    );
+                                }
+                            }
+                        }
                         3u32 => {
                             if tag.wire_type()
                                 != ::buffa::encoding::WireType::LengthDelimited
@@ -4591,74 +4179,6 @@ pub mod __buffa {
                                         )?,
                                     );
                                 }
-                            }
-                        }
-                        1u32 => {
-                            if tag.wire_type()
-                                != ::buffa::encoding::WireType::LengthDelimited
-                            {
-                                return ::core::result::Result::Err(::buffa::DecodeError::WireTypeMismatch {
-                                    field_number: 1u32,
-                                    expected: 2u8,
-                                    actual: tag.wire_type() as u8,
-                                });
-                            }
-                            if depth == 0 {
-                                return Err(::buffa::DecodeError::RecursionLimitExceeded);
-                            }
-                            let sub = ::buffa::types::borrow_bytes(&mut cur)?;
-                            if let Some(
-                                super::super::__buffa::view::oneof::policy::Scope::Keys(
-                                    ref mut existing,
-                                ),
-                            ) = view.scope
-                            {
-                                existing._merge_into_view(sub, depth - 1)?;
-                            } else {
-                                view.scope = Some(
-                                    super::super::__buffa::view::oneof::policy::Scope::Keys(
-                                        ::buffa::alloc::boxed::Box::new(
-                                            super::super::__buffa::view::KeysScopeView::_decode_depth(
-                                                sub,
-                                                depth - 1,
-                                            )?,
-                                        ),
-                                    ),
-                                );
-                            }
-                        }
-                        2u32 => {
-                            if tag.wire_type()
-                                != ::buffa::encoding::WireType::LengthDelimited
-                            {
-                                return ::core::result::Result::Err(::buffa::DecodeError::WireTypeMismatch {
-                                    field_number: 2u32,
-                                    expected: 2u8,
-                                    actual: tag.wire_type() as u8,
-                                });
-                            }
-                            if depth == 0 {
-                                return Err(::buffa::DecodeError::RecursionLimitExceeded);
-                            }
-                            let sub = ::buffa::types::borrow_bytes(&mut cur)?;
-                            if let Some(
-                                super::super::__buffa::view::oneof::policy::Scope::Sequence(
-                                    ref mut existing,
-                                ),
-                            ) = view.scope
-                            {
-                                existing._merge_into_view(sub, depth - 1)?;
-                            } else {
-                                view.scope = Some(
-                                    super::super::__buffa::view::oneof::policy::Scope::Sequence(
-                                        ::buffa::alloc::boxed::Box::new(
-                                            super::super::__buffa::view::SequenceScopeView::_decode_depth(
-                                                sub,
-                                                depth - 1,
-                                            )?,
-                                        ),
-                                    ),
-                                );
                             }
                         }
                         _ => {
@@ -4697,6 +4217,14 @@ pub mod __buffa {
                 use ::buffa::alloc::string::ToString as _;
                 let _ = __buffa_src;
                 super::super::Policy {
+                    keys: match self.keys.as_option() {
+                        Some(v) => {
+                            ::buffa::MessageField::<
+                                super::super::KeysScope,
+                            >::some(v.to_owned_from_source(__buffa_src))
+                        }
+                        None => ::buffa::MessageField::none(),
+                    },
                     retain: match self.retain.as_option() {
                         Some(v) => {
                             ::buffa::MessageField::<
@@ -4705,29 +4233,6 @@ pub mod __buffa {
                         }
                         None => ::buffa::MessageField::none(),
                     },
-                    scope: self
-                        .scope
-                        .as_ref()
-                        .map(|v| match v {
-                            super::super::__buffa::view::oneof::policy::Scope::Keys(
-                                v,
-                            ) => {
-                                super::super::__buffa::oneof::policy::Scope::Keys(
-                                    ::buffa::alloc::boxed::Box::new(
-                                        v.to_owned_from_source(__buffa_src),
-                                    ),
-                                )
-                            }
-                            super::super::__buffa::view::oneof::policy::Scope::Sequence(
-                                v,
-                            ) => {
-                                super::super::__buffa::oneof::policy::Scope::Sequence(
-                                    ::buffa::alloc::boxed::Box::new(
-                                        v.to_owned_from_source(__buffa_src),
-                                    ),
-                                )
-                            }
-                        }),
                     __buffa_unknown_fields: self
                         .__buffa_unknown_fields
                         .to_owned()
@@ -4743,27 +4248,13 @@ pub mod __buffa {
                 #[allow(unused_imports)]
                 use ::buffa::Enumeration as _;
                 let mut size = 0u32;
-                if let ::core::option::Option::Some(ref v) = self.scope {
-                    match v {
-                        super::super::__buffa::view::oneof::policy::Scope::Keys(x) => {
-                            let __slot = __cache.reserve();
-                            let inner = x.compute_size(__cache);
-                            __cache.set(__slot, inner);
-                            size
-                                += 1u32 + ::buffa::encoding::varint_len(inner as u64) as u32
-                                    + inner;
-                        }
-                        super::super::__buffa::view::oneof::policy::Scope::Sequence(
-                            x,
-                        ) => {
-                            let __slot = __cache.reserve();
-                            let inner = x.compute_size(__cache);
-                            __cache.set(__slot, inner);
-                            size
-                                += 1u32 + ::buffa::encoding::varint_len(inner as u64) as u32
-                                    + inner;
-                        }
-                    }
+                if self.keys.is_set() {
+                    let __slot = __cache.reserve();
+                    let inner_size = self.keys.compute_size(__cache);
+                    __cache.set(__slot, inner_size);
+                    size
+                        += 1u32 + ::buffa::encoding::varint_len(inner_size as u64) as u32
+                            + inner_size;
                 }
                 if self.retain.is_set() {
                     let __slot = __cache.reserve();
@@ -4784,35 +4275,14 @@ pub mod __buffa {
             ) {
                 #[allow(unused_imports)]
                 use ::buffa::Enumeration as _;
-                if let ::core::option::Option::Some(ref v) = self.scope {
-                    match v {
-                        super::super::__buffa::view::oneof::policy::Scope::Keys(x) => {
-                            ::buffa::encoding::Tag::new(
-                                    1u32,
-                                    ::buffa::encoding::WireType::LengthDelimited,
-                                )
-                                .encode(buf);
-                            ::buffa::encoding::encode_varint(
-                                __cache.consume_next() as u64,
-                                buf,
-                            );
-                            x.write_to(__cache, buf);
-                        }
-                        super::super::__buffa::view::oneof::policy::Scope::Sequence(
-                            x,
-                        ) => {
-                            ::buffa::encoding::Tag::new(
-                                    2u32,
-                                    ::buffa::encoding::WireType::LengthDelimited,
-                                )
-                                .encode(buf);
-                            ::buffa::encoding::encode_varint(
-                                __cache.consume_next() as u64,
-                                buf,
-                            );
-                            x.write_to(__cache, buf);
-                        }
-                    }
+                if self.keys.is_set() {
+                    ::buffa::encoding::Tag::new(
+                            1u32,
+                            ::buffa::encoding::WireType::LengthDelimited,
+                        )
+                        .encode(buf);
+                    ::buffa::encoding::encode_varint(__cache.consume_next() as u64, buf);
+                    self.keys.write_to(__cache, buf);
                 }
                 if self.retain.is_set() {
                     ::buffa::encoding::Tag::new(
@@ -4845,20 +4315,13 @@ pub mod __buffa {
                 use ::serde::ser::SerializeMap as _;
                 let mut __map = __s.serialize_map(::core::option::Option::None)?;
                 {
-                    if let ::core::option::Option::Some(__v) = self.retain.as_option() {
-                        __map.serialize_entry("retain", __v)?;
+                    if let ::core::option::Option::Some(__v) = self.keys.as_option() {
+                        __map.serialize_entry("keys", __v)?;
                     }
                 }
-                if let ::core::option::Option::Some(ref __ov) = self.scope {
-                    match __ov {
-                        super::super::__buffa::view::oneof::policy::Scope::Keys(v) => {
-                            __map.serialize_entry("keys", v)?;
-                        }
-                        super::super::__buffa::view::oneof::policy::Scope::Sequence(
-                            v,
-                        ) => {
-                            __map.serialize_entry("sequence", v)?;
-                        }
+                {
+                    if let ::core::option::Option::Some(__v) = self.retain.as_option() {
+                        __map.serialize_entry("retain", __v)?;
                     }
                 }
                 __map.end()
@@ -5287,25 +4750,6 @@ pub mod __buffa {
                     ),
                 }
             }
-            pub mod policy {
-                #[allow(unused_imports)]
-                use super::*;
-                #[derive(Clone, Debug)]
-                pub enum Scope<'a> {
-                    Keys(
-                        ::buffa::alloc::boxed::Box<
-                            super::super::super::super::__buffa::view::KeysScopeView<'a>,
-                        >,
-                    ),
-                    Sequence(
-                        ::buffa::alloc::boxed::Box<
-                            super::super::super::super::__buffa::view::SequenceScopeView<
-                                'a,
-                            >,
-                        >,
-                    ),
-                }
-            }
         }
     }
     pub mod oneof {
@@ -5399,55 +4843,6 @@ pub mod __buffa {
                 }
             }
         }
-        pub mod policy {
-            #[allow(unused_imports)]
-            use super::*;
-            #[derive(Clone, PartialEq, Debug)]
-            pub enum Scope {
-                Keys(::buffa::alloc::boxed::Box<super::super::super::KeysScope>),
-                Sequence(::buffa::alloc::boxed::Box<super::super::super::SequenceScope>),
-            }
-            impl ::buffa::Oneof for Scope {}
-            impl From<super::super::super::KeysScope> for Scope {
-                fn from(v: super::super::super::KeysScope) -> Self {
-                    Self::Keys(::buffa::alloc::boxed::Box::new(v))
-                }
-            }
-            impl From<super::super::super::KeysScope> for ::core::option::Option<Scope> {
-                fn from(v: super::super::super::KeysScope) -> Self {
-                    Self::Some(Scope::from(v))
-                }
-            }
-            impl From<super::super::super::SequenceScope> for Scope {
-                fn from(v: super::super::super::SequenceScope) -> Self {
-                    Self::Sequence(::buffa::alloc::boxed::Box::new(v))
-                }
-            }
-            impl From<super::super::super::SequenceScope>
-            for ::core::option::Option<Scope> {
-                fn from(v: super::super::super::SequenceScope) -> Self {
-                    Self::Some(Scope::from(v))
-                }
-            }
-            impl serde::Serialize for Scope {
-                fn serialize<S: serde::Serializer>(
-                    &self,
-                    s: S,
-                ) -> ::core::result::Result<S::Ok, S::Error> {
-                    use serde::ser::SerializeMap;
-                    let mut map = s.serialize_map(Some(1))?;
-                    match self {
-                        Self::Keys(v) => {
-                            map.serialize_entry("keys", v)?;
-                        }
-                        Self::Sequence(v) => {
-                            map.serialize_entry("sequence", v)?;
-                        }
-                    }
-                    map.end()
-                }
-            }
-        }
     }
 }
 #[doc(inline)]
@@ -5466,8 +4861,6 @@ pub use self::__buffa::view::RetainDropAllView;
 pub use self::__buffa::view::PolicyRetainView;
 #[doc(inline)]
 pub use self::__buffa::view::KeysScopeView;
-#[doc(inline)]
-pub use self::__buffa::view::SequenceScopeView;
 #[doc(inline)]
 pub use self::__buffa::view::PolicyView;
 #[doc(inline)]

--- a/sdk/rs/src/lib.rs
+++ b/sdk/rs/src/lib.rs
@@ -14,6 +14,7 @@ pub mod keys;
 pub mod kv_codec;
 pub mod proto;
 pub mod prune_policy;
+pub mod retention;
 pub mod selector;
 pub mod stream_filter;
 pub use keys::{Key, KeyMut, KeyValidationError, Prefix, PrefixError, Value, MAX_KEY_LEN};
@@ -350,15 +351,9 @@ impl PrefixedStoreClient {
         policies
             .iter()
             .map(|policy| {
-                use crate::prune_policy::{PolicyScope, PrunePolicy};
-                let scope = match &policy.scope {
-                    PolicyScope::Keys(scope) => {
-                        let mut scope = scope.clone();
-                        scope.selector = self.prefix.prefix_selector(&scope.selector)?;
-                        PolicyScope::Keys(scope)
-                    }
-                    PolicyScope::Sequence => PolicyScope::Sequence,
-                };
+                use crate::prune_policy::PrunePolicy;
+                let mut scope = policy.scope.clone();
+                scope.selector = self.prefix.prefix_selector(&scope.selector)?;
                 Ok(PrunePolicy {
                     scope,
                     retain: policy.retain.clone(),
@@ -805,6 +800,15 @@ impl PrefixedStoreClient {
             out.push((self.decode_store_key(&key)?, entry.value));
         }
         Ok(Some(out))
+    }
+
+    pub(crate) async fn set_retention(
+        &self,
+        policy: Option<crate::retention::RetentionPolicy>,
+    ) -> Result<Option<u64>, ClientError> {
+        // Retention operates on sequence numbers, not keys, so there is no
+        // per-namespace prefixing to apply here.
+        self.client.set_retention(policy).await
     }
 }
 
@@ -1957,6 +1961,32 @@ impl StoreClient {
         }
     }
 
+    /// Install (`Some`) or clear (`None`) the sequence-log retention rule via
+    /// `log.stream.v1.SetRetention`. Returns the lowest retained sequence after
+    /// one synchronous enforcement of the new rule (`None` when the log is
+    /// empty / no floor exists yet).
+    async fn set_retention(
+        &self,
+        policy: Option<crate::retention::RetentionPolicy>,
+    ) -> Result<Option<u64>, ClientError> {
+        let request = exoware_proto::log::stream::v1::SetRetentionRequest {
+            policy: policy
+                .as_ref()
+                .map(exoware_proto::retention_policy_to_proto)
+                .into(),
+            ..Default::default()
+        };
+        let config =
+            store_connect_client_config(self.stream_uri.clone(), self.connect_request_compression);
+        let client =
+            exoware_proto::log::stream::v1::ServiceClient::new(self.connect_http.clone(), config);
+        let response = client
+            .set_retention(request)
+            .await
+            .map_err(client_error_from_connect)?;
+        Ok(response.into_owned().oldest_retained_sequence)
+    }
+
     pub async fn health(&self) -> Result<bool, ClientError> {
         let resp = self
             .http
@@ -2515,6 +2545,19 @@ impl<'a> Stream<'a> {
         sequence_number: u64,
     ) -> Result<Option<Vec<(Key, Bytes)>>, ClientError> {
         self.c.stream_get(sequence_number).await
+    }
+
+    /// `log.stream.v1.Service.SetRetention` — install (`Some`) or clear
+    /// (`None`) the sequence-log retention rule. The rule is persistent and
+    /// continuously enforced as the log grows; eviction surfaces to
+    /// subscribers as `BATCH_EVICTED`. Returns the lowest retained sequence
+    /// after one synchronous enforcement (`None` when the log is empty / no
+    /// floor exists yet).
+    pub async fn set_retention(
+        &self,
+        policy: Option<crate::retention::RetentionPolicy>,
+    ) -> Result<Option<u64>, ClientError> {
+        self.c.set_retention(policy).await
     }
 }
 

--- a/sdk/rs/src/proto/mod.rs
+++ b/sdk/rs/src/proto/mod.rs
@@ -1144,6 +1144,12 @@ pub use prune_policy_proto::{
     validate_prune_policy_document,
 };
 
+mod retention_proto;
+pub use retention_proto::{
+    parse_retention_policy_from_proto, parse_set_retention_request_view, retention_policy_to_proto,
+    validate_retention_policy,
+};
+
 mod error_details;
 pub use error_details::{
     decode_connect_error, with_bad_request_detail, with_error_info_detail, with_query_detail,

--- a/sdk/rs/src/proto/prune_policy_proto.rs
+++ b/sdk/rs/src/proto/prune_policy_proto.rs
@@ -6,12 +6,12 @@
 use crate::common::kv::v1::Selector as ProtoSelector;
 use crate::kv_codec::Utf8;
 use crate::prune_policy::{
-    GroupBy, KeysScope, OrderBy, OrderEncoding, PolicyScope, PrunePolicy, PrunePolicyDocument,
-    RetainPolicy, PRUNE_POLICY_DOCUMENT_VERSION,
+    GroupBy, KeysScope, OrderBy, OrderEncoding, PrunePolicy, PrunePolicyDocument, RetainPolicy,
+    PRUNE_POLICY_DOCUMENT_VERSION,
 };
 use crate::selector::Selector;
 use crate::store::compact::v1::{
-    policy, policy_retain, KeysScope as ProtoKeysScope, Policy as ProtoPolicy, PolicyOrderBy,
+    policy_retain, KeysScope as ProtoKeysScope, Policy as ProtoPolicy, PolicyOrderBy,
     PolicyOrderEncoding, PruneRequestView,
 };
 use buffa::MessageView;
@@ -94,13 +94,10 @@ fn keys_scope_from_proto(s: &ProtoKeysScope) -> Result<KeysScope, String> {
 }
 
 pub fn parse_prune_policy_from_proto(p: &ProtoPolicy) -> Result<PrunePolicy, String> {
-    let Some(scope_proto) = p.scope.as_ref() else {
-        return Err("prune policy scope is required".to_string());
+    let Some(keys) = p.keys.as_option() else {
+        return Err("prune policy keys scope is required".to_string());
     };
-    let scope = match scope_proto {
-        policy::Scope::Keys(keys) => PolicyScope::Keys(keys_scope_from_proto(keys)?),
-        policy::Scope::Sequence(_) => PolicyScope::Sequence,
-    };
+    let scope = keys_scope_from_proto(keys)?;
 
     let Some(retain_proto) = p.retain.as_option() else {
         return Err("prune policy retain is required".to_string());
@@ -187,18 +184,13 @@ fn prune_policy_to_proto(p: &PrunePolicy) -> crate::store::compact::v1::Policy {
         RetainPolicy::DropAll => policy_retain::Kind::DropAll(Box::default()),
     };
 
-    let scope = match &p.scope {
-        PolicyScope::Keys(s) => policy::Scope::Keys(Box::new(keys_scope_to_proto(s))),
-        PolicyScope::Sequence => policy::Scope::Sequence(Box::default()),
-    };
-
     Policy {
         retain: Some(PolicyRetain {
             kind: Some(retain_kind),
             ..Default::default()
         })
         .into(),
-        scope: Some(scope),
+        keys: Some(keys_scope_to_proto(&p.scope)).into(),
         ..Default::default()
     }
 }
@@ -245,7 +237,7 @@ mod tests {
     #[test]
     fn owned_proto_policy_round_trips_to_domain_policy() {
         let expected = PrunePolicy {
-            scope: PolicyScope::Keys(KeysScope {
+            scope: KeysScope {
                 selector: Selector {
                     prefix: bytes::Bytes::copy_from_slice(&[1]),
                     payload_regex: Utf8::from("(?s)^(?P<logical>.*)-(?P<version>.{8})$"),
@@ -257,7 +249,7 @@ mod tests {
                     capture_group: Utf8::from("version"),
                     encoding: OrderEncoding::U64Be,
                 }),
-            }),
+            },
             retain: RetainPolicy::KeepLatest { count: 2 },
         };
         let proto = prune_policies_to_proto(std::slice::from_ref(&expected))
@@ -275,7 +267,19 @@ mod tests {
         use buffa::Message as _;
 
         let invalid = PrunePolicy {
-            scope: PolicyScope::Sequence,
+            scope: KeysScope {
+                selector: Selector {
+                    prefix: bytes::Bytes::copy_from_slice(&[1]),
+                    payload_regex: Utf8::from("(?s)^(?P<logical>.*)-(?P<version>.{8})$"),
+                },
+                group_by: GroupBy {
+                    capture_groups: vec![Utf8::from("logical")],
+                },
+                order_by: Some(OrderBy {
+                    capture_group: Utf8::from("version"),
+                    encoding: OrderEncoding::U64Be,
+                }),
+            },
             retain: RetainPolicy::KeepLatest { count: 0 },
         };
         let request = crate::store::compact::v1::PruneRequest {

--- a/sdk/rs/src/proto/retention_proto.rs
+++ b/sdk/rs/src/proto/retention_proto.rs
@@ -1,0 +1,121 @@
+//! Parse protobuf retention messages into `retention` domain types.
+//!
+//! Parsing checks only protobuf shape. Call the validation helper on the parsed
+//! output before applying retention effects (the handler is authoritative;
+//! `buf.validate` annotations on the proto are documentation).
+
+use crate::log::stream::v1::{
+    retention_policy, RetentionGreaterThan, RetentionGreaterThanOrEqual, RetentionKeepLatest,
+    RetentionPolicy as ProtoRetentionPolicy, SetRetentionRequestView,
+};
+use crate::retention::RetentionPolicy;
+use buffa::MessageView;
+
+pub fn parse_retention_policy_from_proto(
+    p: &ProtoRetentionPolicy,
+) -> Result<RetentionPolicy, String> {
+    let Some(kind) = p.kind.as_ref() else {
+        return Err("retention policy kind is required".to_string());
+    };
+    let policy = match kind {
+        retention_policy::Kind::KeepLatest(k) => RetentionPolicy::KeepLatest { count: k.count },
+        retention_policy::Kind::GreaterThan(g) => RetentionPolicy::GreaterThan {
+            threshold: g.threshold,
+        },
+        retention_policy::Kind::GreaterThanOrEqual(g) => RetentionPolicy::GreaterThanOrEqual {
+            threshold: g.threshold,
+        },
+        retention_policy::Kind::DropAll(_) => RetentionPolicy::DropAll,
+    };
+    Ok(policy)
+}
+
+pub fn retention_policy_to_proto(policy: &RetentionPolicy) -> ProtoRetentionPolicy {
+    let kind = match policy {
+        RetentionPolicy::KeepLatest { count } => {
+            retention_policy::Kind::KeepLatest(Box::new(RetentionKeepLatest {
+                count: *count,
+                ..Default::default()
+            }))
+        }
+        RetentionPolicy::GreaterThan { threshold } => {
+            retention_policy::Kind::GreaterThan(Box::new(RetentionGreaterThan {
+                threshold: *threshold,
+                ..Default::default()
+            }))
+        }
+        RetentionPolicy::GreaterThanOrEqual { threshold } => {
+            retention_policy::Kind::GreaterThanOrEqual(Box::new(RetentionGreaterThanOrEqual {
+                threshold: *threshold,
+                ..Default::default()
+            }))
+        }
+        RetentionPolicy::DropAll => retention_policy::Kind::DropAll(Box::default()),
+    };
+    ProtoRetentionPolicy {
+        kind: Some(kind),
+        ..Default::default()
+    }
+}
+
+/// Parses a `SetRetention` RPC request. An absent `policy` clears the rule and
+/// maps to `Ok(None)`.
+pub fn parse_set_retention_request_view(
+    req: &SetRetentionRequestView<'_>,
+) -> Result<Option<RetentionPolicy>, String> {
+    let Some(policy_view) = req.policy.as_option() else {
+        return Ok(None);
+    };
+    let policy = policy_view.to_owned_message();
+    Ok(Some(parse_retention_policy_from_proto(&policy)?))
+}
+
+pub fn validate_retention_policy(policy: &RetentionPolicy) -> Result<(), String> {
+    crate::retention::validate_retention_policy(policy).map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use buffa::Message as _;
+
+    #[test]
+    fn owned_proto_round_trips_to_domain() {
+        for expected in [
+            RetentionPolicy::KeepLatest { count: 3 },
+            RetentionPolicy::GreaterThan { threshold: 9 },
+            RetentionPolicy::GreaterThanOrEqual { threshold: 4 },
+            RetentionPolicy::DropAll,
+        ] {
+            let proto = retention_policy_to_proto(&expected);
+            let actual = parse_retention_policy_from_proto(&proto).expect("from proto");
+            assert_eq!(actual, expected);
+        }
+    }
+
+    #[test]
+    fn set_retention_view_with_policy_parses() {
+        let request = crate::log::stream::v1::SetRetentionRequest {
+            policy: Some(retention_policy_to_proto(&RetentionPolicy::KeepLatest {
+                count: 2,
+            }))
+            .into(),
+            ..Default::default()
+        };
+        let bytes = request.encode_to_vec();
+        let view = SetRetentionRequestView::decode_view(&bytes).expect("decode view");
+
+        let parsed = parse_set_retention_request_view(&view).expect("parse");
+        assert_eq!(parsed, Some(RetentionPolicy::KeepLatest { count: 2 }));
+    }
+
+    #[test]
+    fn set_retention_view_absent_policy_clears() {
+        let request = crate::log::stream::v1::SetRetentionRequest::default();
+        let bytes = request.encode_to_vec();
+        let view = SetRetentionRequestView::decode_view(&bytes).expect("decode view");
+
+        let parsed = parse_set_retention_request_view(&view).expect("parse");
+        assert_eq!(parsed, None);
+    }
+}

--- a/sdk/rs/src/prune_policy.rs
+++ b/sdk/rs/src/prune_policy.rs
@@ -10,27 +10,22 @@ use crate::kv_codec::Utf8;
 use crate::selector::{compile_payload_regex, Selector};
 
 pub const PRUNE_POLICY_CONTROL_KEY: &str = "manifest/control/compaction-prune-policies";
-pub const PRUNE_POLICY_DOCUMENT_VERSION: u32 = 1;
+/// Wire version of the persisted prune-policy document. A prune document
+/// carries only key scopes; sequence-log retention is configured separately via
+/// `log.stream.v1.SetRetention`.
+pub const PRUNE_POLICY_DOCUMENT_VERSION: u32 = 2;
 
-/// One prune rule. `scope` picks the keyspace; `retain` decides what survives.
+/// One prune rule. `scope` selects which keys to consider; `retain` decides
+/// what survives.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct PrunePolicy {
-    pub scope: PolicyScope,
+    pub scope: KeysScope,
     pub retain: RetainPolicy,
 }
 
-/// Which keyspace a `PrunePolicy` applies to. `Keys` mirrors the original
-/// user-keys prune (filter by family+regex, group, order, then retain).
-/// `Sequence` operates over the sequence-number-indexed log served by
-/// `log.stream.v1` — no grouping/ordering needed.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub enum PolicyScope {
-    Keys(KeysScope),
-    Sequence,
-}
-
-/// User-key-space scope: same meaning as the previous top-level prune policy
-/// fields, just nested under the scope discriminator.
+/// User-key-space scope: filter a key-prefix family by `selector`, partition
+/// matched keys into `group_by` groups, order within each group by `order_by`,
+/// then apply `retain` to decide which keys to delete.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct KeysScope {
     pub selector: Selector,
@@ -217,40 +212,6 @@ impl Read for KeysScope {
     }
 }
 
-impl Write for PolicyScope {
-    fn write(&self, buf: &mut impl BufMut) {
-        match self {
-            PolicyScope::Keys(s) => {
-                0u8.write(buf);
-                s.write(buf);
-            }
-            PolicyScope::Sequence => {
-                1u8.write(buf);
-            }
-        }
-    }
-}
-
-impl EncodeSize for PolicyScope {
-    fn encode_size(&self) -> usize {
-        1 + match self {
-            PolicyScope::Keys(s) => s.encode_size(),
-            PolicyScope::Sequence => 0,
-        }
-    }
-}
-
-impl Read for PolicyScope {
-    type Cfg = ();
-    fn read_cfg(buf: &mut impl Buf, _: &()) -> Result<Self, CodecError> {
-        match u8::read(buf)? {
-            0 => Ok(PolicyScope::Keys(KeysScope::read(buf)?)),
-            1 => Ok(PolicyScope::Sequence),
-            v => Err(CodecError::InvalidEnum(v)),
-        }
-    }
-}
-
 impl Write for PrunePolicy {
     fn write(&self, buf: &mut impl BufMut) {
         self.scope.write(buf);
@@ -268,7 +229,7 @@ impl Read for PrunePolicy {
     type Cfg = ();
     fn read_cfg(buf: &mut impl Buf, _: &()) -> Result<Self, CodecError> {
         Ok(PrunePolicy {
-            scope: PolicyScope::read(buf)?,
+            scope: KeysScope::read(buf)?,
             retain: RetainPolicy::read(buf)?,
         })
     }
@@ -298,13 +259,7 @@ impl Read for PrunePolicyDocument {
 }
 
 pub fn validate_policy(policy: &PrunePolicy) -> anyhow::Result<()> {
-    match &policy.scope {
-        PolicyScope::Keys(scope) => validate_user_keys_scope(scope)?,
-        PolicyScope::Sequence => {
-            // No scope-level configuration to validate; retention rules below
-            // are constrained by `validate_retain_for_scope`.
-        }
-    }
+    validate_user_keys_scope(&policy.scope)?;
     validate_retain_for_scope(policy)?;
     Ok(())
 }
@@ -332,65 +287,45 @@ fn validate_user_keys_scope(scope: &KeysScope) -> anyhow::Result<()> {
 }
 
 fn validate_retain_for_scope(policy: &PrunePolicy) -> anyhow::Result<()> {
-    match &policy.scope {
-        PolicyScope::Keys(scope) => match policy.retain {
-            RetainPolicy::KeepLatest { count } => {
-                ensure!(count > 0, "keep_latest count must be > 0");
-                ensure!(
-                    scope.order_by.is_some(),
-                    "keep_latest requires order_by to be configured"
-                );
-            }
-            RetainPolicy::GreaterThan { .. } | RetainPolicy::GreaterThanOrEqual { .. } => {
-                let order_by = scope
-                    .order_by
-                    .as_ref()
-                    .context("threshold retention requires order_by to be configured")?;
-                ensure!(
-                    matches!(order_by.encoding, OrderEncoding::U64Be),
-                    "threshold retention currently requires order_by.encoding = u64_be"
-                );
-            }
-            RetainPolicy::DropAll => {}
-        },
-        PolicyScope::Sequence => match policy.retain {
-            RetainPolicy::KeepLatest { count } => {
-                ensure!(count > 0, "keep_latest count must be > 0");
-            }
-            RetainPolicy::GreaterThan { .. }
-            | RetainPolicy::GreaterThanOrEqual { .. }
-            | RetainPolicy::DropAll => {}
-        },
+    let scope = &policy.scope;
+    match policy.retain {
+        RetainPolicy::KeepLatest { count } => {
+            ensure!(count > 0, "keep_latest count must be > 0");
+            ensure!(
+                scope.order_by.is_some(),
+                "keep_latest requires order_by to be configured"
+            );
+        }
+        RetainPolicy::GreaterThan { .. } | RetainPolicy::GreaterThanOrEqual { .. } => {
+            let order_by = scope
+                .order_by
+                .as_ref()
+                .context("threshold retention requires order_by to be configured")?;
+            ensure!(
+                matches!(order_by.encoding, OrderEncoding::U64Be),
+                "threshold retention currently requires order_by.encoding = u64_be"
+            );
+        }
+        RetainPolicy::DropAll => {}
     }
     Ok(())
 }
 
 pub fn ensure_unique_policy_families(policies: &[PrunePolicy]) -> anyhow::Result<()> {
     let mut user_prefixes: Vec<&[u8]> = Vec::new();
-    let mut sequence_seen = false;
     for policy in policies {
-        match &policy.scope {
-            PolicyScope::Keys(scope) => {
-                // Nested prefixes select overlapping physical key ranges, so
-                // two policies could disagree about the same rows. Reject any
-                // pair where one prefix extends the other (equality included).
-                let prefix: &[u8] = &scope.selector.prefix;
-                for seen in &user_prefixes {
-                    ensure!(
-                        !seen.starts_with(prefix) && !prefix.starts_with(seen),
-                        "overlapping compaction prune policies for key prefixes {seen:?} and {prefix:?}"
-                    );
-                }
-                user_prefixes.push(prefix);
-            }
-            PolicyScope::Sequence => {
-                ensure!(
-                    !sequence_seen,
-                    "duplicate compaction prune policy for sequence scope"
-                );
-                sequence_seen = true;
-            }
+        let scope = &policy.scope;
+        // Nested prefixes select overlapping physical key ranges, so two
+        // policies could disagree about the same rows. Reject any pair where
+        // one prefix extends the other (equality included).
+        let prefix: &[u8] = &scope.selector.prefix;
+        for seen in &user_prefixes {
+            ensure!(
+                !seen.starts_with(prefix) && !prefix.starts_with(seen),
+                "overlapping compaction prune policies for key prefixes {seen:?} and {prefix:?}"
+            );
         }
+        user_prefixes.push(prefix);
     }
     Ok(())
 }
@@ -451,15 +386,15 @@ fn capture_groups_are_unique(groups: &[Utf8]) -> bool {
 mod tests {
     use super::{
         decode_policy_document, encode_policy_document, GroupBy, KeysScope, OrderBy, OrderEncoding,
-        PolicyScope, PrunePolicy, PrunePolicyDocument, RetainPolicy, Selector,
-        PRUNE_POLICY_CONTROL_KEY,
+        PrunePolicy, PrunePolicyDocument, RetainPolicy, Selector, PRUNE_POLICY_CONTROL_KEY,
+        PRUNE_POLICY_DOCUMENT_VERSION,
     };
     use crate::kv_codec::Utf8;
     use bytes::Bytes;
 
     fn sample_policy() -> PrunePolicy {
         PrunePolicy {
-            scope: PolicyScope::Keys(KeysScope {
+            scope: KeysScope {
                 selector: Selector {
                     prefix: Bytes::copy_from_slice(&[1]),
                     payload_regex: Utf8::from(
@@ -473,14 +408,14 @@ mod tests {
                     capture_group: Utf8::from("version"),
                     encoding: OrderEncoding::U64Be,
                 }),
-            }),
+            },
             retain: RetainPolicy::KeepLatest { count: 10 },
         }
     }
 
     fn sample_document() -> PrunePolicyDocument {
         PrunePolicyDocument {
-            version: 1,
+            version: PRUNE_POLICY_DOCUMENT_VERSION,
             policies: vec![sample_policy()],
         }
     }
@@ -488,20 +423,14 @@ mod tests {
     #[test]
     fn nested_selector_prefixes_rejected() {
         let mut nested = sample_policy();
-        let PolicyScope::Keys(scope) = &mut nested.scope else {
-            unreachable!("sample policy uses Keys scope");
-        };
-        scope.selector.prefix = Bytes::copy_from_slice(&[1, 2]);
+        nested.scope.selector.prefix = Bytes::copy_from_slice(&[1, 2]);
         let err = super::ensure_unique_policy_families(&[sample_policy(), nested])
             .expect_err("nested prefixes overlap");
         assert!(err.to_string().contains("overlapping compaction"));
 
         let disjoint = sample_policy();
         let mut other = sample_policy();
-        let PolicyScope::Keys(scope) = &mut other.scope else {
-            unreachable!("sample policy uses Keys scope");
-        };
-        scope.selector.prefix = Bytes::copy_from_slice(&[2]);
+        other.scope.selector.prefix = Bytes::copy_from_slice(&[2]);
         super::ensure_unique_policy_families(&[disjoint, other]).expect("disjoint prefixes");
     }
 
@@ -515,7 +444,7 @@ mod tests {
     #[test]
     fn empty_bytes_means_no_policies() {
         let decoded = decode_policy_document(b"").expect("empty ok");
-        assert_eq!(decoded.version, 1);
+        assert_eq!(decoded.version, PRUNE_POLICY_DOCUMENT_VERSION);
         assert!(decoded.policies.is_empty());
         assert_eq!(
             PRUNE_POLICY_CONTROL_KEY,
@@ -526,9 +455,9 @@ mod tests {
     #[test]
     fn keep_latest_requires_order_by() {
         let doc = PrunePolicyDocument {
-            version: 1,
+            version: PRUNE_POLICY_DOCUMENT_VERSION,
             policies: vec![PrunePolicy {
-                scope: PolicyScope::Keys(KeysScope {
+                scope: KeysScope {
                     selector: Selector {
                         prefix: Bytes::copy_from_slice(&[1]),
                         payload_regex: Utf8::from(
@@ -539,7 +468,7 @@ mod tests {
                         capture_groups: vec![Utf8::from("logical")],
                     },
                     order_by: None,
-                }),
+                },
                 retain: RetainPolicy::KeepLatest { count: 1 },
             }],
         };
@@ -554,9 +483,9 @@ mod tests {
     #[test]
     fn capture_groups_must_exist() {
         let doc = PrunePolicyDocument {
-            version: 1,
+            version: PRUNE_POLICY_DOCUMENT_VERSION,
             policies: vec![PrunePolicy {
-                scope: PolicyScope::Keys(KeysScope {
+                scope: KeysScope {
                     selector: Selector {
                         prefix: Bytes::copy_from_slice(&[1]),
                         payload_regex: Utf8::from("(?s)^(?P<logical>.+)$"),
@@ -568,7 +497,7 @@ mod tests {
                         capture_group: Utf8::from("logical"),
                         encoding: OrderEncoding::BytesAsc,
                     }),
-                }),
+                },
                 retain: RetainPolicy::KeepLatest { count: 1 },
             }],
         };
@@ -583,53 +512,20 @@ mod tests {
     #[test]
     fn oversized_selector_prefix_returns_error() {
         let doc = PrunePolicyDocument {
-            version: 1,
+            version: PRUNE_POLICY_DOCUMENT_VERSION,
             policies: vec![PrunePolicy {
-                scope: PolicyScope::Keys(KeysScope {
+                scope: KeysScope {
                     selector: Selector {
                         prefix: Bytes::from(vec![0u8; crate::keys::MAX_KEY_LEN + 1]),
                         payload_regex: Utf8::from("(?s)^(?P<logical>.+)$"),
                     },
                     group_by: GroupBy::default(),
                     order_by: None,
-                }),
+                },
                 retain: RetainPolicy::DropAll,
             }],
         };
         let err = encode_policy_document(&doc).expect_err("oversized prefix");
         assert!(err.to_string().contains("invalid selector prefix"));
-    }
-
-    #[test]
-    fn sequence_scope_codec_round_trip() {
-        let doc = PrunePolicyDocument {
-            version: 1,
-            policies: vec![PrunePolicy {
-                scope: PolicyScope::Sequence,
-                retain: RetainPolicy::KeepLatest { count: 100 },
-            }],
-        };
-        let encoded = encode_policy_document(&doc).expect("encode");
-        let decoded = decode_policy_document(&encoded).expect("decode");
-        assert_eq!(decoded, doc);
-    }
-
-    #[test]
-    fn sequence_scope_rejects_duplicate() {
-        let doc = PrunePolicyDocument {
-            version: 1,
-            policies: vec![
-                PrunePolicy {
-                    scope: PolicyScope::Sequence,
-                    retain: RetainPolicy::DropAll,
-                },
-                PrunePolicy {
-                    scope: PolicyScope::Sequence,
-                    retain: RetainPolicy::GreaterThan { threshold: 10 },
-                },
-            ],
-        };
-        let err = encode_policy_document(&doc).unwrap_err();
-        assert!(err.to_string().contains("sequence"));
     }
 }

--- a/sdk/rs/src/retention.rs
+++ b/sdk/rs/src/retention.rs
@@ -1,0 +1,125 @@
+//! Sequence-log retention policy (the domain model behind
+//! `log.stream.v1.SetRetention`).
+//!
+//! Retention is owned end-to-end by the stream service: unlike a one-shot
+//! prune, an installed rule is persistent and continuously enforced as the log
+//! grows, evicting whatever falls below the rule's floor. This module carries
+//! the wire-stable domain type plus its `commonware_codec` impls (so the rule
+//! can be persisted next to the log) and its validation.
+
+use anyhow::ensure;
+use bytes::{Buf, BufMut};
+use commonware_codec::{EncodeSize, Error as CodecError, FixedSize, Read, ReadExt, Write};
+
+/// A sequence-log retention rule. Interpreted directly over sequence numbers;
+/// the stream service tracks the live frontier and evicts continuously.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum RetentionPolicy {
+    /// Keep the newest `count` batches, sliding the retained window forward as
+    /// the frontier advances. `count` must be > 0.
+    KeepLatest { count: u64 },
+    /// Retain sequence numbers strictly greater than `threshold`.
+    GreaterThan { threshold: u64 },
+    /// Retain sequence numbers greater than or equal to `threshold`.
+    GreaterThanOrEqual { threshold: u64 },
+    /// Retain nothing: evict up to the live frontier, continuously.
+    DropAll,
+}
+
+impl Write for RetentionPolicy {
+    fn write(&self, buf: &mut impl BufMut) {
+        match self {
+            RetentionPolicy::KeepLatest { count } => {
+                0u8.write(buf);
+                count.write(buf);
+            }
+            RetentionPolicy::GreaterThan { threshold } => {
+                1u8.write(buf);
+                threshold.write(buf);
+            }
+            RetentionPolicy::GreaterThanOrEqual { threshold } => {
+                2u8.write(buf);
+                threshold.write(buf);
+            }
+            RetentionPolicy::DropAll => {
+                3u8.write(buf);
+            }
+        }
+    }
+}
+
+impl EncodeSize for RetentionPolicy {
+    fn encode_size(&self) -> usize {
+        1 + match self {
+            RetentionPolicy::KeepLatest { .. }
+            | RetentionPolicy::GreaterThan { .. }
+            | RetentionPolicy::GreaterThanOrEqual { .. } => u64::SIZE,
+            RetentionPolicy::DropAll => 0,
+        }
+    }
+}
+
+impl Read for RetentionPolicy {
+    type Cfg = ();
+    fn read_cfg(buf: &mut impl Buf, _: &()) -> Result<Self, CodecError> {
+        match u8::read(buf)? {
+            0 => Ok(RetentionPolicy::KeepLatest {
+                count: u64::read(buf)?,
+            }),
+            1 => Ok(RetentionPolicy::GreaterThan {
+                threshold: u64::read(buf)?,
+            }),
+            2 => Ok(RetentionPolicy::GreaterThanOrEqual {
+                threshold: u64::read(buf)?,
+            }),
+            3 => Ok(RetentionPolicy::DropAll),
+            v => Err(CodecError::InvalidEnum(v)),
+        }
+    }
+}
+
+/// Reject rules that cannot be enforced. `keep_latest` must keep at least one
+/// batch; the threshold and drop-all rules accept any value.
+pub fn validate_retention_policy(policy: &RetentionPolicy) -> anyhow::Result<()> {
+    if let RetentionPolicy::KeepLatest { count } = policy {
+        ensure!(*count > 0, "keep_latest count must be > 0");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{validate_retention_policy, RetentionPolicy};
+    use commonware_codec::{DecodeExt, Encode};
+
+    fn round_trip(policy: &RetentionPolicy) {
+        let encoded = policy.encode();
+        let decoded = RetentionPolicy::decode(encoded).expect("decode");
+        assert_eq!(&decoded, policy);
+    }
+
+    #[test]
+    fn codec_round_trip() {
+        round_trip(&RetentionPolicy::KeepLatest { count: 5 });
+        round_trip(&RetentionPolicy::GreaterThan { threshold: 42 });
+        round_trip(&RetentionPolicy::GreaterThanOrEqual { threshold: 7 });
+        round_trip(&RetentionPolicy::DropAll);
+    }
+
+    #[test]
+    fn keep_latest_requires_positive_count() {
+        let err = validate_retention_policy(&RetentionPolicy::KeepLatest { count: 0 })
+            .expect_err("count 0 rejected");
+        assert!(err.to_string().contains("keep_latest count must be > 0"));
+
+        validate_retention_policy(&RetentionPolicy::KeepLatest { count: 1 }).expect("count 1 ok");
+    }
+
+    #[test]
+    fn other_rules_validate() {
+        validate_retention_policy(&RetentionPolicy::GreaterThan { threshold: 0 }).expect("gt ok");
+        validate_retention_policy(&RetentionPolicy::GreaterThanOrEqual { threshold: 0 })
+            .expect("gte ok");
+        validate_retention_policy(&RetentionPolicy::DropAll).expect("drop_all ok");
+    }
+}

--- a/sdk/ts/__tests__/sdk.test.ts
+++ b/sdk/ts/__tests__/sdk.test.ts
@@ -496,23 +496,20 @@ describe('Exoware TS SDK', () => {
             }
 
             const policy = create(PolicySchema, {
-                scope: {
-                    case: 'keys',
-                    value: create(KeysScopeSchema, {
-                        selector: create(SelectorSchema, {
-                            prefix: new Uint8Array(),
-                            payloadRegex:
-                                '(?s-u)^prune-test-(?P<group>[a-z]+)\\x00\\x00(?P<version>.{8})$',
-                        }),
-                        groupBy: create(PolicyGroupBySchema, {
-                            captureGroups: ['group'],
-                        }),
-                        orderBy: create(PolicyOrderBySchema, {
-                            captureGroup: 'version',
-                            encoding: PolicyOrderEncoding.U64_BE,
-                        }),
+                keys: create(KeysScopeSchema, {
+                    selector: create(SelectorSchema, {
+                        prefix: new Uint8Array(),
+                        payloadRegex:
+                            '(?s-u)^prune-test-(?P<group>[a-z]+)\\x00\\x00(?P<version>.{8})$',
                     }),
-                },
+                    groupBy: create(PolicyGroupBySchema, {
+                        captureGroups: ['group'],
+                    }),
+                    orderBy: create(PolicyOrderBySchema, {
+                        captureGroup: 'version',
+                        encoding: PolicyOrderEncoding.U64_BE,
+                    }),
+                }),
                 retain: create(PolicyRetainSchema, {
                     kind: {
                         case: 'keepLatest',

--- a/sdk/ts/src/gen/ts/log/v1/stream_pb.ts
+++ b/sdk/ts/src/gen/ts/log/v1/stream_pb.ts
@@ -13,7 +13,7 @@ import type { Message } from "@bufbuild/protobuf";
  * Describes the file log/v1/stream.proto.
  */
 export const file_log_v1_stream: GenFile = /*@__PURE__*/
-  fileDesc("ChNsb2cvdjEvc3RyZWFtLnByb3RvEg1sb2cuc3RyZWFtLnYxIr4BChBTdWJzY3JpYmVSZXF1ZXN0EjUKCXNlbGVjdG9ycxgBIAMoCzIWLmNvbW1vbi5rdi52MS5TZWxlY3RvckIKukgHkgEECAEQEBI1Cg12YWx1ZV9maWx0ZXJzGAIgAygLMhQuY29tbW9uLmt2LnYxLkZpbHRlckIIukgFkgECEBASIgoVc2luY2Vfc2VxdWVuY2VfbnVtYmVyGAMgASgESACIAQFCGAoWX3NpbmNlX3NlcXVlbmNlX251bWJlciIlCgpHZXRSZXF1ZXN0EhcKD3NlcXVlbmNlX251bWJlchgBIAEoBCJSChFTdWJzY3JpYmVSZXNwb25zZRIXCg9zZXF1ZW5jZV9udW1iZXIYASABKAQSJAoHZW50cmllcxgCIAMoCzITLmNvbW1vbi5rdi52MS5FbnRyeSJMCgtHZXRSZXNwb25zZRIXCg9zZXF1ZW5jZV9udW1iZXIYASABKAQSJAoHZW50cmllcxgCIAMoCzITLmNvbW1vbi5rdi52MS5FbnRyeTKZAQoHU2VydmljZRJQCglTdWJzY3JpYmUSHy5sb2cuc3RyZWFtLnYxLlN1YnNjcmliZVJlcXVlc3QaIC5sb2cuc3RyZWFtLnYxLlN1YnNjcmliZVJlc3BvbnNlMAESPAoDR2V0EhkubG9nLnN0cmVhbS52MS5HZXRSZXF1ZXN0GhoubG9nLnN0cmVhbS52MS5HZXRSZXNwb25zZWIGcHJvdG8z", [file_buf_validate_validate, file_common_v1_kv]);
+  fileDesc("ChNsb2cvdjEvc3RyZWFtLnByb3RvEg1sb2cuc3RyZWFtLnYxIr4BChBTdWJzY3JpYmVSZXF1ZXN0EjUKCXNlbGVjdG9ycxgBIAMoCzIWLmNvbW1vbi5rdi52MS5TZWxlY3RvckIKukgHkgEECAEQEBI1Cg12YWx1ZV9maWx0ZXJzGAIgAygLMhQuY29tbW9uLmt2LnYxLkZpbHRlckIIukgFkgECEBASIgoVc2luY2Vfc2VxdWVuY2VfbnVtYmVyGAMgASgESACIAQFCGAoWX3NpbmNlX3NlcXVlbmNlX251bWJlciIlCgpHZXRSZXF1ZXN0EhcKD3NlcXVlbmNlX251bWJlchgBIAEoBCJSChFTdWJzY3JpYmVSZXNwb25zZRIXCg9zZXF1ZW5jZV9udW1iZXIYASABKAQSJAoHZW50cmllcxgCIAMoCzITLmNvbW1vbi5rdi52MS5FbnRyeSJMCgtHZXRSZXNwb25zZRIXCg9zZXF1ZW5jZV9udW1iZXIYASABKAQSJAoHZW50cmllcxgCIAMoCzITLmNvbW1vbi5rdi52MS5FbnRyeSItChNSZXRlbnRpb25LZWVwTGF0ZXN0EhYKBWNvdW50GAEgASgEQge6SAQyAiAAIikKFFJldGVudGlvbkdyZWF0ZXJUaGFuEhEKCXRocmVzaG9sZBgBIAEoBCIwChtSZXRlbnRpb25HcmVhdGVyVGhhbk9yRXF1YWwSEQoJdGhyZXNob2xkGAEgASgEIhIKEFJldGVudGlvbkRyb3BBbGwikwIKD1JldGVudGlvblBvbGljeRI5CgtrZWVwX2xhdGVzdBgBIAEoCzIiLmxvZy5zdHJlYW0udjEuUmV0ZW50aW9uS2VlcExhdGVzdEgAEjsKDGdyZWF0ZXJfdGhhbhgCIAEoCzIjLmxvZy5zdHJlYW0udjEuUmV0ZW50aW9uR3JlYXRlclRoYW5IABJLChVncmVhdGVyX3RoYW5fb3JfZXF1YWwYAyABKAsyKi5sb2cuc3RyZWFtLnYxLlJldGVudGlvbkdyZWF0ZXJUaGFuT3JFcXVhbEgAEjMKCGRyb3BfYWxsGAQgASgLMh8ubG9nLnN0cmVhbS52MS5SZXRlbnRpb25Ecm9wQWxsSABCBgoEa2luZCJFChNTZXRSZXRlbnRpb25SZXF1ZXN0Ei4KBnBvbGljeRgBIAEoCzIeLmxvZy5zdHJlYW0udjEuUmV0ZW50aW9uUG9saWN5IloKFFNldFJldGVudGlvblJlc3BvbnNlEiUKGG9sZGVzdF9yZXRhaW5lZF9zZXF1ZW5jZRgBIAEoBEgAiAEBQhsKGV9vbGRlc3RfcmV0YWluZWRfc2VxdWVuY2Uy8gEKB1NlcnZpY2USUAoJU3Vic2NyaWJlEh8ubG9nLnN0cmVhbS52MS5TdWJzY3JpYmVSZXF1ZXN0GiAubG9nLnN0cmVhbS52MS5TdWJzY3JpYmVSZXNwb25zZTABEjwKA0dldBIZLmxvZy5zdHJlYW0udjEuR2V0UmVxdWVzdBoaLmxvZy5zdHJlYW0udjEuR2V0UmVzcG9uc2USVwoMU2V0UmV0ZW50aW9uEiIubG9nLnN0cmVhbS52MS5TZXRSZXRlbnRpb25SZXF1ZXN0GiMubG9nLnN0cmVhbS52MS5TZXRSZXRlbnRpb25SZXNwb25zZWIGcHJvdG8z", [file_buf_validate_validate, file_common_v1_kv]);
 
 /**
  * Live (and optionally replayed) subscription request.
@@ -135,6 +135,175 @@ export const GetResponseSchema: GenMessage<GetResponse> = /*@__PURE__*/
   messageDesc(file_log_v1_stream, 3);
 
 /**
+ * Keep the newest `count` batches. Continuous: as new batches are appended the
+ * retained window slides forward with the live frontier, evicting whatever
+ * falls below it.
+ *
+ * @generated from message log.stream.v1.RetentionKeepLatest
+ */
+export type RetentionKeepLatest = Message<"log.stream.v1.RetentionKeepLatest"> & {
+  /**
+   * @generated from field: uint64 count = 1;
+   */
+  count: bigint;
+};
+
+/**
+ * Describes the message log.stream.v1.RetentionKeepLatest.
+ * Use `create(RetentionKeepLatestSchema)` to create a new message.
+ */
+export const RetentionKeepLatestSchema: GenMessage<RetentionKeepLatest> = /*@__PURE__*/
+  messageDesc(file_log_v1_stream, 4);
+
+/**
+ * Retain sequence numbers strictly greater than `threshold`; evict the rest.
+ *
+ * @generated from message log.stream.v1.RetentionGreaterThan
+ */
+export type RetentionGreaterThan = Message<"log.stream.v1.RetentionGreaterThan"> & {
+  /**
+   * @generated from field: uint64 threshold = 1;
+   */
+  threshold: bigint;
+};
+
+/**
+ * Describes the message log.stream.v1.RetentionGreaterThan.
+ * Use `create(RetentionGreaterThanSchema)` to create a new message.
+ */
+export const RetentionGreaterThanSchema: GenMessage<RetentionGreaterThan> = /*@__PURE__*/
+  messageDesc(file_log_v1_stream, 5);
+
+/**
+ * Retain sequence numbers greater than or equal to `threshold`; evict the rest.
+ *
+ * @generated from message log.stream.v1.RetentionGreaterThanOrEqual
+ */
+export type RetentionGreaterThanOrEqual = Message<"log.stream.v1.RetentionGreaterThanOrEqual"> & {
+  /**
+   * @generated from field: uint64 threshold = 1;
+   */
+  threshold: bigint;
+};
+
+/**
+ * Describes the message log.stream.v1.RetentionGreaterThanOrEqual.
+ * Use `create(RetentionGreaterThanOrEqualSchema)` to create a new message.
+ */
+export const RetentionGreaterThanOrEqualSchema: GenMessage<RetentionGreaterThanOrEqual> = /*@__PURE__*/
+  messageDesc(file_log_v1_stream, 6);
+
+/**
+ * Retain nothing: evict up to the live frontier and keep doing so as the log
+ * grows.
+ *
+ * @generated from message log.stream.v1.RetentionDropAll
+ */
+export type RetentionDropAll = Message<"log.stream.v1.RetentionDropAll"> & {
+};
+
+/**
+ * Describes the message log.stream.v1.RetentionDropAll.
+ * Use `create(RetentionDropAllSchema)` to create a new message.
+ */
+export const RetentionDropAllSchema: GenMessage<RetentionDropAll> = /*@__PURE__*/
+  messageDesc(file_log_v1_stream, 7);
+
+/**
+ * The retention rule to enforce over the sequence log.
+ *
+ * @generated from message log.stream.v1.RetentionPolicy
+ */
+export type RetentionPolicy = Message<"log.stream.v1.RetentionPolicy"> & {
+  /**
+   * @generated from oneof log.stream.v1.RetentionPolicy.kind
+   */
+  kind: {
+    /**
+     * @generated from field: log.stream.v1.RetentionKeepLatest keep_latest = 1;
+     */
+    value: RetentionKeepLatest;
+    case: "keepLatest";
+  } | {
+    /**
+     * @generated from field: log.stream.v1.RetentionGreaterThan greater_than = 2;
+     */
+    value: RetentionGreaterThan;
+    case: "greaterThan";
+  } | {
+    /**
+     * @generated from field: log.stream.v1.RetentionGreaterThanOrEqual greater_than_or_equal = 3;
+     */
+    value: RetentionGreaterThanOrEqual;
+    case: "greaterThanOrEqual";
+  } | {
+    /**
+     * @generated from field: log.stream.v1.RetentionDropAll drop_all = 4;
+     */
+    value: RetentionDropAll;
+    case: "dropAll";
+  } | { case: undefined; value?: undefined };
+};
+
+/**
+ * Describes the message log.stream.v1.RetentionPolicy.
+ * Use `create(RetentionPolicySchema)` to create a new message.
+ */
+export const RetentionPolicySchema: GenMessage<RetentionPolicy> = /*@__PURE__*/
+  messageDesc(file_log_v1_stream, 8);
+
+/**
+ * Install or clear the sequence-log retention rule.
+ *
+ * Retention is a persistent, continuously-enforced rule owned by the stream
+ * service (not a one-shot prune): once installed it keeps tracking the live
+ * frontier as batches are appended, evicting whatever falls below the rule's
+ * floor. Evicted batches surface to subscribers/point-lookups as
+ * `OUT_OF_RANGE` with an `ErrorInfo { reason: "BATCH_EVICTED", metadata: {
+ * "oldest_retained": ... } }` detail.
+ *
+ * @generated from message log.stream.v1.SetRetentionRequest
+ */
+export type SetRetentionRequest = Message<"log.stream.v1.SetRetentionRequest"> & {
+  /**
+   * The rule to install. Absent -> clear the rule: enforcement stops and no
+   * further eviction happens.
+   *
+   * @generated from field: log.stream.v1.RetentionPolicy policy = 1;
+   */
+  policy?: RetentionPolicy;
+};
+
+/**
+ * Describes the message log.stream.v1.SetRetentionRequest.
+ * Use `create(SetRetentionRequestSchema)` to create a new message.
+ */
+export const SetRetentionRequestSchema: GenMessage<SetRetentionRequest> = /*@__PURE__*/
+  messageDesc(file_log_v1_stream, 9);
+
+/**
+ * Result of applying the rule change once, synchronously.
+ *
+ * @generated from message log.stream.v1.SetRetentionResponse
+ */
+export type SetRetentionResponse = Message<"log.stream.v1.SetRetentionResponse"> & {
+  /**
+   * Lowest sequence number still retained after that application. Absent when
+   * the log is empty / no floor exists yet.
+   *
+   * @generated from field: optional uint64 oldest_retained_sequence = 1;
+   */
+  oldestRetainedSequence?: bigint;
+};
+
+/**
+ * Describes the message log.stream.v1.SetRetentionResponse.
+ * Use `create(SetRetentionResponseSchema)` to create a new message.
+ */
+export const SetRetentionResponseSchema: GenMessage<SetRetentionResponse> = /*@__PURE__*/
+  messageDesc(file_log_v1_stream, 10);
+
+/**
  * Push-based subscription + point-lookup over the store's log.
  *
  * `Subscribe` delivers a `SubscribeResponse` per atomic `Put` batch whose
@@ -163,6 +332,17 @@ export const Service: GenService<{
     methodKind: "unary";
     input: typeof GetRequestSchema;
     output: typeof GetResponseSchema;
+  },
+  /**
+   * Install (or clear) the sequence-log retention rule. The rule is persistent
+   * and continuously enforced as the log grows — see `SetRetentionRequest`.
+   *
+   * @generated from rpc log.stream.v1.Service.SetRetention
+   */
+  setRetention: {
+    methodKind: "unary";
+    input: typeof SetRetentionRequestSchema;
+    output: typeof SetRetentionResponseSchema;
   },
 }> = /*@__PURE__*/
   serviceDesc(file_log_v1_stream, 0);

--- a/sdk/ts/src/gen/ts/log/v1/stream_pb.ts
+++ b/sdk/ts/src/gen/ts/log/v1/stream_pb.ts
@@ -334,9 +334,6 @@ export const Service: GenService<{
     output: typeof GetResponseSchema;
   },
   /**
-   * Install (or clear) the sequence-log retention rule. The rule is persistent
-   * and continuously enforced as the log grows — see `SetRetentionRequest`.
-   *
    * @generated from rpc log.stream.v1.Service.SetRetention
    */
   setRetention: {

--- a/sdk/ts/src/gen/ts/store/v1/compact_pb.ts
+++ b/sdk/ts/src/gen/ts/store/v1/compact_pb.ts
@@ -13,7 +13,7 @@ import type { Message } from "@bufbuild/protobuf";
  * Describes the file store/v1/compact.proto.
  */
 export const file_store_v1_compact: GenFile = /*@__PURE__*/
-  fileDesc("ChZzdG9yZS92MS9jb21wYWN0LnByb3RvEhBzdG9yZS5jb21wYWN0LnYxIicKDVBvbGljeUdyb3VwQnkSFgoOY2FwdHVyZV9ncm91cHMYASADKAkiXwoNUG9saWN5T3JkZXJCeRIVCg1jYXB0dXJlX2dyb3VwGAEgASgJEjcKCGVuY29kaW5nGAIgASgOMiUuc3RvcmUuY29tcGFjdC52MS5Qb2xpY3lPcmRlckVuY29kaW5nIioKEFJldGFpbktlZXBMYXRlc3QSFgoFY291bnQYASABKARCB7pIBDICIAAiJgoRUmV0YWluR3JlYXRlclRoYW4SEQoJdGhyZXNob2xkGAEgASgEIi0KGFJldGFpbkdyZWF0ZXJUaGFuT3JFcXVhbBIRCgl0aHJlc2hvbGQYASABKAQiDwoNUmV0YWluRHJvcEFsbCKQAgoMUG9saWN5UmV0YWluEjkKC2tlZXBfbGF0ZXN0GAEgASgLMiIuc3RvcmUuY29tcGFjdC52MS5SZXRhaW5LZWVwTGF0ZXN0SAASOwoMZ3JlYXRlcl90aGFuGAIgASgLMiMuc3RvcmUuY29tcGFjdC52MS5SZXRhaW5HcmVhdGVyVGhhbkgAEksKFWdyZWF0ZXJfdGhhbl9vcl9lcXVhbBgDIAEoCzIqLnN0b3JlLmNvbXBhY3QudjEuUmV0YWluR3JlYXRlclRoYW5PckVxdWFsSAASMwoIZHJvcF9hbGwYBCABKAsyHy5zdG9yZS5jb21wYWN0LnYxLlJldGFpbkRyb3BBbGxIAEIGCgRraW5kIq0BCglLZXlzU2NvcGUSKAoIc2VsZWN0b3IYASABKAsyFi5jb21tb24ua3YudjEuU2VsZWN0b3ISMQoIZ3JvdXBfYnkYAiABKAsyHy5zdG9yZS5jb21wYWN0LnYxLlBvbGljeUdyb3VwQnkSNgoIb3JkZXJfYnkYAyABKAsyHy5zdG9yZS5jb21wYWN0LnYxLlBvbGljeU9yZGVyQnlIAIgBAUILCglfb3JkZXJfYnkiDwoNU2VxdWVuY2VTY29wZSKjAQoGUG9saWN5EisKBGtleXMYASABKAsyGy5zdG9yZS5jb21wYWN0LnYxLktleXNTY29wZUgAEjMKCHNlcXVlbmNlGAIgASgLMh8uc3RvcmUuY29tcGFjdC52MS5TZXF1ZW5jZVNjb3BlSAASLgoGcmV0YWluGAMgASgLMh4uc3RvcmUuY29tcGFjdC52MS5Qb2xpY3lSZXRhaW5CBwoFc2NvcGUiRAoMUHJ1bmVSZXF1ZXN0EjQKCHBvbGljaWVzGAEgAygLMhguc3RvcmUuY29tcGFjdC52MS5Qb2xpY3lCCLpIBZIBAggBIg8KDVBydW5lUmVzcG9uc2UqfgoTUG9saWN5T3JkZXJFbmNvZGluZxIjCh9QT0xJQ1lfT1JERVJfRU5DT0RJTkdfQllURVNfQVNDEAASIAocUE9MSUNZX09SREVSX0VOQ09ESU5HX1U2NF9CRRABEiAKHFBPTElDWV9PUkRFUl9FTkNPRElOR19JNjRfQkUQAjJTCgdTZXJ2aWNlEkgKBVBydW5lEh4uc3RvcmUuY29tcGFjdC52MS5QcnVuZVJlcXVlc3QaHy5zdG9yZS5jb21wYWN0LnYxLlBydW5lUmVzcG9uc2ViBnByb3RvMw", [file_buf_validate_validate, file_common_v1_kv]);
+  fileDesc("ChZzdG9yZS92MS9jb21wYWN0LnByb3RvEhBzdG9yZS5jb21wYWN0LnYxIicKDVBvbGljeUdyb3VwQnkSFgoOY2FwdHVyZV9ncm91cHMYASADKAkiXwoNUG9saWN5T3JkZXJCeRIVCg1jYXB0dXJlX2dyb3VwGAEgASgJEjcKCGVuY29kaW5nGAIgASgOMiUuc3RvcmUuY29tcGFjdC52MS5Qb2xpY3lPcmRlckVuY29kaW5nIioKEFJldGFpbktlZXBMYXRlc3QSFgoFY291bnQYASABKARCB7pIBDICIAAiJgoRUmV0YWluR3JlYXRlclRoYW4SEQoJdGhyZXNob2xkGAEgASgEIi0KGFJldGFpbkdyZWF0ZXJUaGFuT3JFcXVhbBIRCgl0aHJlc2hvbGQYASABKAQiDwoNUmV0YWluRHJvcEFsbCKQAgoMUG9saWN5UmV0YWluEjkKC2tlZXBfbGF0ZXN0GAEgASgLMiIuc3RvcmUuY29tcGFjdC52MS5SZXRhaW5LZWVwTGF0ZXN0SAASOwoMZ3JlYXRlcl90aGFuGAIgASgLMiMuc3RvcmUuY29tcGFjdC52MS5SZXRhaW5HcmVhdGVyVGhhbkgAEksKFWdyZWF0ZXJfdGhhbl9vcl9lcXVhbBgDIAEoCzIqLnN0b3JlLmNvbXBhY3QudjEuUmV0YWluR3JlYXRlclRoYW5PckVxdWFsSAASMwoIZHJvcF9hbGwYBCABKAsyHy5zdG9yZS5jb21wYWN0LnYxLlJldGFpbkRyb3BBbGxIAEIGCgRraW5kIq0BCglLZXlzU2NvcGUSKAoIc2VsZWN0b3IYASABKAsyFi5jb21tb24ua3YudjEuU2VsZWN0b3ISMQoIZ3JvdXBfYnkYAiABKAsyHy5zdG9yZS5jb21wYWN0LnYxLlBvbGljeUdyb3VwQnkSNgoIb3JkZXJfYnkYAyABKAsyHy5zdG9yZS5jb21wYWN0LnYxLlBvbGljeU9yZGVyQnlIAIgBAUILCglfb3JkZXJfYnkiYwoGUG9saWN5EikKBGtleXMYASABKAsyGy5zdG9yZS5jb21wYWN0LnYxLktleXNTY29wZRIuCgZyZXRhaW4YAyABKAsyHi5zdG9yZS5jb21wYWN0LnYxLlBvbGljeVJldGFpbiJECgxQcnVuZVJlcXVlc3QSNAoIcG9saWNpZXMYASADKAsyGC5zdG9yZS5jb21wYWN0LnYxLlBvbGljeUIIukgFkgECCAEiDwoNUHJ1bmVSZXNwb25zZSp+ChNQb2xpY3lPcmRlckVuY29kaW5nEiMKH1BPTElDWV9PUkRFUl9FTkNPRElOR19CWVRFU19BU0MQABIgChxQT0xJQ1lfT1JERVJfRU5DT0RJTkdfVTY0X0JFEAESIAocUE9MSUNZX09SREVSX0VOQ09ESU5HX0k2NF9CRRACMlMKB1NlcnZpY2USSAoFUHJ1bmUSHi5zdG9yZS5jb21wYWN0LnYxLlBydW5lUmVxdWVzdBofLnN0b3JlLmNvbXBhY3QudjEuUHJ1bmVSZXNwb25zZWIGcHJvdG8z", [file_buf_validate_validate, file_common_v1_kv]);
 
 /**
  * Controls how matched keys are partitioned into independent groups before
@@ -227,52 +227,16 @@ export const KeysScopeSchema: GenMessage<KeysScope> = /*@__PURE__*/
   messageDesc(file_store_v1_compact, 7);
 
 /**
- * Sequence-number scope: prune the per-batch sequence log served by the
- * store's `Stream` service. `selector` / `group_by` / `order_by` are not
- * meaningful here — the log has a single implicit ordering by sequence
- * number. The `retain` rule on the parent `Policy` is interpreted directly
- * over sequence numbers:
- *
- *   - `keep_latest { count: N }`        -> keep the last N batches
- *   - `greater_than { threshold: T }`   -> keep sequence numbers > T
- *   - `greater_than_or_equal { .. T }`  -> keep sequence numbers >= T
- *   - `drop_all`                        -> clear the log entirely
- *
- * @generated from message store.compact.v1.SequenceScope
- */
-export type SequenceScope = Message<"store.compact.v1.SequenceScope"> & {
-};
-
-/**
- * Describes the message store.compact.v1.SequenceScope.
- * Use `create(SequenceScopeSchema)` to create a new message.
- */
-export const SequenceScopeSchema: GenMessage<SequenceScope> = /*@__PURE__*/
-  messageDesc(file_store_v1_compact, 8);
-
-/**
- * A single prune policy. `scope` discriminates the keyspace the rule applies
- * to; `retain` is shared between scopes.
+ * A single prune policy: group keys via `keys`, then apply `retain` to decide
+ * which of them survive. `keys` is required.
  *
  * @generated from message store.compact.v1.Policy
  */
 export type Policy = Message<"store.compact.v1.Policy"> & {
   /**
-   * @generated from oneof store.compact.v1.Policy.scope
+   * @generated from field: store.compact.v1.KeysScope keys = 1;
    */
-  scope: {
-    /**
-     * @generated from field: store.compact.v1.KeysScope keys = 1;
-     */
-    value: KeysScope;
-    case: "keys";
-  } | {
-    /**
-     * @generated from field: store.compact.v1.SequenceScope sequence = 2;
-     */
-    value: SequenceScope;
-    case: "sequence";
-  } | { case: undefined; value?: undefined };
+  keys?: KeysScope;
 
   /**
    * @generated from field: store.compact.v1.PolicyRetain retain = 3;
@@ -285,7 +249,7 @@ export type Policy = Message<"store.compact.v1.Policy"> & {
  * Use `create(PolicySchema)` to create a new message.
  */
 export const PolicySchema: GenMessage<Policy> = /*@__PURE__*/
-  messageDesc(file_store_v1_compact, 9);
+  messageDesc(file_store_v1_compact, 8);
 
 /**
  * Request to execute prune policies.
@@ -307,7 +271,7 @@ export type PruneRequest = Message<"store.compact.v1.PruneRequest"> & {
  * Use `create(PruneRequestSchema)` to create a new message.
  */
 export const PruneRequestSchema: GenMessage<PruneRequest> = /*@__PURE__*/
-  messageDesc(file_store_v1_compact, 10);
+  messageDesc(file_store_v1_compact, 9);
 
 /**
  * Empty response returned on successful prune execution.
@@ -322,7 +286,7 @@ export type PruneResponse = Message<"store.compact.v1.PruneResponse"> & {
  * Use `create(PruneResponseSchema)` to create a new message.
  */
 export const PruneResponseSchema: GenMessage<PruneResponse> = /*@__PURE__*/
-  messageDesc(file_store_v1_compact, 11);
+  messageDesc(file_store_v1_compact, 10);
 
 /**
  * Interpretation of the order-by capture group bytes when comparing keys

--- a/sdk/ts/src/index.ts
+++ b/sdk/ts/src/index.ts
@@ -71,7 +71,6 @@ export type {
 export {
     PolicySchema,
     KeysScopeSchema,
-    SequenceScopeSchema,
     PolicyGroupBySchema,
     PolicyOrderBySchema,
     PolicyRetainSchema,
@@ -86,7 +85,6 @@ export {
 export type {
     Policy,
     KeysScope,
-    SequenceScope,
     PolicyGroupBy,
     PolicyOrderBy,
     PolicyRetain,
@@ -104,10 +102,24 @@ export {
     SubscribeResponseSchema,
     GetRequestSchema,
     GetResponseSchema,
+    RetentionKeepLatestSchema,
+    RetentionGreaterThanSchema,
+    RetentionGreaterThanOrEqualSchema,
+    RetentionDropAllSchema,
+    RetentionPolicySchema,
+    SetRetentionRequestSchema,
+    SetRetentionResponseSchema,
 } from './gen/ts/log/v1/stream_pb.js';
 export type {
     SubscribeRequest,
     SubscribeResponse,
     GetRequest,
     GetResponse,
+    RetentionKeepLatest,
+    RetentionGreaterThan,
+    RetentionGreaterThanOrEqual,
+    RetentionDropAll,
+    RetentionPolicy,
+    SetRetentionRequest,
+    SetRetentionResponse,
 } from './gen/ts/log/v1/stream_pb.js';

--- a/sdk/ts/src/store.ts
+++ b/sdk/ts/src/store.ts
@@ -303,18 +303,15 @@ function toStoreBatch(
 function prefixPolicies(policies: Policy[], prefix?: StoreKeyPrefix): Policy[] {
     if (!prefix) return policies;
     return policies.map((policy) => {
-        if (policy.scope.case !== 'keys') {
+        const scope = policy.keys;
+        if (!scope) {
             return policy;
         }
-        const scope = policy.scope.value;
         return {
             ...policy,
-            scope: {
-                case: 'keys',
-                value: {
-                    ...scope,
-                    selector: scope.selector ? prefix.prefixSelector(scope.selector) : undefined,
-                },
+            keys: {
+                ...scope,
+                selector: scope.selector ? prefix.prefixSelector(scope.selector) : undefined,
             },
         } as Policy;
     });

--- a/server/README.md
+++ b/server/README.md
@@ -25,8 +25,8 @@ default.
 use bytes::Bytes;
 use exoware_sdk::prune_policy::PrunePolicyDocument;
 use exoware_server::{
-    AppState, Log, Ingest, Prune, Query, QueryExtra, RangeScan, RangeScanBatch, Sequence,
-    StoreEngine, connect_stack,
+    AppState, Log, Ingest, Prune, Query, QueryExtra, RangeScan, RangeScanBatch, Retention,
+    Sequence, StoreEngine, connect_stack,
 };
 use std::future::Future;
 
@@ -49,4 +49,7 @@ use std::future::Future;
 //   Log:
 //   fn get_batch(&self, sequence_number: u64) -> impl Future<Output = Result<Option<Vec<(Bytes, Bytes)>>, String>> + Send + '_;
 //   fn oldest_retained_batch(&self) -> impl Future<Output = Result<Option<u64>, String>> + Send + '_;
+//
+//   Retention:
+//   fn set_retention(&self, policy: Option<RetentionPolicy>) -> impl Future<Output = Result<Option<u64>, String>> + Send + '_;
 ```

--- a/server/src/connect.rs
+++ b/server/src/connect.rs
@@ -21,7 +21,8 @@ use exoware_proto::ingest::{
 };
 use exoware_proto::log::stream::v1::{
     GetRequestView, GetResponse as StreamGetResponse, Service as StreamApi,
-    ServiceServer as StreamServiceServer, SubscribeRequestView, SubscribeResponse,
+    ServiceServer as StreamServiceServer, SetRetentionRequestView, SetRetentionResponse,
+    SubscribeRequestView, SubscribeResponse,
 };
 use exoware_proto::query::{
     Detail, GetManyEntry, GetManyFrame, GetResponse, RangeFrame, ReduceResponse,
@@ -43,7 +44,9 @@ use tokio::sync::Notify;
 use crate::reduce::RangeReducer;
 use crate::stream::{StreamHub, StreamNotifier};
 use crate::validate::{self, IngestLimits};
-use crate::{Ingest, IngestError, Log, LogBatch, Prune, Query, QueryExtra, RangeScan, StoreEngine};
+use crate::{
+    Ingest, IngestError, Log, LogBatch, Prune, Query, QueryExtra, RangeScan, Retention, StoreEngine,
+};
 
 // TODO (#57): Make limits configurable.
 const MAX_CONNECTRPC_BODY_BYTES: usize = 256 * 1024 * 1024;
@@ -317,7 +320,7 @@ impl<L> Clone for StreamState<L> {
 
 impl<L> StreamState<L>
 where
-    L: Log,
+    L: Log + Retention,
 {
     pub fn new(log: Arc<L>, notifier: Arc<dyn StreamNotifier>) -> Self {
         Self { log, notifier }
@@ -772,7 +775,7 @@ impl<B> Clone for StreamConnect<B> {
 
 impl<B> StreamConnect<B>
 where
-    B: Log,
+    B: Log + Retention,
 {
     pub fn new(state: impl Into<StreamState<B>>) -> Self {
         Self {
@@ -857,7 +860,7 @@ struct SubscriptionState<B> {
 
 impl<B> SubscriptionState<B>
 where
-    B: Log,
+    B: Log + Retention,
 {
     fn new(
         state: StreamState<B>,
@@ -1020,7 +1023,7 @@ fn domain_filter_from_subscribe_view(
 
 impl<B> StreamApi for StreamConnect<B>
 where
-    B: Log,
+    B: Log + Retention,
 {
     async fn subscribe(
         &self,
@@ -1115,6 +1118,33 @@ where
             }
         }
     }
+
+    async fn set_retention(
+        &self,
+        _ctx: Context,
+        request: buffa::view::OwnedView<SetRetentionRequestView<'static>>,
+    ) -> connectrpc::ServiceResult<SetRetentionResponse> {
+        // Parse the wire shape, then authoritatively validate: buf.validate
+        // annotations on the proto are documentation, so the handler enforces
+        // the rule (e.g. keep_latest count > 0), mirroring the Prune handler.
+        let policy = exoware_proto::parse_set_retention_request_view(&request)
+            .map_err(ConnectError::invalid_argument)?;
+        if let Some(policy) = policy.as_ref() {
+            exoware_proto::validate_retention_policy(policy)
+                .map_err(ConnectError::invalid_argument)?;
+        }
+
+        let oldest_retained_sequence = self
+            .state
+            .log
+            .set_retention(policy)
+            .await
+            .map_err(ConnectError::internal)?;
+        connectrpc::Response::ok(SetRetentionResponse {
+            oldest_retained_sequence,
+            ..Default::default()
+        })
+    }
 }
 
 fn connect_limits() -> Limits {
@@ -1163,7 +1193,7 @@ where
 
 fn stream_server<B>(state: StreamState<B>) -> StreamServiceServer<StreamConnect<B>>
 where
-    B: Log,
+    B: Log + Retention,
 {
     StreamServiceServer::new(StreamConnect::new(state))
 }
@@ -1197,7 +1227,7 @@ where
 
 pub fn stream_service<B>(state: StreamState<B>) -> StreamService<B>
 where
-    B: Log,
+    B: Log + Retention,
 {
     ConnectRpcService::new(stream_server(state))
         .with_limits(connect_limits())
@@ -1210,7 +1240,7 @@ pub fn query_stack<Q, B>(
 ) -> QueryStack<Q, B>
 where
     Q: Query,
-    B: Log,
+    B: Log + Retention,
 {
     ConnectRpcService::new(Chain(
         query_server(query_state),
@@ -1248,20 +1278,23 @@ mod tests {
 
     use buffa::Message;
     use exoware_proto::common::kv::v1::Selector as ProtoSelector;
-    use exoware_proto::log::stream::v1::{SubscribeRequest, SubscribeRequestView};
+    use exoware_proto::log::stream::v1::{
+        SetRetentionRequest, SubscribeRequest, SubscribeRequestView,
+    };
     use exoware_proto::store::compact::v1::{
-        policy, policy_retain, Policy as ProtoPolicy, PolicyRetain, PruneRequest, PruneRequestView,
-        RetainKeepLatest,
+        policy_retain, KeysScope, Policy as ProtoPolicy, PolicyRetain, PruneRequest,
+        PruneRequestView, RetainKeepLatest,
     };
     use exoware_sdk::keys::Prefix;
     use exoware_sdk::kv_codec::KvReducedValue;
     use exoware_sdk::prune_policy::{PrunePolicyDocument, PRUNE_POLICY_DOCUMENT_VERSION};
+    use exoware_sdk::retention::RetentionPolicy;
     use exoware_sdk::{decode_connect_error, to_domain_reduce_response};
     use futures::StreamExt;
 
     use crate::{
-        Ingest, IngestError, Log, Prune, Query, QueryExtra, RangeScan, RangeScanBatch, Sequence,
-        StreamNotification, StreamNotifier,
+        Ingest, IngestError, Log, Prune, Query, QueryExtra, RangeScan, RangeScanBatch, Retention,
+        Sequence, StreamNotification, StreamNotifier,
     };
 
     const TEST_PREFIX: u8 = 1;
@@ -1285,6 +1318,8 @@ mod tests {
         query_extra: QueryExtra,
         prune_policy_counts: Vec<usize>,
         put_error: Option<IngestError>,
+        retention_calls: Vec<Option<RetentionPolicy>>,
+        retention_floor: Option<u64>,
     }
 
     #[derive(Default)]
@@ -1390,6 +1425,14 @@ mod tests {
 
         fn set_query_extra(&self, extra: QueryExtra) {
             self.state.lock().expect("lock").query_extra = extra;
+        }
+
+        fn set_retention_floor(&self, floor: Option<u64>) {
+            self.state.lock().expect("lock").retention_floor = floor;
+        }
+
+        fn retention_calls(&self) -> Vec<Option<RetentionPolicy>> {
+            self.state.lock().expect("lock").retention_calls.clone()
         }
     }
 
@@ -1509,6 +1552,21 @@ mod tests {
         }
     }
 
+    impl Retention for FakeEngine {
+        async fn set_retention(
+            &self,
+            policy: Option<RetentionPolicy>,
+        ) -> Result<Option<u64>, String> {
+            self.state
+                .lock()
+                .map(|mut state| {
+                    state.retention_calls.push(policy);
+                    state.retention_floor
+                })
+                .map_err(|e| e.to_string())
+        }
+    }
+
     struct QueryOnlyEngine {
         sequence_number: u64,
         value: Option<Bytes>,
@@ -1571,6 +1629,15 @@ mod tests {
                     documents.push((document.version, document.policies.len()));
                 })
                 .map_err(|e| e.to_string())
+        }
+    }
+
+    impl Retention for PruneOnlyEngine {
+        async fn set_retention(
+            &self,
+            _policy: Option<RetentionPolicy>,
+        ) -> Result<Option<u64>, String> {
+            Ok(None)
         }
     }
 
@@ -1651,9 +1718,21 @@ mod tests {
         .expect("decode put request")
     }
 
-    fn sequence_drop_all_policy() -> ProtoPolicy {
+    fn keys_scope() -> KeysScope {
+        KeysScope {
+            selector: Some(ProtoSelector {
+                prefix: Bytes::from(vec![TEST_PREFIX]),
+                payload_regex: "(?s).*".to_string(),
+                ..Default::default()
+            })
+            .into(),
+            ..Default::default()
+        }
+    }
+
+    fn keys_drop_all_policy() -> ProtoPolicy {
         ProtoPolicy {
-            scope: Some(policy::Scope::Sequence(Box::default())),
+            keys: Some(keys_scope()).into(),
             retain: Some(PolicyRetain {
                 kind: Some(policy_retain::Kind::DropAll(Box::default())),
                 ..Default::default()
@@ -1663,9 +1742,9 @@ mod tests {
         }
     }
 
-    fn sequence_keep_latest_policy(count: u64) -> ProtoPolicy {
+    fn keys_keep_latest_policy(count: u64) -> ProtoPolicy {
         ProtoPolicy {
-            scope: Some(policy::Scope::Sequence(Box::default())),
+            keys: Some(keys_scope()).into(),
             retain: Some(PolicyRetain {
                 kind: Some(policy_retain::Kind::KeepLatest(Box::new(
                     RetainKeepLatest {
@@ -1700,7 +1779,7 @@ mod tests {
         ConnectError,
     >
     where
-        B: Log,
+        B: Log + Retention,
     {
         let bytes = subscribe_request_bytes(since_sequence_number);
         let request = buffa::view::OwnedView::<SubscribeRequestView<'static>>::decode(bytes.into())
@@ -1710,11 +1789,36 @@ mod tests {
             .body)
     }
 
+    async fn set_retention<B>(
+        connect: &StreamConnect<B>,
+        policy: Option<RetentionPolicy>,
+    ) -> Result<SetRetentionResponse, ConnectError>
+    where
+        B: Log + Retention,
+    {
+        let bytes = SetRetentionRequest {
+            policy: policy
+                .as_ref()
+                .map(exoware_proto::retention_policy_to_proto)
+                .into(),
+            ..Default::default()
+        }
+        .encode_to_vec();
+        let request =
+            buffa::view::OwnedView::<SetRetentionRequestView<'static>>::decode(bytes.into())
+                .expect("decode set_retention request");
+        Ok(
+            StreamApi::set_retention(connect, Context::default(), request)
+                .await?
+                .body,
+        )
+    }
+
     #[tokio::test]
     async fn compact_connect_accepts_prune_only_engine() {
         let prune = Arc::new(PruneOnlyEngine::default());
         let connect = CompactConnect::new(CompactState::new(prune.clone()));
-        let request = prune_request(vec![sequence_drop_all_policy()]);
+        let request = prune_request(vec![keys_drop_all_policy()]);
 
         CompactApi::prune(&connect, Context::default(), request)
             .await
@@ -1731,8 +1835,10 @@ mod tests {
     async fn compact_rejects_unparseable_policy_before_engine_prune() {
         let prune = Arc::new(PruneOnlyEngine::default());
         let connect = CompactConnect::new(CompactState::new(prune.clone()));
+        // A Keys scope without its required selector fails to parse into a
+        // domain policy, so the handler rejects it before reaching the engine.
         let invalid_policy = ProtoPolicy {
-            scope: Some(policy::Scope::Sequence(Box::default())),
+            keys: Some(KeysScope::default()).into(),
             ..Default::default()
         };
         let request = prune_request(vec![invalid_policy]);
@@ -1749,7 +1855,7 @@ mod tests {
     async fn compact_rejects_invalid_policy_before_engine_prune() {
         let prune = Arc::new(PruneOnlyEngine::default());
         let connect = CompactConnect::new(CompactState::new(prune.clone()));
-        let request = prune_request(vec![sequence_keep_latest_policy(0)]);
+        let request = prune_request(vec![keys_keep_latest_policy(0)]);
 
         let err = CompactApi::prune(&connect, Context::default(), request)
             .await
@@ -1757,6 +1863,57 @@ mod tests {
 
         assert_eq!(err.code, connectrpc::ErrorCode::InvalidArgument);
         assert_eq!(prune.applied_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn set_retention_applies_policy_and_returns_floor() {
+        let engine = Arc::new(FakeEngine::default());
+        engine.set_current_sequence(5);
+        engine.set_retention_floor(Some(4));
+        let notifier = Arc::new(ManualNotifier::new(5));
+        let connect = StreamConnect::new(StreamState::new(engine.clone(), notifier));
+
+        let response = set_retention(&connect, Some(RetentionPolicy::KeepLatest { count: 2 }))
+            .await
+            .expect("set_retention");
+
+        // The floor is whatever the backend reports after one enforcement.
+        assert_eq!(response.oldest_retained_sequence, Some(4));
+        assert_eq!(
+            engine.retention_calls(),
+            vec![Some(RetentionPolicy::KeepLatest { count: 2 })]
+        );
+    }
+
+    #[tokio::test]
+    async fn set_retention_rejects_zero_keep_latest_before_engine() {
+        let engine = Arc::new(FakeEngine::default());
+        let notifier = Arc::new(ManualNotifier::new(0));
+        let connect = StreamConnect::new(StreamState::new(engine.clone(), notifier));
+
+        let err = set_retention(&connect, Some(RetentionPolicy::KeepLatest { count: 0 }))
+            .await
+            .expect_err("count 0 rejected");
+
+        assert_eq!(err.code, connectrpc::ErrorCode::InvalidArgument);
+        // Validation is authoritative, so the backend is never touched.
+        assert!(engine.retention_calls().is_empty());
+    }
+
+    #[tokio::test]
+    async fn set_retention_absent_policy_clears_rule() {
+        let engine = Arc::new(FakeEngine::default());
+        engine.set_retention_floor(None);
+        let notifier = Arc::new(ManualNotifier::new(0));
+        let connect = StreamConnect::new(StreamState::new(engine.clone(), notifier));
+
+        let response = set_retention(&connect, None)
+            .await
+            .expect("clear retention");
+
+        // Clearing keeps enforcement off; no floor exists so none is returned.
+        assert_eq!(response.oldest_retained_sequence, None);
+        assert_eq!(engine.retention_calls(), vec![None]);
     }
 
     #[tokio::test]

--- a/server/src/engine.rs
+++ b/server/src/engine.rs
@@ -12,6 +12,7 @@ use bytes::Bytes;
 use exoware_sdk::common::kv::v1::Entry;
 use exoware_sdk::log::stream::v1::GetResponse as StreamGetResponse;
 use exoware_sdk::prune_policy::PrunePolicyDocument;
+use exoware_sdk::retention::RetentionPolicy;
 
 /// Backend-defined query metadata.
 ///
@@ -191,7 +192,17 @@ pub trait Log: Sequence {
     fn oldest_retained_batch(&self) -> impl Future<Output = Result<Option<u64>, String>> + Send;
 }
 
-/// Compatibility facade for backends that serve every store capability.
-pub trait StoreEngine: Ingest + Query + Prune + Log {}
+/// Sequence-log retention capability (`log.stream.v1` SetRetention).
+pub trait Retention: Send + Sync + 'static {
+    /// Persist and apply the retention rule; `None` clears it. Returns the oldest retained
+    /// sequence after one synchronous enforcement (`None` when the log is empty / no floor).
+    fn set_retention(
+        &self,
+        policy: Option<RetentionPolicy>,
+    ) -> impl Future<Output = Result<Option<u64>, String>> + Send;
+}
 
-impl<T: Ingest + Query + Prune + Log> StoreEngine for T {}
+/// Compatibility facade for backends that serve every store capability.
+pub trait StoreEngine: Ingest + Query + Prune + Log + Retention {}
+
+impl<T: Ingest + Query + Prune + Log + Retention> StoreEngine for T {}

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -16,7 +16,7 @@ pub use connect::{
 };
 pub use engine::{
     Ingest, IngestError, Log, LogBatch, Prune, Query, QueryExtra, RangeScan, RangeScanBatch,
-    Sequence, StoreEngine,
+    Retention, Sequence, StoreEngine,
 };
 pub use reduce::RangeError;
 pub use stream::{StreamHub, StreamNotification, StreamNotifier};

--- a/sql/rs/src/prune.rs
+++ b/sql/rs/src/prune.rs
@@ -1,6 +1,6 @@
 use exoware_sdk::kv_codec::Utf8;
 use exoware_sdk::prune_policy::{
-    GroupBy, KeysScope, OrderBy, OrderEncoding, PolicyScope, PrunePolicy, RetainPolicy,
+    GroupBy, KeysScope, OrderBy, OrderEncoding, PrunePolicy, RetainPolicy,
 };
 use exoware_sdk::selector::Selector;
 
@@ -31,7 +31,7 @@ fn keep_latest_versions_with_regex(
     }
 
     Ok(PrunePolicy {
-        scope: PolicyScope::Keys(KeysScope {
+        scope: KeysScope {
             selector: Selector {
                 prefix: prefix.as_bytes().clone(),
                 payload_regex,
@@ -43,7 +43,7 @@ fn keep_latest_versions_with_regex(
                 capture_group: Utf8::from("version"),
                 encoding: OrderEncoding::U64Be,
             }),
-        }),
+        },
         retain: RetainPolicy::KeepLatest { count },
     })
 }
@@ -97,14 +97,11 @@ mod tests {
     use crate::CellValue;
     use datafusion::arrow::datatypes::DataType;
     use exoware_sdk::kv_codec::Utf8;
-    use exoware_sdk::prune_policy::{validate_policy, OrderEncoding, PolicyScope, RetainPolicy};
+    use exoware_sdk::prune_policy::{validate_policy, OrderEncoding, RetainPolicy};
     use exoware_sdk::selector::compile_payload_regex;
 
     fn keys_scope(policy: &super::PrunePolicy) -> &super::KeysScope {
-        match &policy.scope {
-            PolicyScope::Keys(s) => s,
-            PolicyScope::Sequence => panic!("expected Keys scope"),
-        }
+        &policy.scope
     }
 
     fn entity_version_model(entity_type: DataType) -> TableModel {


### PR DESCRIPTION
Resolves https://github.com/exowarexyz/monorepo/issues/109.

Moves log retention controls into the log protobuf API. And actually maintains "latest N" policies in the simulator, which currently only advance the retention floor in the moment when the policy is set through RPC.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes replay/eviction semantics and API surface (breaking compact sequence prune); retention correctness depends on floor/trim invariants and post-ingest best-effort enforcement.
> 
> **Overview**
> **Sequence-log retention moves off compact prune** onto a new stream **`SetRetention`** RPC with dedicated **`RetentionPolicy`** messages (`keep_latest`, thresholds, `drop_all`). Compact **`Policy`** is **keys-only** (`KeysScope` directly; **`SequenceScope` removed**), and **`PrunePolicy`** / qmdb helpers drop sequence-scoped prune builders.
> 
> The **RocksDB simulator** implements **`Retention`**: rules persist in a meta row, **re-apply on open**, and **trim continuously after each ingest** (best-effort `spawn_blocking`, no failing acked batches). Log trimming uses **unsynced** range deletes with a **`trimmed`** cutoff to skip redundant work; it still **raises the state floor** and **never evicts above the published frontier**.
> 
> Tests and e2e flows switch batch eviction from **`compact().prune`** to **`stream().set_retention`**, with new contract coverage for sliding **keep_latest**, reopen, and invalid persisted rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d360fda10dfab11932587dea20c33d0540468d28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->