### PR TITLE
support auth

### DIFF
--- a/sdk/rs/README.md
+++ b/sdk/rs/README.md
@@ -34,3 +34,18 @@ batch.push(&orders, &order_key, order_value)?;
 batch.push(&accounts, &account_key, account_value)?;
 let sequence = batch.commit(&base).await?;
 ```
+
+## Examples
+
+`remote` writes a batch to a deployed endpoint and reads it back, pinning each read to the sequence it just committed:
+
+```bash
+EXOWARE_URL=https://query.<deployment>.<domain> \
+    EXOWARE_API_KEY=<token> \
+    cargo run -p exoware-sdk --example remote
+```
+
+`EXOWARE_API_KEY` is the credential a public deployment requires, and the builder reads it from
+the environment when `.api_key(...)` is not set. This example needs one covering both scopes.
+
+Add `EXOWARE_WRITE_URL` to reach a deployment that serves its write path on a separate origin.

--- a/sdk/rs/examples/remote.rs
+++ b/sdk/rs/examples/remote.rs
@@ -1,0 +1,101 @@
+//! Round-trip a batch of keys against a deployed Exoware endpoint.
+//!
+//! ```bash
+//! EXOWARE_URL=https://query.<deployment>.<domain> \
+//!     EXOWARE_API_KEY=<token> \
+//!     cargo run -p exoware-sdk --example remote
+//! ```
+//!
+//! A public deployment requires a credential covering both scopes, obtained from whoever
+//! operates it. The builder reads one from `EXOWARE_API_KEY`.
+//!
+//! Set `EXOWARE_WRITE_URL` as well to reach a deployment that serves its write path
+//! on a separate origin. It defaults to `EXOWARE_URL`.
+
+use std::process::ExitCode;
+
+use bytes::Bytes;
+use exoware_sdk::{Key, StoreClient, StoreKeyPrefix};
+
+/// Everything written here lives under one prefix, so the demo stays separable
+/// from other keys in a shared store.
+const NAMESPACE: &[u8] = b"example/remote/";
+
+#[tokio::main]
+async fn main() -> ExitCode {
+    let url = std::env::var("EXOWARE_URL").unwrap_or_else(|_| "http://localhost:8080".to_string());
+    let write_url = std::env::var("EXOWARE_WRITE_URL").unwrap_or_else(|_| url.clone());
+
+    println!("read  {url}");
+    println!("write {write_url}");
+
+    match round_trip(&url, &write_url).await {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(err) => {
+            // Display rather than the Debug that returning Err from main would print.
+            eprintln!("\nfailed: {err}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+async fn round_trip(url: &str, write_url: &str) -> Result<(), Box<dyn std::error::Error>> {
+    // `health()` and `ready()` are plain `GET /health` and `GET /ready` against
+    // health_url, which a path-routed deployment need not expose. This example
+    // reaches the services directly instead of probing.
+    let client = StoreClient::builder()
+        .query_url(url)
+        .stream_url(url)
+        .health_url(url)
+        .ingest_url(write_url)
+        .compact_url(write_url)
+        .build()?;
+    let store = client.prefixed(StoreKeyPrefix::new(Bytes::from_static(NAMESPACE))?);
+
+    let entries: Vec<(Key, &[u8])> = vec![
+        (key(b"answer"), b"42".as_slice()),
+        (key(b"greeting"), b"hello".as_slice()),
+        (key(b"unit"), b"bytes".as_slice()),
+    ];
+    let batch: Vec<(&Key, &[u8])> = entries.iter().map(|(k, v)| (k, *v)).collect();
+
+    // One commit for the whole batch, sequenced by the store.
+    let sequence = store.ingest().put(&batch).await?;
+    println!("\ncommitted {} entries at sequence {sequence}", batch.len());
+
+    // Query replicas trail the write path, so pin each read to the sequence just
+    // committed rather than racing it.
+    let greeting = key(b"greeting");
+    match store
+        .query()
+        .get_with_min_sequence_number(&greeting, sequence)
+        .await?
+    {
+        Some(value) => println!("greeting = {}", String::from_utf8_lossy(&value)),
+        None => println!("greeting = <missing>"),
+    }
+
+    // Logical bounds spanning the namespace: the empty key up to 0xFF repeated to
+    // fill whatever length the prefix leaves.
+    let start = Key::new();
+    let end = Key::from(vec![0xFF; store.key_prefix().max_logical_key_len()]);
+    let scanned = store
+        .query()
+        .range_with_min_sequence_number(&start, &end, 16, sequence)
+        .await?;
+
+    println!("\nrange over {} keys:", scanned.len());
+    for (k, value) in &scanned {
+        println!(
+            "  {} = {}",
+            String::from_utf8_lossy(k),
+            String::from_utf8_lossy(value)
+        );
+    }
+
+    Ok(())
+}
+
+fn key(bytes: &[u8]) -> Key {
+    Bytes::copy_from_slice(bytes)
+}

--- a/sdk/rs/examples/remote.rs
+++ b/sdk/rs/examples/remote.rs
@@ -64,15 +64,19 @@ async fn round_trip(url: &str, write_url: &str) -> Result<(), Box<dyn std::error
     println!("\ncommitted {} entries at sequence {sequence}", batch.len());
 
     // Query replicas trail the write path, so pin each read to the sequence just
-    // committed rather than racing it.
+    // committed rather than racing it. Pinned there, a miss or a wrong value is the
+    // deployment failing, so both reads below are checked rather than printed.
     let greeting = key(b"greeting");
-    match store
+    let value = store
         .query()
         .get_with_min_sequence_number(&greeting, sequence)
         .await?
-    {
-        Some(value) => println!("greeting = {}", String::from_utf8_lossy(&value)),
-        None => println!("greeting = <missing>"),
+        .ok_or_else(|| format!("greeting is absent at sequence {sequence}, which committed it"))?;
+    println!("greeting = {}", String::from_utf8_lossy(&value));
+    if value != b"hello".as_slice() {
+        return Err(
+            format!("greeting reads back as {value:?} rather than the \"hello\" written").into(),
+        );
     }
 
     // Logical bounds spanning the namespace: the empty key up to 0xFF repeated to
@@ -91,6 +95,22 @@ async fn round_trip(url: &str, write_url: &str) -> Result<(), Box<dyn std::error
             String::from_utf8_lossy(k),
             String::from_utf8_lossy(value)
         );
+    }
+
+    // Containment rather than an exact count, because the namespace may hold keys this
+    // run did not write.
+    for (expected_key, expected_value) in &entries {
+        let name = String::from_utf8_lossy(expected_key);
+        match scanned.iter().find(|(k, _)| k == expected_key) {
+            Some((_, value)) if value == expected_value => {}
+            Some((_, value)) => {
+                return Err(format!(
+                    "range returns {name} as {value:?} rather than {expected_value:?}"
+                )
+                .into())
+            }
+            None => return Err(format!("range over the namespace omits {name}").into()),
+        }
     }
 
     Ok(())

--- a/sdk/rs/src/credential.rs
+++ b/sdk/rs/src/credential.rs
@@ -1,20 +1,17 @@
 //! The API key a client presents, and what a rejection tells the caller to do about it.
 //!
-//! A deployment behind a load balancer authenticates every RPC, and one without a load balancer
-//! authenticates none, so a client cannot know from its configuration whether a credential is
-//! required. It carries whatever it has and explains itself when a call comes back rejected.
+//! A client cannot tell from its configuration whether the endpoint requires a credential, since
+//! a deployment behind a load balancer authenticates every RPC and one without authenticates
+//! none. It sends whatever it has and explains itself when a call is rejected.
 
 use std::fmt;
 
-use crate::{ClientError, ConnectError, ErrorCode};
+use crate::{ClientBuildError, ClientError, ConnectError, ErrorCode};
 
 /// Environment variable read for the API key when none is set on the builder.
 pub const API_KEY_ENV: &str = "EXOWARE_API_KEY";
 
-/// The API key, held so that it is never printed.
-///
-/// The credential authorizes every RPC this client makes, so a `Debug` of the builder must not
-/// leak it into a log.
+/// The API key, wrapped so a `Debug` of the builder cannot leak it into a log.
 #[derive(Clone, Default)]
 pub(crate) struct ApiKey(pub(crate) String);
 
@@ -24,11 +21,20 @@ impl fmt::Debug for ApiKey {
     }
 }
 
+/// How a constructor handles an `EXOWARE_API_KEY` that cannot be an HTTP header.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum UnusableEnvKey {
+    /// Fail the build.
+    Reject,
+    /// Build without a credential, leaving a rejected request to name the variable. The only
+    /// option for the infallible constructors, which would otherwise have to panic.
+    Tolerate,
+}
+
 /// Whether this client sends a credential with every request.
 ///
-/// Decided once when the client is built, then carried to each site that can raise an RPC error.
-/// A rejection is the only place the distinction matters and the least able to see it, since an
-/// endpoint reports the same code whether a credential was missing or merely refused.
+/// Threaded to every site that can raise an RPC error, because an endpoint reports the same code
+/// whether a credential was missing or refused, and only the client knows which.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum Credential {
     Sent,
@@ -37,22 +43,69 @@ pub(crate) enum Credential {
     Unusable,
 }
 
+/// A resolved credential, ready to configure a client with.
+#[derive(Debug)]
+pub(crate) struct Resolved {
+    pub(crate) header: Option<http::HeaderValue>,
+    pub(crate) credential: Credential,
+}
+
+/// Chooses between an explicitly configured key and one found in the environment.
+///
+/// Takes the environment lookup as an argument rather than reading it, so that every case is
+/// reachable without touching a process-wide variable.
+pub(crate) fn resolve(
+    explicit: Option<String>,
+    from_environment: Option<String>,
+    unusable_env_key: UnusableEnvKey,
+) -> Result<Resolved, ClientBuildError> {
+    let (key, is_from_environment) = match explicit {
+        Some(key) => (Some(key), false),
+        None => (from_environment, true),
+    };
+
+    // Surrounding whitespace is trimmed rather than rejected. A key routinely arrives as
+    // EXOWARE_API_KEY=$(cat token), which carries a trailing newline that is no part of it.
+    let key = key
+        .map(|key| key.trim().to_string())
+        .filter(|key| !key.is_empty());
+    let Some(key) = key else {
+        return Ok(Resolved {
+            header: None,
+            credential: Credential::Absent,
+        });
+    };
+
+    match bearer_header(&key) {
+        Some(header) => Ok(Resolved {
+            header: Some(header),
+            credential: Credential::Sent,
+        }),
+        None if !is_from_environment => Err(ClientBuildError::InvalidApiKey),
+        None => match unusable_env_key {
+            UnusableEnvKey::Reject => Err(ClientBuildError::InvalidApiKeyEnv),
+            UnusableEnvKey::Tolerate => Ok(Resolved {
+                header: None,
+                credential: Credential::Unusable,
+            }),
+        },
+    }
+}
+
 /// Builds the Authorization header for a key, or `None` if the key cannot be one.
 ///
 /// Marked sensitive so the credential cannot reach a log or a Debug of the client.
-pub(crate) fn bearer_header(key: &str) -> Option<http::HeaderValue> {
+fn bearer_header(key: &str) -> Option<http::HeaderValue> {
     let mut value = http::HeaderValue::from_str(&format!("Bearer {key}")).ok()?;
     value.set_sensitive(true);
     Some(value)
 }
 
 impl Credential {
-    /// What to do about an unauthenticated rejection. The two cases share no advice, which is
-    /// the reason this is threaded through at all.
+    /// Advice for an unauthenticated rejection.
     ///
-    /// Whoever reads this may be running a binary they did not build, so neither case names an
-    /// API. `Absent` means nothing was configured in code either, so the environment variable is
-    /// something the reader can act on.
+    /// The reader may be running a binary they did not build, so no case names a Rust API. The
+    /// environment variable is the one thing they can always act on.
     const fn remedy(self) -> &'static str {
         match self {
             Self::Absent => concat!(
@@ -72,6 +125,8 @@ impl Credential {
     }
 }
 
+/// Presents an RPC error to the caller, dropping any page a proxy answered with and telling a
+/// rejected caller what to do about their credential.
 pub(crate) fn client_error_from_connect(
     mut err: ConnectError,
     credential: Credential,
@@ -88,6 +143,10 @@ pub(crate) fn client_error_from_connect(
 }
 
 /// Drops an HTML error page from a message, keeping whatever preceded it.
+///
+/// A proxy that rejects a request before it reaches a service answers with a page rather than a
+/// ConnectRPC error, and the whole page arrives in the message. Returns `None` when nothing but
+/// markup was there.
 fn without_html_body(message: String) -> Option<String> {
     let lowercase = message.to_ascii_lowercase();
     let Some(start) = ["<html", "<!doctype"]
@@ -102,14 +161,15 @@ fn without_html_body(message: String) -> Option<String> {
     (!kept.is_empty()).then(|| kept.to_string())
 }
 
-/// The 401 body an ALB serves when it rejects a token, verbatim. Shared with the builder tests
-/// in `lib.rs`, which check that a client built from an unusable key explains itself.
-#[cfg(test)]
-pub(crate) const PROXY_REJECTION: &str = "HTTP error 401: <html>\r\n<head><title>401 Authorization Required</title></head>\r\n<body>\r\n<center><h1>401 Authorization Required</h1></center>\r\n</body>\r\n</html>\r\n";
-
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The 401 body an ALB serves when it rejects a token, verbatim.
+    const PROXY_REJECTION: &str = "HTTP error 401: <html>\r\n<head><title>401 Authorization Required</title></head>\r\n<body>\r\n<center><h1>401 Authorization Required</h1></center>\r\n</body>\r\n</html>\r\n";
+
+    /// An unusable key, being a byte no base64url token contains.
+    const UNUSABLE: &str = "has\nnewline";
 
     fn rejection(credential: Credential) -> String {
         client_error_from_connect(
@@ -117,6 +177,10 @@ mod tests {
             credential,
         )
         .to_string()
+    }
+
+    fn from_env(key: &str, unusable_env_key: UnusableEnvKey) -> Result<Resolved, ClientBuildError> {
+        resolve(None, Some(key.to_string()), unusable_env_key)
     }
 
     #[test]
@@ -188,15 +252,87 @@ mod tests {
 
     #[test]
     fn a_key_becomes_a_sensitive_bearer_header() {
-        let value = bearer_header("token-abc").unwrap();
-        assert_eq!(value, "Bearer token-abc");
+        let resolved = from_env("token-abc", UnusableEnvKey::Reject).unwrap();
+        let header = resolved.header.unwrap();
 
+        assert_eq!(resolved.credential, Credential::Sent);
+        assert_eq!(header, "Bearer token-abc");
         // set_sensitive is what keeps the credential out of any log that debugs the transport.
-        assert!(!format!("{value:?}").contains("token-abc"));
+        assert!(!format!("{header:?}").contains("token-abc"));
     }
 
     #[test]
-    fn a_key_that_cannot_be_a_header_yields_no_header() {
-        assert!(bearer_header("has\nnewline").is_none());
+    fn an_explicit_key_wins_over_the_environment() {
+        let resolved = resolve(
+            Some("explicit".to_string()),
+            Some("from-env".to_string()),
+            UnusableEnvKey::Reject,
+        )
+        .unwrap();
+
+        assert_eq!(resolved.header.unwrap(), "Bearer explicit");
+    }
+
+    #[test]
+    fn no_key_anywhere_sends_no_header() {
+        // A deployment with no load balancer in front of it authenticates nothing, so this has to
+        // keep working rather than demand a credential.
+        let resolved = resolve(None, None, UnusableEnvKey::Reject).unwrap();
+
+        assert!(resolved.header.is_none());
+        assert_eq!(resolved.credential, Credential::Absent);
+    }
+
+    /// A key reaching the environment through `$(cat token)` carries a trailing newline, which
+    /// would otherwise make it unusable.
+    #[test]
+    fn surrounding_whitespace_is_trimmed_rather_than_rejected() {
+        let resolved = from_env("  padded-token\n", UnusableEnvKey::Reject).unwrap();
+
+        assert_eq!(resolved.header.unwrap(), "Bearer padded-token");
+        assert_eq!(resolved.credential, Credential::Sent);
+    }
+
+    #[test]
+    fn a_variable_holding_only_whitespace_is_an_unset_one() {
+        let resolved = from_env("   \n", UnusableEnvKey::Reject).unwrap();
+
+        assert!(resolved.header.is_none());
+        assert_eq!(resolved.credential, Credential::Absent);
+    }
+
+    #[test]
+    fn an_explicit_unusable_key_always_fails() {
+        // The caller passed it in code and called a fallible build, so the policy never applies.
+        for unusable_env_key in [UnusableEnvKey::Reject, UnusableEnvKey::Tolerate] {
+            assert!(matches!(
+                resolve(Some(UNUSABLE.to_string()), None, unusable_env_key),
+                Err(ClientBuildError::InvalidApiKey)
+            ));
+        }
+    }
+
+    #[test]
+    fn an_unusable_environment_key_follows_the_policy() {
+        assert!(matches!(
+            from_env(UNUSABLE, UnusableEnvKey::Reject),
+            Err(ClientBuildError::InvalidApiKeyEnv)
+        ));
+
+        let tolerated = from_env(UNUSABLE, UnusableEnvKey::Tolerate).unwrap();
+        assert!(tolerated.header.is_none());
+        assert_eq!(tolerated.credential, Credential::Unusable);
+    }
+
+    /// Whoever set the variable may not have written the binary, so the message names the
+    /// variable and not the builder.
+    #[test]
+    fn rejecting_an_environment_key_names_the_variable() {
+        let rendered = from_env(UNUSABLE, UnusableEnvKey::Reject)
+            .unwrap_err()
+            .to_string();
+
+        assert!(rendered.contains(API_KEY_ENV), "{rendered}");
+        assert!(!rendered.contains("StoreClient"), "{rendered}");
     }
 }

--- a/sdk/rs/src/credential.rs
+++ b/sdk/rs/src/credential.rs
@@ -1,0 +1,202 @@
+//! The API key a client presents, and what a rejection tells the caller to do about it.
+//!
+//! A deployment behind a load balancer authenticates every RPC, and one without a load balancer
+//! authenticates none, so a client cannot know from its configuration whether a credential is
+//! required. It carries whatever it has and explains itself when a call comes back rejected.
+
+use std::fmt;
+
+use crate::{ClientError, ConnectError, ErrorCode};
+
+/// Environment variable read for the API key when none is set on the builder.
+pub const API_KEY_ENV: &str = "EXOWARE_API_KEY";
+
+/// The API key, held so that it is never printed.
+///
+/// The credential authorizes every RPC this client makes, so a `Debug` of the builder must not
+/// leak it into a log.
+#[derive(Clone, Default)]
+pub(crate) struct ApiKey(pub(crate) String);
+
+impl fmt::Debug for ApiKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("<redacted>")
+    }
+}
+
+/// Whether this client sends a credential with every request.
+///
+/// Decided once when the client is built, then carried to each site that can raise an RPC error.
+/// A rejection is the only place the distinction matters and the least able to see it, since an
+/// endpoint reports the same code whether a credential was missing or merely refused.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum Credential {
+    Sent,
+    Absent,
+    /// Configured through the environment, but not sendable as an HTTP header value.
+    Unusable,
+}
+
+/// Builds the Authorization header for a key, or `None` if the key cannot be one.
+///
+/// Marked sensitive so the credential cannot reach a log or a Debug of the client.
+pub(crate) fn bearer_header(key: &str) -> Option<http::HeaderValue> {
+    let mut value = http::HeaderValue::from_str(&format!("Bearer {key}")).ok()?;
+    value.set_sensitive(true);
+    Some(value)
+}
+
+impl Credential {
+    /// What to do about an unauthenticated rejection. The two cases share no advice, which is
+    /// the reason this is threaded through at all.
+    ///
+    /// Whoever reads this may be running a binary they did not build, so neither case names an
+    /// API. `Absent` means nothing was configured in code either, so the environment variable is
+    /// something the reader can act on.
+    const fn remedy(self) -> &'static str {
+        match self {
+            Self::Absent => concat!(
+                "This endpoint requires a credential and none was sent. The EXOWARE_API_KEY ",
+                "environment variable supplies one"
+            ),
+            Self::Sent => concat!(
+                "The credential sent with this request was refused. It may have expired, or ",
+                "been issued for a different deployment, or lack the scope this call needs"
+            ),
+            Self::Unusable => concat!(
+                "The EXOWARE_API_KEY environment variable is set to a value that cannot be an ",
+                "HTTP header, so no credential was sent. Remove any control or non-ASCII ",
+                "characters from it"
+            ),
+        }
+    }
+}
+
+pub(crate) fn client_error_from_connect(
+    mut err: ConnectError,
+    credential: Credential,
+) -> ClientError {
+    err.message = err.message.take().and_then(without_html_body);
+    if err.code == ErrorCode::Unauthenticated {
+        let remedy = credential.remedy();
+        err.message = Some(match err.message.take() {
+            Some(message) => format!("{message}. {remedy}"),
+            None => remedy.to_string(),
+        });
+    }
+    ClientError::Rpc(Box::new(err))
+}
+
+/// Drops an HTML error page from a message, keeping whatever preceded it.
+fn without_html_body(message: String) -> Option<String> {
+    let lowercase = message.to_ascii_lowercase();
+    let Some(start) = ["<html", "<!doctype"]
+        .iter()
+        .filter_map(|marker| lowercase.find(marker))
+        .min()
+    else {
+        return Some(message);
+    };
+
+    let kept = message[..start].trim_end().trim_end_matches(':').trim_end();
+    (!kept.is_empty()).then(|| kept.to_string())
+}
+
+/// The 401 body an ALB serves when it rejects a token, verbatim. Shared with the builder tests
+/// in `lib.rs`, which check that a client built from an unusable key explains itself.
+#[cfg(test)]
+pub(crate) const PROXY_REJECTION: &str = "HTTP error 401: <html>\r\n<head><title>401 Authorization Required</title></head>\r\n<body>\r\n<center><h1>401 Authorization Required</h1></center>\r\n</body>\r\n</html>\r\n";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rejection(credential: Credential) -> String {
+        client_error_from_connect(
+            ConnectError::new(ErrorCode::Unauthenticated, PROXY_REJECTION),
+            credential,
+        )
+        .to_string()
+    }
+
+    #[test]
+    fn proxy_rejection_keeps_the_status_and_drops_the_page() {
+        let err = client_error_from_connect(
+            ConnectError::new(ErrorCode::Unauthenticated, PROXY_REJECTION),
+            Credential::Sent,
+        );
+        let rendered = err.to_string();
+        assert_eq!(err.rpc_code(), Some(ErrorCode::Unauthenticated));
+        assert!(!rendered.contains('<'), "kept markup: {rendered}");
+        assert!(rendered.contains("HTTP error 401"), "{rendered}");
+    }
+
+    #[test]
+    fn a_missing_credential_is_told_how_to_supply_one() {
+        let rendered = rejection(Credential::Absent);
+        assert!(rendered.contains("none was sent"), "{rendered}");
+        assert!(rendered.contains(API_KEY_ENV), "{rendered}");
+    }
+
+    /// The reader may not control the binary, so no rejection may point at a Rust API.
+    #[test]
+    fn no_remedy_names_an_api() {
+        for credential in [Credential::Sent, Credential::Absent, Credential::Unusable] {
+            let rendered = rejection(credential);
+            assert!(!rendered.contains("StoreClient"), "{rendered}");
+            assert!(!rendered.contains("::"), "{rendered}");
+        }
+    }
+
+    /// A client that sent a credential needs to hear why one it already has failed, so it must
+    /// not be told to set the variable it already set.
+    #[test]
+    fn a_refused_credential_is_told_why_rather_than_how_to_set_one() {
+        let rendered = rejection(Credential::Sent);
+        assert!(rendered.contains("refused"), "{rendered}");
+        assert!(rendered.contains("expired"), "{rendered}");
+        assert!(!rendered.contains(API_KEY_ENV), "{rendered}");
+    }
+
+    #[test]
+    fn other_codes_carry_no_credential_remedy() {
+        let err = client_error_from_connect(
+            ConnectError::new(ErrorCode::NotFound, "no such key"),
+            Credential::Absent,
+        );
+        assert_eq!(err.to_string(), "RPC error (not_found: no such key)");
+    }
+
+    #[test]
+    fn html_body_recognized_with_a_doctype_and_when_it_is_the_whole_message() {
+        assert_eq!(
+            without_html_body("HTTP error 502: <!DOCTYPE html><html></html>".to_string()),
+            Some("HTTP error 502".to_string())
+        );
+        assert_eq!(without_html_body("<html>bare</html>".to_string()), None);
+    }
+
+    #[test]
+    fn a_service_message_survives_untouched() {
+        // Service errors are the common case, and nothing about them should be trimmed.
+        let message = "key not found: a < b";
+        assert_eq!(
+            without_html_body(message.to_string()),
+            Some(message.to_string())
+        );
+    }
+
+    #[test]
+    fn a_key_becomes_a_sensitive_bearer_header() {
+        let value = bearer_header("token-abc").unwrap();
+        assert_eq!(value, "Bearer token-abc");
+
+        // set_sensitive is what keeps the credential out of any log that debugs the transport.
+        assert!(!format!("{value:?}").contains("token-abc"));
+    }
+
+    #[test]
+    fn a_key_that_cannot_be_a_header_yields_no_header() {
+        assert!(bearer_header("has\nnewline").is_none());
+    }
+}

--- a/sdk/rs/src/lib.rs
+++ b/sdk/rs/src/lib.rs
@@ -26,7 +26,7 @@ extern crate self as exoware_proto;
 use bytes::Bytes;
 use connectrpc::client::{ClientConfig, ServerStream as ConnectServerStream};
 pub use connectrpc::{ConnectError, ErrorCode};
-use credential::{bearer_header, client_error_from_connect, ApiKey, Credential};
+use credential::{client_error_from_connect, ApiKey, Credential, UnusableEnvKey};
 use exoware_proto::compact::ServiceClient as CompactServiceClient;
 use exoware_proto::ingest::ServiceClient as IngestServiceClient;
 use exoware_proto::log::ingest::v1::PutRequest as ProtoPutRequest;
@@ -1542,8 +1542,10 @@ pub enum ClientBuildError {
     InvalidEndpointUrl { url: String },
     #[error("StoreClientBuilder: failed to configure platform TLS verifier: {0}")]
     TlsConfig(#[source] connectrpc::rustls::Error),
-    #[error("StoreClientBuilder: API key is not valid in an HTTP header (check for whitespace or non-ASCII)")]
+    #[error("StoreClientBuilder: API key is not valid in an HTTP header (check for control or non-ASCII characters)")]
     InvalidApiKey,
+    #[error("{API_KEY_ENV} is set to a value that cannot be an HTTP header. Remove any control or non-ASCII characters from it")]
+    InvalidApiKeyEnv,
 }
 
 /// Configures a [`StoreClient`] with explicit bases for health probes and store services.
@@ -1628,7 +1630,19 @@ impl StoreClientBuilder {
     }
 
     /// Build the client, or return an error if any required URL was not set.
+    /// Takes the API key from [`API_KEY_ENV`] unless [`Self::api_key`] set one, and fails if
+    /// either cannot be an HTTP header.
     pub fn build(self) -> Result<StoreClient, ClientBuildError> {
+        self.build_with(std::env::var(API_KEY_ENV).ok(), UnusableEnvKey::Reject)
+    }
+
+    /// Takes the environment lookup as an argument, so a test can cover every credential case
+    /// without mutating a variable that the rest of the process is reading.
+    fn build_with(
+        self,
+        env_api_key: Option<String>,
+        unusable_env_key: UnusableEnvKey,
+    ) -> Result<StoreClient, ClientBuildError> {
         let health_url = self.health_url.ok_or(ClientBuildError::MissingHealthUrl)?;
         let ingest_url = self.ingest_url.ok_or(ClientBuildError::MissingIngestUrl)?;
         let query_url = self.query_url.ok_or(ClientBuildError::MissingQueryUrl)?;
@@ -1651,35 +1665,11 @@ impl StoreClientBuilder {
             ProtoPreferZstdHttpClient::plaintext()
         };
 
-        // Surrounding whitespace is trimmed rather than rejected. A key routinely arrives as
-        // EXOWARE_API_KEY=$(cat token), which carries a trailing newline that is no part of it.
-        let (api_key, from_env) = match self.api_key.map(|key| key.0) {
-            Some(key) => (Some(key), false),
-            None => (std::env::var(API_KEY_ENV).ok(), true),
-        };
-        let api_key = api_key
-            .map(|key| key.trim().to_string())
-            .filter(|key| !key.is_empty());
-
-        let mut credential = if api_key.is_some() {
-            Credential::Sent
-        } else {
-            Credential::Absent
-        };
-        let connect_http = match api_key {
-            Some(key) => match bearer_header(&key) {
-                Some(value) => connect_http.with_authorization(value),
-                // An explicit key is the caller's own argument and they called a fallible
-                // build, so it fails. One from the environment is deployment config reaching
-                // an infallible constructor, and a stray byte there must not abort the
-                // process, so the client is built without a credential and says so when a
-                // request is rejected.
-                None if !from_env => return Err(ClientBuildError::InvalidApiKey),
-                None => {
-                    credential = Credential::Unusable;
-                    connect_http
-                }
-            },
+        let resolved =
+            credential::resolve(self.api_key.map(|key| key.0), env_api_key, unusable_env_key)?;
+        let credential = resolved.credential;
+        let connect_http = match resolved.header {
+            Some(value) => connect_http.with_authorization(value),
             None => connect_http,
         };
         Ok(StoreClient {
@@ -1762,11 +1752,13 @@ impl StoreClient {
         Self::with_retry_config(url, RetryConfig::standard())
     }
 
+    /// Panics if `url` is not a valid endpoint. A malformed [`API_KEY_ENV`] is ignored rather
+    /// than panicking, so use [`Self::builder`] to have it rejected.
     pub fn with_retry_config(url: &str, retry_config: RetryConfig) -> Self {
         Self::builder()
             .url(url)
             .retry_config(retry_config)
-            .build()
+            .build_with(std::env::var(API_KEY_ENV).ok(), UnusableEnvKey::Tolerate)
             .expect("failed to configure Store client")
     }
 
@@ -2974,7 +2966,6 @@ fn retry_backoff_delay(attempt: usize, retry_config: RetryConfig) -> Duration {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::credential::PROXY_REJECTION;
     use crate::kv_codec::{KvFieldKind, KvPredicate, KvPredicateCheck, KvPredicateConstraint};
     use exoware_proto::query::TraversalMode as ProtoTraversalMode;
 
@@ -2998,22 +2989,8 @@ mod tests {
     }
 
     #[test]
-    fn the_builder_records_whether_a_credential_will_be_sent() {
-        let _guard = API_KEY_ENV_LOCK.lock().unwrap();
-        std::env::remove_var(API_KEY_ENV);
-        assert_eq!(
-            StoreClient::new("https://store.example.com").credential,
-            Credential::Absent
-        );
+    fn an_explicit_key_records_that_one_will_be_sent() {
         assert_eq!(built_with_api_key("token").credential, Credential::Sent);
-
-        // The environment is the other way a credential arrives, and it counts the same.
-        std::env::set_var(API_KEY_ENV, "from-env");
-        assert_eq!(
-            StoreClient::new("https://store.example.com").credential,
-            Credential::Sent
-        );
-        std::env::remove_var(API_KEY_ENV);
     }
 
     #[test]
@@ -3086,9 +3063,6 @@ mod tests {
         ));
     }
 
-    /// Serializes the tests that mutate `EXOWARE_API_KEY`, which is process-wide.
-    static API_KEY_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
     fn built_with_api_key(key: &str) -> StoreClient {
         StoreClient::builder()
             .url("https://example.test")
@@ -3129,50 +3103,34 @@ mod tests {
         assert!(!rendered.contains("token-abc"));
     }
 
-    #[test]
-    fn no_api_key_sends_no_header() {
-        let _guard = API_KEY_ENV_LOCK.lock().unwrap();
-        std::env::remove_var(API_KEY_ENV);
-
-        // A deployment with no load balancer in front of it authenticates nothing, so local and
-        // in-VPC clients must keep working with no credential configured.
-        let client = StoreClient::builder()
+    /// Builds with `key` standing in for the environment lookup, so nothing here depends on a
+    /// variable another test could be changing. `credential.rs` covers which key wins.
+    fn built_with_env_key(key: Option<&str>, unusable_env_key: UnusableEnvKey) -> StoreClient {
+        StoreClient::builder()
             .url("https://example.test")
-            .build()
-            .unwrap();
-
-        assert!(client.connect_http.authorization().is_none());
+            .build_with(key.map(str::to_string), unusable_env_key)
+            .expect("builder should accept this environment key")
     }
 
     #[test]
-    fn the_environment_supplies_a_key_and_an_explicit_one_wins() {
-        let _guard = API_KEY_ENV_LOCK.lock().unwrap();
-        std::env::set_var(API_KEY_ENV, "from-env");
+    fn no_api_key_sends_no_header() {
+        // A deployment with no load balancer in front of it authenticates nothing, so local and
+        // in-VPC clients must keep working with no credential configured.
+        let client = built_with_env_key(None, UnusableEnvKey::Reject);
 
-        let from_env = StoreClient::builder()
-            .url("https://example.test")
-            .build()
-            .unwrap();
+        assert!(client.connect_http.authorization().is_none());
+        assert_eq!(client.credential, Credential::Absent);
+    }
+
+    #[test]
+    fn an_environment_key_reaches_the_transport() {
+        let client = built_with_env_key(Some("from-env"), UnusableEnvKey::Reject);
+
         assert_eq!(
-            from_env.connect_http.authorization().unwrap(),
+            client.connect_http.authorization().unwrap(),
             "Bearer from-env"
         );
-
-        let explicit = built_with_api_key("explicit");
-        assert_eq!(
-            explicit.connect_http.authorization().unwrap(),
-            "Bearer explicit"
-        );
-
-        // An empty variable is an unset one, not a credential of "Bearer ".
-        std::env::set_var(API_KEY_ENV, "");
-        let empty = StoreClient::builder()
-            .url("https://example.test")
-            .build()
-            .unwrap();
-        assert!(empty.connect_http.authorization().is_none());
-
-        std::env::remove_var(API_KEY_ENV);
+        assert_eq!(client.credential, Credential::Sent);
     }
 
     #[test]
@@ -3186,49 +3144,21 @@ mod tests {
         ));
     }
 
-    /// `new` returns `Self`, so a variable an operator sets must not be able to abort the
-    /// process. An unusable one yields a client with no credential that says why.
+    /// The infallible constructors would have to panic, so they build a client that carries no
+    /// credential and says why when a request is rejected.
     #[test]
-    fn an_unusable_environment_key_does_not_panic_the_infallible_constructors() {
-        let _guard = API_KEY_ENV_LOCK.lock().unwrap();
-        std::env::set_var(API_KEY_ENV, "has\nnewline");
-
-        let client = StoreClient::new("https://example.test");
+    fn a_tolerated_unusable_key_yields_a_client_that_explains_itself() {
+        let client = built_with_env_key(Some("has\nnewline"), UnusableEnvKey::Tolerate);
         assert!(client.connect_http.authorization().is_none());
         assert_eq!(client.credential, Credential::Unusable);
 
         let rendered = client_error_from_connect(
-            ConnectError::new(ErrorCode::Unauthenticated, PROXY_REJECTION),
+            ConnectError::new(ErrorCode::Unauthenticated, "HTTP error 401"),
             client.credential,
         )
         .to_string();
         assert!(rendered.contains(API_KEY_ENV), "{rendered}");
         assert!(rendered.contains("cannot be an HTTP header"), "{rendered}");
-
-        std::env::remove_var(API_KEY_ENV);
-    }
-
-    /// A key reaching the environment through `$(cat token)` carries a trailing newline, which
-    /// would otherwise make it unusable.
-    #[test]
-    fn surrounding_whitespace_in_a_key_is_trimmed_rather_than_rejected() {
-        let _guard = API_KEY_ENV_LOCK.lock().unwrap();
-        std::env::set_var(API_KEY_ENV, "  padded-token\n");
-
-        let client = StoreClient::new("https://example.test");
-        assert_eq!(
-            client.connect_http.authorization().unwrap(),
-            "Bearer padded-token"
-        );
-        assert_eq!(client.credential, Credential::Sent);
-
-        // A variable holding only whitespace is an unset one, not an unusable credential.
-        std::env::set_var(API_KEY_ENV, "   \n");
-        let blank = StoreClient::new("https://example.test");
-        assert!(blank.connect_http.authorization().is_none());
-        assert_eq!(blank.credential, Credential::Absent);
-
-        std::env::remove_var(API_KEY_ENV);
     }
 
     #[test]

--- a/sdk/rs/src/lib.rs
+++ b/sdk/rs/src/lib.rs
@@ -23,7 +23,7 @@ extern crate self as exoware_proto;
 
 use bytes::Bytes;
 use connectrpc::client::{ClientConfig, ServerStream as ConnectServerStream};
-use connectrpc::{ConnectError, ErrorCode};
+pub use connectrpc::{ConnectError, ErrorCode};
 use exoware_proto::compact::ServiceClient as CompactServiceClient;
 use exoware_proto::ingest::ServiceClient as IngestServiceClient;
 use exoware_proto::log::ingest::v1::PutRequest as ProtoPutRequest;
@@ -47,6 +47,7 @@ use keys::is_valid_key_size;
 use kv_codec::{KvExpr, KvFieldRef, KvReducedValue};
 use rustls_platform_verifier::ConfigVerifierExt;
 use std::collections::HashMap;
+use std::fmt;
 use std::sync::{
     atomic::{AtomicU64, Ordering},
     Arc,
@@ -1114,6 +1115,7 @@ pub struct RangeStream {
     finished: bool,
     observed_sequence: Option<Arc<AtomicU64>>,
     key_prefix: Option<StoreKeyPrefix>,
+    credential: Credential,
 }
 
 impl RangeStream {
@@ -1124,6 +1126,7 @@ impl RangeStream {
         >,
         observed_sequence: Option<Arc<AtomicU64>>,
         key_prefix: Option<StoreKeyPrefix>,
+        credential: Credential,
     ) -> Self {
         Self {
             stream,
@@ -1133,6 +1136,7 @@ impl RangeStream {
             finished: false,
             observed_sequence,
             key_prefix,
+            credential,
         }
     }
 
@@ -1174,11 +1178,11 @@ impl RangeStream {
                     .stream
                     .message()
                     .await
-                    .map_err(client_error_from_connect)?
+                    .map_err(|err| client_error_from_connect(err, self.credential))?
                 else {
                     self.finished = true;
                     if let Some(err) = self.stream.error() {
-                        return Err(client_error_from_connect(err.clone()));
+                        return Err(client_error_from_connect(err.clone(), self.credential));
                     }
                     self.final_count = Some(self.rows_seen);
                     return Ok(None);
@@ -1228,6 +1232,7 @@ pub struct GetManyStream {
     finished: bool,
     observed_sequence: Option<Arc<AtomicU64>>,
     key_prefix: Option<StoreKeyPrefix>,
+    credential: Credential,
 }
 
 impl GetManyStream {
@@ -1238,6 +1243,7 @@ impl GetManyStream {
         >,
         observed_sequence: Option<Arc<AtomicU64>>,
         key_prefix: Option<StoreKeyPrefix>,
+        credential: Credential,
     ) -> Self {
         Self {
             stream,
@@ -1245,6 +1251,7 @@ impl GetManyStream {
             finished: false,
             observed_sequence,
             key_prefix,
+            credential,
         }
     }
 
@@ -1280,11 +1287,11 @@ impl GetManyStream {
                     .stream
                     .message()
                     .await
-                    .map_err(client_error_from_connect)?
+                    .map_err(|err| client_error_from_connect(err, self.credential))?
                 else {
                     self.finished = true;
                     if let Some(err) = self.stream.error() {
-                        return Err(client_error_from_connect(err.clone()));
+                        return Err(client_error_from_connect(err.clone(), self.credential));
                     }
                     return Ok(None);
                 };
@@ -1365,6 +1372,7 @@ pub struct StreamSubscription {
         exoware_proto::log::stream::v1::SubscribeResponseView<'static>,
     >,
     key_prefix: Option<StoreKeyPrefix>,
+    credential: Credential,
 }
 
 impl std::fmt::Debug for StreamSubscription {
@@ -1381,7 +1389,7 @@ impl StreamSubscription {
                 .stream
                 .message()
                 .await
-                .map_err(client_error_from_connect)?
+                .map_err(|err| client_error_from_connect(err, self.credential))?
             {
                 Some(view) => {
                     let owned = view.to_owned_message();
@@ -1408,7 +1416,7 @@ impl StreamSubscription {
                 }
                 None => {
                     if let Some(err) = self.stream.error() {
-                        return Err(client_error_from_connect(err.clone()));
+                        return Err(client_error_from_connect(err.clone(), self.credential));
                     } else {
                         return Ok(None);
                     }
@@ -1532,6 +1540,24 @@ pub enum ClientBuildError {
     InvalidEndpointUrl { url: String },
     #[error("StoreClientBuilder: failed to configure platform TLS verifier: {0}")]
     TlsConfig(#[source] connectrpc::rustls::Error),
+    #[error("StoreClientBuilder: API key is not valid in an HTTP header (check for whitespace or non-ASCII)")]
+    InvalidApiKey,
+}
+
+/// Environment variable read for the API key when none is set on the builder.
+pub const API_KEY_ENV: &str = "EXOWARE_API_KEY";
+
+/// The API key, held so that it is never printed.
+///
+/// The credential authorizes every RPC this client makes, so a `Debug` of the builder must not
+/// leak it into a log.
+#[derive(Clone, Default)]
+struct ApiKey(String);
+
+impl fmt::Debug for ApiKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("<redacted>")
+    }
 }
 
 /// Configures a [`StoreClient`] with explicit bases for health probes and store services.
@@ -1548,6 +1574,7 @@ pub struct StoreClientBuilder {
     stream_url: Option<String>,
     retry_config: RetryConfig,
     connect_request_compression: ConnectRequestCompression,
+    api_key: Option<ApiKey>,
 }
 
 impl StoreClientBuilder {
@@ -1592,6 +1619,16 @@ impl StoreClientBuilder {
         self
     }
 
+    /// API key sent as `Authorization: Bearer <key>` on every RPC.
+    ///
+    /// Leaving this unset falls back to the `EXOWARE_API_KEY` environment variable, if present.
+    ///
+    /// Ignored for [`StoreClient::health`] and [`StoreClient::ready`].
+    pub fn api_key(mut self, key: &str) -> Self {
+        self.api_key = Some(ApiKey(key.to_string()));
+        self
+    }
+
     /// Retry policy for idempotent read operations (get / range / reduce).
     pub fn retry_config(mut self, retry: RetryConfig) -> Self {
         self.retry_config = retry.sanitized();
@@ -1627,6 +1664,38 @@ impl StoreClientBuilder {
         } else {
             ProtoPreferZstdHttpClient::plaintext()
         };
+
+        // Surrounding whitespace is trimmed rather than rejected. A key routinely arrives as
+        // EXOWARE_API_KEY=$(cat token), which carries a trailing newline that is no part of it.
+        let (api_key, from_env) = match self.api_key.map(|key| key.0) {
+            Some(key) => (Some(key), false),
+            None => (std::env::var(API_KEY_ENV).ok(), true),
+        };
+        let api_key = api_key
+            .map(|key| key.trim().to_string())
+            .filter(|key| !key.is_empty());
+
+        let mut credential = if api_key.is_some() {
+            Credential::Sent
+        } else {
+            Credential::Absent
+        };
+        let connect_http = match api_key {
+            Some(key) => match bearer_header(&key) {
+                Some(value) => connect_http.with_authorization(value),
+                // An explicit key is the caller's own argument and they called a fallible
+                // build, so it fails. One from the environment is deployment config reaching
+                // an infallible constructor, and a stray byte there must not abort the
+                // process, so the client is built without a credential and says so when a
+                // request is rejected.
+                None if !from_env => return Err(ClientBuildError::InvalidApiKey),
+                None => {
+                    credential = Credential::Unusable;
+                    connect_http
+                }
+            },
+            None => connect_http,
+        };
         Ok(StoreClient {
             health_url,
             ingest_uri,
@@ -1637,6 +1706,7 @@ impl StoreClientBuilder {
             connect_http,
             retry_config: self.retry_config,
             connect_request_compression: self.connect_request_compression,
+            credential,
         })
     }
 }
@@ -1654,6 +1724,7 @@ pub struct StoreClient {
     connect_http: ProtoPreferZstdHttpClient,
     retry_config: RetryConfig,
     connect_request_compression: ConnectRequestCompression,
+    credential: Credential,
 }
 
 /// A session that enforces monotonic read consistency via a fixed `min_sequence_number` floor.
@@ -1786,7 +1857,7 @@ impl StoreClient {
                 ..Default::default()
             })
             .await
-            .map_err(client_error_from_connect)?;
+            .map_err(|err| client_error_from_connect(err, self.credential))?;
         Ok(response.into_owned().sequence_number)
     }
 
@@ -1840,8 +1911,12 @@ impl StoreClient {
                 .await
             {
                 Ok(stream) => {
-                    let mut gms =
-                        GetManyStream::from_connect_stream(stream, observed_sequence.clone(), None);
+                    let mut gms = GetManyStream::from_connect_stream(
+                        stream,
+                        observed_sequence.clone(),
+                        None,
+                        self.credential,
+                    );
                     if let Err(err) = gms.prefetch_first_frame().await {
                         if attempt < max_attempts && is_retryable_error(&err) {
                             let delay = retry_delay_for_error(&err, attempt, self.retry_config);
@@ -1849,7 +1924,7 @@ impl StoreClient {
                             attempt += 1;
                             continue;
                         }
-                        return Err(client_error_from_connect(err));
+                        return Err(client_error_from_connect(err, self.credential));
                     }
                     return Ok(gms);
                 }
@@ -1860,7 +1935,7 @@ impl StoreClient {
                         attempt += 1;
                         continue;
                     }
-                    return Err(client_error_from_connect(err));
+                    return Err(client_error_from_connect(err, self.credential));
                 }
             }
         }
@@ -1879,7 +1954,7 @@ impl StoreClient {
                 ..Default::default()
             })
             .await
-            .map_err(client_error_from_connect)?;
+            .map_err(|err| client_error_from_connect(err, self.credential))?;
         Ok(())
     }
 
@@ -1932,10 +2007,11 @@ impl StoreClient {
         let stream = client
             .subscribe(request)
             .await
-            .map_err(client_error_from_connect)?;
+            .map_err(|err| client_error_from_connect(err, self.credential))?;
         Ok(StreamSubscription {
             stream,
             key_prefix: None,
+            credential: self.credential,
         })
     }
 
@@ -1963,7 +2039,7 @@ impl StoreClient {
                 if is_batch_missing_error(&err) {
                     Ok(None)
                 } else {
-                    Err(client_error_from_connect(err))
+                    Err(client_error_from_connect(err, self.credential))
                 }
             }
         }
@@ -1991,7 +2067,7 @@ impl StoreClient {
         let response = client
             .set_retention(request)
             .await
-            .map_err(client_error_from_connect)?;
+            .map_err(|err| client_error_from_connect(err, self.credential))?;
         Ok(response.into_owned().oldest_retained_sequence)
     }
 
@@ -2129,12 +2205,16 @@ impl StoreClient {
                         attempt += 1;
                         continue;
                     }
-                    return Err(client_error_from_connect(err));
+                    return Err(client_error_from_connect(err, self.credential));
                 }
             };
 
-            let mut stream =
-                RangeStream::from_connect_stream(response, options.observed_sequence.clone(), None);
+            let mut stream = RangeStream::from_connect_stream(
+                response,
+                options.observed_sequence.clone(),
+                None,
+                self.credential,
+            );
             if let Err(err) = stream.prefetch_first_frame().await {
                 if attempt < max_attempts && is_retryable_error(&err) {
                     let delay = retry_delay_for_error(&err, attempt, self.retry_config);
@@ -2149,7 +2229,7 @@ impl StoreClient {
                     attempt += 1;
                     continue;
                 }
-                return Err(client_error_from_connect(err));
+                return Err(client_error_from_connect(err, self.credential));
             }
             return Ok(stream);
         }
@@ -2215,7 +2295,7 @@ impl StoreClient {
                         attempt += 1;
                         continue;
                     }
-                    return Err(client_error_from_connect(err));
+                    return Err(client_error_from_connect(err, self.credential));
                 }
             }
         }
@@ -2860,8 +2940,79 @@ impl SerializableReadSession {
     }
 }
 
-fn client_error_from_connect(err: ConnectError) -> ClientError {
+/// Whether this client sends a credential with every request.
+///
+/// Decided once when the client is built, then carried to each site that can raise an RPC error.
+/// A rejection is the only place the distinction matters and the least able to see it, since an
+/// endpoint reports the same code whether a credential was missing or merely refused.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum Credential {
+    Sent,
+    Absent,
+    /// Configured through the environment, but not sendable as an HTTP header value.
+    Unusable,
+}
+
+/// Builds the Authorization header for a key, or `None` if the key cannot be one.
+///
+/// Marked sensitive so the credential cannot reach a log or a Debug of the client.
+fn bearer_header(key: &str) -> Option<http::HeaderValue> {
+    let mut value = http::HeaderValue::from_str(&format!("Bearer {key}")).ok()?;
+    value.set_sensitive(true);
+    Some(value)
+}
+
+impl Credential {
+    /// What to do about an unauthenticated rejection. The two cases share no advice, which is
+    /// the reason this is threaded through at all.
+    ///
+    /// Whoever reads this may be running a binary they did not build, so neither case names an
+    /// API. `Absent` means nothing was configured in code either, so the environment variable is
+    /// something the reader can act on.
+    const fn remedy(self) -> &'static str {
+        match self {
+            Self::Absent => concat!(
+                "This endpoint requires a credential and none was sent. The EXOWARE_API_KEY ",
+                "environment variable supplies one"
+            ),
+            Self::Sent => concat!(
+                "The credential sent with this request was refused. It may have expired, or ",
+                "been issued for a different deployment, or lack the scope this call needs"
+            ),
+            Self::Unusable => concat!(
+                "The EXOWARE_API_KEY environment variable is set to a value that cannot be an ",
+                "HTTP header, so no credential was sent. Remove any control or non-ASCII ",
+                "characters from it"
+            ),
+        }
+    }
+}
+
+fn client_error_from_connect(mut err: ConnectError, credential: Credential) -> ClientError {
+    err.message = err.message.take().and_then(without_html_body);
+    if err.code == ErrorCode::Unauthenticated {
+        let remedy = credential.remedy();
+        err.message = Some(match err.message.take() {
+            Some(message) => format!("{message}. {remedy}"),
+            None => remedy.to_string(),
+        });
+    }
     ClientError::Rpc(Box::new(err))
+}
+
+/// Drops an HTML error page from a message, keeping whatever preceded it.
+fn without_html_body(message: String) -> Option<String> {
+    let lowercase = message.to_ascii_lowercase();
+    let Some(start) = ["<html", "<!doctype"]
+        .iter()
+        .filter_map(|marker| lowercase.find(marker))
+        .min()
+    else {
+        return Some(message);
+    };
+
+    let kept = message[..start].trim_end().trim_end_matches(':').trim_end();
+    (!kept.is_empty()).then(|| kept.to_string())
 }
 
 fn is_retryable_error(err: &ConnectError) -> bool {
@@ -2934,6 +3085,103 @@ mod tests {
         assert!(!client.connect_http.supports_tls());
     }
 
+    /// The 401 body an ALB serves when it rejects a token, verbatim.
+    const PROXY_REJECTION: &str = "HTTP error 401: <html>\r\n<head><title>401 Authorization Required</title></head>\r\n<body>\r\n<center><h1>401 Authorization Required</h1></center>\r\n</body>\r\n</html>\r\n";
+
+    fn rejection(credential: Credential) -> String {
+        client_error_from_connect(
+            ConnectError::new(ErrorCode::Unauthenticated, PROXY_REJECTION),
+            credential,
+        )
+        .to_string()
+    }
+
+    #[test]
+    fn proxy_rejection_keeps_the_status_and_drops_the_page() {
+        let err = client_error_from_connect(
+            ConnectError::new(ErrorCode::Unauthenticated, PROXY_REJECTION),
+            Credential::Sent,
+        );
+        let rendered = err.to_string();
+        assert_eq!(err.rpc_code(), Some(ErrorCode::Unauthenticated));
+        assert!(!rendered.contains('<'), "kept markup: {rendered}");
+        assert!(rendered.contains("HTTP error 401"), "{rendered}");
+    }
+
+    #[test]
+    fn a_missing_credential_is_told_how_to_supply_one() {
+        let rendered = rejection(Credential::Absent);
+        assert!(rendered.contains("none was sent"), "{rendered}");
+        assert!(rendered.contains(API_KEY_ENV), "{rendered}");
+    }
+
+    /// The reader may not control the binary, so no rejection may point at a Rust API.
+    #[test]
+    fn no_remedy_names_an_api() {
+        for credential in [Credential::Sent, Credential::Absent, Credential::Unusable] {
+            let rendered = rejection(credential);
+            assert!(!rendered.contains("StoreClient"), "{rendered}");
+            assert!(!rendered.contains("::"), "{rendered}");
+        }
+    }
+
+    /// A client that sent a credential needs to hear why one it already has failed, so it must
+    /// not be told to set the variable it already set.
+    #[test]
+    fn a_refused_credential_is_told_why_rather_than_how_to_set_one() {
+        let rendered = rejection(Credential::Sent);
+        assert!(rendered.contains("refused"), "{rendered}");
+        assert!(rendered.contains("expired"), "{rendered}");
+        assert!(!rendered.contains(API_KEY_ENV), "{rendered}");
+    }
+
+    #[test]
+    fn other_codes_carry_no_credential_remedy() {
+        let err = client_error_from_connect(
+            ConnectError::new(ErrorCode::NotFound, "no such key"),
+            Credential::Absent,
+        );
+        assert_eq!(err.to_string(), "RPC error (not_found: no such key)");
+    }
+
+    #[test]
+    fn the_builder_records_whether_a_credential_will_be_sent() {
+        let _guard = API_KEY_ENV_LOCK.lock().unwrap();
+        std::env::remove_var(API_KEY_ENV);
+        assert_eq!(
+            StoreClient::new("https://store.example.com").credential,
+            Credential::Absent
+        );
+        assert_eq!(built_with_api_key("token").credential, Credential::Sent);
+
+        // The environment is the other way a credential arrives, and it counts the same.
+        std::env::set_var(API_KEY_ENV, "from-env");
+        assert_eq!(
+            StoreClient::new("https://store.example.com").credential,
+            Credential::Sent
+        );
+        std::env::remove_var(API_KEY_ENV);
+    }
+
+    #[test]
+    fn html_body_recognized_with_a_doctype_and_when_it_is_the_whole_message() {
+        assert_eq!(
+            without_html_body("HTTP error 502: <!DOCTYPE html><html></html>".to_string()),
+            Some("HTTP error 502".to_string())
+        );
+        assert_eq!(without_html_body("<html>bare</html>".to_string()), None);
+    }
+
+    #[test]
+    fn a_service_message_survives_untouched() {
+        // Service errors are the common case, and nothing about them should be trimmed.
+        let message = "key not found: a < b";
+        assert_eq!(
+            without_html_body(message.to_string()),
+            Some(message.to_string())
+        );
+    }
+
     #[test]
     fn client_creation_enables_tls_for_https() {
         let client = StoreClient::new("https://store.example.com");
@@ -3002,6 +3250,151 @@ mod tests {
                 .build(),
             Err(ClientBuildError::MissingStreamUrl)
         ));
+    }
+
+    /// Serializes the tests that mutate `EXOWARE_API_KEY`, which is process-wide.
+    static API_KEY_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    fn built_with_api_key(key: &str) -> StoreClient {
+        StoreClient::builder()
+            .url("https://example.test")
+            .api_key(key)
+            .build()
+            .expect("builder should accept this key")
+    }
+
+    #[test]
+    fn api_key_becomes_a_bearer_header() {
+        let client = built_with_api_key("token-abc");
+
+        assert_eq!(
+            client.connect_http.authorization().unwrap(),
+            "Bearer token-abc"
+        );
+    }
+
+    #[test]
+    fn api_key_is_redacted_in_debug_output() {
+        let rendered = format!(
+            "{:?}",
+            StoreClient::builder()
+                .url("https://example.test")
+                .api_key("token-abc")
+        );
+
+        assert!(!rendered.contains("token-abc"), "builder leaked the key");
+        assert!(rendered.contains("<redacted>"));
+    }
+
+    #[test]
+    fn a_bearer_header_never_renders_the_key() {
+        // set_sensitive is what keeps the credential out of any log that debugs the transport.
+        let client = built_with_api_key("token-abc");
+        let rendered = format!("{:?}", client.connect_http.authorization().unwrap());
+
+        assert!(!rendered.contains("token-abc"));
+    }
+
+    #[test]
+    fn no_api_key_sends_no_header() {
+        let _guard = API_KEY_ENV_LOCK.lock().unwrap();
+        std::env::remove_var(API_KEY_ENV);
+
+        // A deployment with no load balancer in front of it authenticates nothing, so local and
+        // in-VPC clients must keep working with no credential configured.
+        let client = StoreClient::builder()
+            .url("https://example.test")
+            .build()
+            .unwrap();
+
+        assert!(client.connect_http.authorization().is_none());
+    }
+
+    #[test]
+    fn the_environment_supplies_a_key_and_an_explicit_one_wins() {
+        let _guard = API_KEY_ENV_LOCK.lock().unwrap();
+        std::env::set_var(API_KEY_ENV, "from-env");
+
+        let from_env = StoreClient::builder()
+            .url("https://example.test")
+            .build()
+            .unwrap();
+        assert_eq!(
+            from_env.connect_http.authorization().unwrap(),
+            "Bearer from-env"
+        );
+
+        let explicit = built_with_api_key("explicit");
+        assert_eq!(
+            explicit.connect_http.authorization().unwrap(),
+            "Bearer explicit"
+        );
+
+        // An empty variable is an unset one, not a credential of "Bearer ".
+        std::env::set_var(API_KEY_ENV, "");
+        let empty = StoreClient::builder()
+            .url("https://example.test")
+            .build()
+            .unwrap();
+        assert!(empty.connect_http.authorization().is_none());
+
+        std::env::remove_var(API_KEY_ENV);
+    }
+
+    #[test]
+    fn a_key_that_cannot_be_a_header_fails_the_build() {
+        assert!(matches!(
+            StoreClient::builder()
+                .url("https://example.test")
+                .api_key("has\nnewline")
+                .build(),
+            Err(ClientBuildError::InvalidApiKey)
+        ));
+    }
+
+    /// `new` returns `Self`, so a variable an operator sets must not be able to abort the
+    /// process. An unusable one yields a client with no credential that says why.
+    #[test]
+    fn an_unusable_environment_key_does_not_panic_the_infallible_constructors() {
+        let _guard = API_KEY_ENV_LOCK.lock().unwrap();
+        std::env::set_var(API_KEY_ENV, "has\nnewline");
+
+        let client = StoreClient::new("https://example.test");
+        assert!(client.connect_http.authorization().is_none());
+        assert_eq!(client.credential, Credential::Unusable);
+
+        let rendered = client_error_from_connect(
+            ConnectError::new(ErrorCode::Unauthenticated, PROXY_REJECTION),
+            client.credential,
+        )
+        .to_string();
+        assert!(rendered.contains(API_KEY_ENV), "{rendered}");
+        assert!(rendered.contains("cannot be an HTTP header"), "{rendered}");
+
+        std::env::remove_var(API_KEY_ENV);
+    }
+
+    /// A key reaching the environment through `$(cat token)` carries a trailing newline, which
+    /// would otherwise make it unusable.
+    #[test]
+    fn surrounding_whitespace_in_a_key_is_trimmed_rather_than_rejected() {
+        let _guard = API_KEY_ENV_LOCK.lock().unwrap();
+        std::env::set_var(API_KEY_ENV, "  padded-token\n");
+
+        let client = StoreClient::new("https://example.test");
+        assert_eq!(
+            client.connect_http.authorization().unwrap(),
+            "Bearer padded-token"
+        );
+        assert_eq!(client.credential, Credential::Sent);
+
+        // A variable holding only whitespace is an unset one, not an unusable credential.
+        std::env::set_var(API_KEY_ENV, "   \n");
+        let blank = StoreClient::new("https://example.test");
+        assert!(blank.connect_http.authorization().is_none());
+        assert_eq!(blank.credential, Credential::Absent);
+
+        std::env::remove_var(API_KEY_ENV);
     }
 
     #[test]

--- a/sdk/rs/src/lib.rs
+++ b/sdk/rs/src/lib.rs
@@ -10,6 +10,7 @@
 //! protobuf `google.rpc` details (and `store.query.v1.Detail` on query RPC errors), not string parsing.
 //! Idempotent reads honor `google.rpc.RetryInfo` when deciding backoff (see `retry_delay_for_error`).
 
+mod credential;
 pub mod keys;
 pub mod kv_codec;
 pub mod proto;
@@ -17,6 +18,7 @@ pub mod prune_policy;
 pub mod retention;
 pub mod selector;
 pub mod stream_filter;
+pub use credential::API_KEY_ENV;
 pub use keys::{Key, KeyMut, KeyValidationError, Prefix, PrefixError, Value, MAX_KEY_LEN};
 pub use proto::*;
 extern crate self as exoware_proto;
@@ -24,6 +26,7 @@ extern crate self as exoware_proto;
 use bytes::Bytes;
 use connectrpc::client::{ClientConfig, ServerStream as ConnectServerStream};
 pub use connectrpc::{ConnectError, ErrorCode};
+use credential::{bearer_header, client_error_from_connect, ApiKey, Credential};
 use exoware_proto::compact::ServiceClient as CompactServiceClient;
 use exoware_proto::ingest::ServiceClient as IngestServiceClient;
 use exoware_proto::log::ingest::v1::PutRequest as ProtoPutRequest;
@@ -47,7 +50,6 @@ use keys::is_valid_key_size;
 use kv_codec::{KvExpr, KvFieldRef, KvReducedValue};
 use rustls_platform_verifier::ConfigVerifierExt;
 use std::collections::HashMap;
-use std::fmt;
 use std::sync::{
     atomic::{AtomicU64, Ordering},
     Arc,
@@ -1544,22 +1546,6 @@ pub enum ClientBuildError {
     InvalidApiKey,
 }
 
-/// Environment variable read for the API key when none is set on the builder.
-pub const API_KEY_ENV: &str = "EXOWARE_API_KEY";
-
-/// The API key, held so that it is never printed.
-///
-/// The credential authorizes every RPC this client makes, so a `Debug` of the builder must not
-/// leak it into a log.
-#[derive(Clone, Default)]
-struct ApiKey(String);
-
-impl fmt::Debug for ApiKey {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str("<redacted>")
-    }
-}
-
 /// Configures a [`StoreClient`] with explicit bases for health probes and store services.
 ///
 /// Use [`StoreClient::builder()`] to construct. Call [`Self::url`] to point every
@@ -2940,81 +2926,6 @@ impl SerializableReadSession {
     }
 }
 
-/// Whether this client sends a credential with every request.
-///
-/// Decided once when the client is built, then carried to each site that can raise an RPC error.
-/// A rejection is the only place the distinction matters and the least able to see it, since an
-/// endpoint reports the same code whether a credential was missing or merely refused.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) enum Credential {
-    Sent,
-    Absent,
-    /// Configured through the environment, but not sendable as an HTTP header value.
-    Unusable,
-}
-
-/// Builds the Authorization header for a key, or `None` if the key cannot be one.
-///
-/// Marked sensitive so the credential cannot reach a log or a Debug of the client.
-fn bearer_header(key: &str) -> Option<http::HeaderValue> {
-    let mut value = http::HeaderValue::from_str(&format!("Bearer {key}")).ok()?;
-    value.set_sensitive(true);
-    Some(value)
-}
-
-impl Credential {
-    /// What to do about an unauthenticated rejection. The two cases share no advice, which is
-    /// the reason this is threaded through at all.
-    ///
-    /// Whoever reads this may be running a binary they did not build, so neither case names an
-    /// API. `Absent` means nothing was configured in code either, so the environment variable is
-    /// something the reader can act on.
-    const fn remedy(self) -> &'static str {
-        match self {
-            Self::Absent => concat!(
-                "This endpoint requires a credential and none was sent. The EXOWARE_API_KEY ",
-                "environment variable supplies one"
-            ),
-            Self::Sent => concat!(
-                "The credential sent with this request was refused. It may have expired, or ",
-                "been issued for a different deployment, or lack the scope this call needs"
-            ),
-            Self::Unusable => concat!(
-                "The EXOWARE_API_KEY environment variable is set to a value that cannot be an ",
-                "HTTP header, so no credential was sent. Remove any control or non-ASCII ",
-                "characters from it"
-            ),
-        }
-    }
-}
-
-fn client_error_from_connect(mut err: ConnectError, credential: Credential) -> ClientError {
-    err.message = err.message.take().and_then(without_html_body);
-    if err.code == ErrorCode::Unauthenticated {
-        let remedy = credential.remedy();
-        err.message = Some(match err.message.take() {
-            Some(message) => format!("{message}. {remedy}"),
-            None => remedy.to_string(),
-        });
-    }
-    ClientError::Rpc(Box::new(err))
-}
-
-/// Drops an HTML error page from a message, keeping whatever preceded it.
-fn without_html_body(message: String) -> Option<String> {
-    let lowercase = message.to_ascii_lowercase();
-    let Some(start) = ["<html", "<!doctype"]
-        .iter()
-        .filter_map(|marker| lowercase.find(marker))
-        .min()
-    else {
-        return Some(message);
-    };
-
-    let kept = message[..start].trim_end().trim_end_matches(':').trim_end();
-    (!kept.is_empty()).then(|| kept.to_string())
-}
-
 fn is_retryable_error(err: &ConnectError) -> bool {
     matches!(
         err.code,
@@ -3063,6 +2974,7 @@ fn retry_backoff_delay(attempt: usize, retry_config: RetryConfig) -> Duration {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::credential::PROXY_REJECTION;
     use crate::kv_codec::{KvFieldKind, KvPredicate, KvPredicateCheck, KvPredicateConstraint};
     use exoware_proto::query::TraversalMode as ProtoTraversalMode;
 
@@ -3085,65 +2997,6 @@ mod tests {
         assert!(!client.connect_http.supports_tls());
     }
 
-    /// The 401 body an ALB serves when it rejects a token, verbatim.
-    const PROXY_REJECTION: &str = "HTTP error 401: <html>\r\n<head><title>401 Authorization Required</title></head>\r\n<body>\r\n<center><h1>401 Authorization Required</h1></center>\r\n</body>\r\n</html>\r\n";
-
-    fn rejection(credential: Credential) -> String {
-        client_error_from_connect(
-            ConnectError::new(ErrorCode::Unauthenticated, PROXY_REJECTION),
-            credential,
-        )
-        .to_string()
-    }
-
-    #[test]
-    fn proxy_rejection_keeps_the_status_and_drops_the_page() {
-        let err = client_error_from_connect(
-            ConnectError::new(ErrorCode::Unauthenticated, PROXY_REJECTION),
-            Credential::Sent,
-        );
-        let rendered = err.to_string();
-        assert_eq!(err.rpc_code(), Some(ErrorCode::Unauthenticated));
-        assert!(!rendered.contains('<'), "kept markup: {rendered}");
-        assert!(rendered.contains("HTTP error 401"), "{rendered}");
-    }
-
-    #[test]
-    fn a_missing_credential_is_told_how_to_supply_one() {
-        let rendered = rejection(Credential::Absent);
-        assert!(rendered.contains("none was sent"), "{rendered}");
-        assert!(rendered.contains(API_KEY_ENV), "{rendered}");
-    }
-
-    /// The reader may not control the binary, so no rejection may point at a Rust API.
-    #[test]
-    fn no_remedy_names_an_api() {
-        for credential in [Credential::Sent, Credential::Absent, Credential::Unusable] {
-            let rendered = rejection(credential);
-            assert!(!rendered.contains("StoreClient"), "{rendered}");
-            assert!(!rendered.contains("::"), "{rendered}");
-        }
-    }
-
-    /// A client that sent a credential needs to hear why one it already has failed, so it must
-    /// not be told to set the variable it already set.
-    #[test]
-    fn a_refused_credential_is_told_why_rather_than_how_to_set_one() {
-        let rendered = rejection(Credential::Sent);
-        assert!(rendered.contains("refused"), "{rendered}");
-        assert!(rendered.contains("expired"), "{rendered}");
-        assert!(!rendered.contains(API_KEY_ENV), "{rendered}");
-    }
-
-    #[test]
-    fn other_codes_carry_no_credential_remedy() {
-        let err = client_error_from_connect(
-            ConnectError::new(ErrorCode::NotFound, "no such key"),
-            Credential::Absent,
-        );
-        assert_eq!(err.to_string(), "RPC error (not_found: no such key)");
-    }
-
     #[test]
     fn the_builder_records_whether_a_credential_will_be_sent() {
         let _guard = API_KEY_ENV_LOCK.lock().unwrap();
@@ -3161,25 +3014,6 @@ mod tests {
             Credential::Sent
         );
         std::env::remove_var(API_KEY_ENV);
-    }
-
-    #[test]
-    fn html_body_recognized_with_a_doctype_and_when_it_is_the_whole_message() {
-        assert_eq!(
-            without_html_body("HTTP error 502: <!DOCTYPE html><html></html>".to_string()),
-            Some("HTTP error 502".to_string())
-        );
-        assert_eq!(without_html_body("<html>bare</html>".to_string()), None);
-    }
-
-    #[test]
-    fn a_service_message_survives_untouched() {
-        // Service errors are the common case, and nothing about them should be trimmed.
-        let message = "key not found: a < b";
-        assert_eq!(
-            without_html_body(message.to_string()),
-            Some(message.to_string())
-        );
     }
 
     #[test]

--- a/sdk/rs/src/proto/transport.rs
+++ b/sdk/rs/src/proto/transport.rs
@@ -31,7 +31,7 @@ use connectrpc::compression::CompressionRegistry;
 use connectrpc::rustls::ClientConfig;
 use connectrpc::ConnectError;
 use cookie_store::{Cookie, CookieDomain, CookieStore};
-use http::header::{ACCEPT_ENCODING, COOKIE, SET_COOKIE};
+use http::header::{ACCEPT_ENCODING, AUTHORIZATION, COOKIE, SET_COOKIE};
 use http::{Request, Response};
 use reqwest::Url;
 
@@ -46,11 +46,15 @@ pub fn connect_compression_registry() -> CompressionRegistry {
 ///
 /// Also persists HTTP cookies: every `Set-Cookie` response header is stored in an RFC6265 jar and
 /// replayed as `Cookie` when it matches a later request URL.
+///
+/// Carries the optional bearer credential too, so one place authenticates every RPC service
+/// rather than each generated client doing it.
 #[derive(Clone, Debug)]
 pub struct PreferZstdHttpClient {
     plaintext: HttpClient,
     tls: Option<HttpClient>,
     cookies: Arc<Mutex<CookieStore>>,
+    authorization: Option<http::HeaderValue>,
 }
 
 impl PreferZstdHttpClient {
@@ -60,6 +64,7 @@ impl PreferZstdHttpClient {
             plaintext: HttpClient::plaintext(),
             tls: None,
             cookies: Arc::new(Mutex::new(CookieStore::new())),
+            authorization: None,
         }
     }
 
@@ -69,7 +74,26 @@ impl PreferZstdHttpClient {
             plaintext: HttpClient::plaintext(),
             tls: Some(HttpClient::with_tls(tls_config)),
             cookies: Arc::new(Mutex::new(CookieStore::new())),
+            authorization: None,
         }
+    }
+
+    /// Send `value` as `Authorization` on every RPC.
+    ///
+    /// Mark the value sensitive before passing it here so it stays redacted in `Debug` output.
+    #[must_use]
+    pub fn with_authorization(mut self, value: http::HeaderValue) -> Self {
+        self.authorization = Some(value);
+        self
+    }
+
+    /// The `Authorization` value this client sends, if it has one.
+    ///
+    /// Only the crate's own tests read this back. Nothing on the request path needs it, because
+    /// `send` uses the field directly.
+    #[cfg(test)]
+    pub(crate) fn authorization(&self) -> Option<&http::HeaderValue> {
+        self.authorization.as_ref()
     }
 
     #[cfg(test)]
@@ -163,6 +187,10 @@ impl ClientTransport for PreferZstdHttpClient {
             http::HeaderValue::from_static("zstd, gzip"),
         );
 
+        if let Some(ref authorization) = self.authorization {
+            apply_authorization(request.headers_mut(), authorization);
+        }
+
         let this = self.clone();
         Box::pin(async move {
             let response = transport.send(request).await?;
@@ -172,6 +200,17 @@ impl ClientTransport for PreferZstdHttpClient {
             }
             Ok(Response::from_parts(parts, body))
         })
+    }
+}
+
+/// Set the client's credential as `Authorization`, leaving any caller-supplied one alone.
+///
+/// Deferring to the caller matches how jar cookies defer to caller-supplied cookie names, and it
+/// is what lets one client reach a deployment that expects a different credential on a specific
+/// call.
+fn apply_authorization(headers: &mut http::HeaderMap, value: &http::HeaderValue) {
+    if !headers.contains_key(AUTHORIZATION) {
+        headers.insert(AUTHORIZATION, value.clone());
     }
 }
 
@@ -533,5 +572,33 @@ mod tests {
         assert!(values.contains(&b"caller=token".to_vec()));
         assert!(values.contains(&b"AWSALB=abc".to_vec()));
         assert!(!values.contains(&b"opaque=jar".to_vec()));
+    }
+
+    #[test]
+    fn authorization_is_set_when_absent() {
+        let mut headers = http::HeaderMap::new();
+
+        apply_authorization(&mut headers, &"Bearer client".parse().unwrap());
+
+        assert_eq!(headers.get(AUTHORIZATION).unwrap(), "Bearer client");
+    }
+
+    #[test]
+    fn authorization_defers_to_the_caller() {
+        let mut headers = http::HeaderMap::new();
+        headers.insert(AUTHORIZATION, "Bearer caller".parse().unwrap());
+
+        apply_authorization(&mut headers, &"Bearer client".parse().unwrap());
+
+        assert_eq!(headers.get(AUTHORIZATION).unwrap(), "Bearer caller");
+        assert_eq!(headers.get_all(AUTHORIZATION).iter().count(), 1);
+    }
+
+    #[test]
+    fn no_credential_sends_no_authorization() {
+        let client = PreferZstdHttpClient::plaintext();
+
+        // A deployment with no load balancer in front of it must still be reachable.
+        assert!(client.authorization.is_none());
     }
 }

--- a/sdk/rs/tests/api_key_env.rs
+++ b/sdk/rs/tests/api_key_env.rs
@@ -1,0 +1,90 @@
+//! `EXOWARE_API_KEY` reaching the constructors.
+//!
+//! The unit tests cover which key wins and what each one resolves to. Only the lookup itself is
+//! left, and it needs a process whose environment holds the variable. Setting one in-process
+//! would be read by every other test building a client, so each case runs in a child instead.
+
+use std::process::{Command, Output};
+
+use exoware_sdk::{ClientBuildError, StoreClient, API_KEY_ENV};
+
+/// Re-runs this binary for a single `#[ignore]`d case, with `EXOWARE_API_KEY` set to `key`.
+fn run_in_child(case: &str, key: Option<&str>) -> Output {
+    let mut command = Command::new(std::env::current_exe().expect("test binary path"));
+    command.args([case, "--exact", "--ignored", "--nocapture"]);
+    match key {
+        Some(key) => command.env(API_KEY_ENV, key),
+        None => command.env_remove(API_KEY_ENV),
+    };
+    command.output().expect("child test process should run")
+}
+
+fn assert_case_passes(case: &str, key: Option<&str>) {
+    let output = run_in_child(case, key);
+    assert!(
+        output.status.success(),
+        "{case} failed in a child process\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+/// A byte no base64url token contains, so the variable is broken config rather than a credential
+/// that might still work.
+const UNUSABLE: &str = "has\nnewline";
+
+#[test]
+fn build_reads_the_variable() {
+    assert_case_passes("child_build_reads_the_variable", Some("token-abc"));
+}
+
+#[test]
+fn build_rejects_an_unusable_variable() {
+    assert_case_passes("child_build_rejects_an_unusable_variable", Some(UNUSABLE));
+}
+
+#[test]
+fn an_unusable_variable_does_not_panic_the_infallible_constructors() {
+    assert_case_passes("child_new_tolerates_an_unusable_variable", Some(UNUSABLE));
+}
+
+#[test]
+fn an_absent_variable_builds() {
+    assert_case_passes("child_build_without_the_variable", None);
+}
+
+#[test]
+#[ignore = "run by build_reads_the_variable in a child process"]
+fn child_build_reads_the_variable() {
+    StoreClient::builder()
+        .url("https://example.test")
+        .build()
+        .expect("a usable variable should build");
+}
+
+#[test]
+#[ignore = "run by build_rejects_an_unusable_variable in a child process"]
+fn child_build_rejects_an_unusable_variable() {
+    let err = StoreClient::builder()
+        .url("https://example.test")
+        .build()
+        .expect_err("an unusable variable should fail a fallible build");
+
+    assert!(matches!(err, ClientBuildError::InvalidApiKeyEnv), "{err:?}");
+    assert!(err.to_string().contains(API_KEY_ENV), "{err}");
+}
+
+#[test]
+#[ignore = "run by an_unusable_variable_does_not_panic_the_infallible_constructors in a child process"]
+fn child_new_tolerates_an_unusable_variable() {
+    StoreClient::new("https://example.test");
+}
+
+#[test]
+#[ignore = "run by an_absent_variable_builds in a child process"]
+fn child_build_without_the_variable() {
+    StoreClient::builder()
+        .url("https://example.test")
+        .build()
+        .expect("no variable should build");
+}


### PR DESCRIPTION
Support bearer token auth through the `EXOWARE_API_KEY` env var or the `.api_key` builder method. Add a `remote` example that can be used to smoke test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches all RPC authentication paths and client construction; misconfiguration could block access to protected deployments, but unauthenticated local use remains supported and changes are SDK-only.
> 
> **Overview**
> Adds **bearer token authentication** to the Rust store SDK so clients can reach deployments that require credentials.
> 
> `StoreClientBuilder` gains **`.api_key()`**, which sends `Authorization: Bearer …` on every Connect RPC (not on `health`/`ready`). If unset, **`EXOWARE_API_KEY`** is read at build time, with trimming for trailing newlines from `$(cat token)`. Explicit keys win over the environment; invalid header values fail **`build()`**, while **`StoreClient::new`** tolerates a broken env var and explains on `Unauthenticated` instead of panicking. Keys are **redacted** in `Debug` output.
> 
> A new **`credential`** module centralizes resolution and enriches **`Unauthenticated`** RPC errors (missing vs refused vs unusable env key) and strips **HTML proxy error pages** from messages.
> 
> **`PreferZstdHttpClient`** attaches the bearer header on all RPCs unless the caller already set `Authorization`.
> 
> Documentation adds a **`remote`** example that ingests a batch, pins reads to the commit sequence, and supports optional **`EXOWARE_WRITE_URL`** for split read/write origins.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfb0ef5821871c13ef7220f28881cb98c98c05ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->