### PR TITLE
qmdb reconstruct checkpoint peaks from pins

### DIFF
--- a/qmdb/rs/src/core.rs
+++ b/qmdb/rs/src/core.rs
@@ -538,15 +538,15 @@ pub(crate) fn extend_merkle_from_peaks_with_inactive_peaks<
 
 pub(crate) fn extend_merkle_from_pinned_nodes<F: Family, H: Hasher, Op: AsRef<[u8]>>(
     pinned_nodes: Vec<H::Digest>,
-    previous_leaves: Location<F>,
+    pruning_boundary: Location<F>,
     encoded_operations: impl IntoIterator<Item = Op>,
     inactive_peaks: usize,
 ) -> Result<MerkleExtension<F, H::Digest>, QmdbError> {
-    let previous_size = Position::try_from(previous_leaves)
+    let previous_size = Position::try_from(pruning_boundary)
         .map_err(|e| QmdbError::CorruptData(format!("invalid incremental ops size {e}")))?;
 
     let hasher = commonware_storage::qmdb::hasher::<H>();
-    let mem = Mem::<F, H::Digest>::from_components(Vec::new(), previous_leaves, pinned_nodes)
+    let mem = Mem::<F, H::Digest>::from_components(Vec::new(), pruning_boundary, pinned_nodes)
         .map_err(|e| QmdbError::CommonwareMerkle(e.to_string()))?;
     let mut batch = mem.new_batch();
     for encoded in encoded_operations {

--- a/qmdb/rs/src/core.rs
+++ b/qmdb/rs/src/core.rs
@@ -528,6 +528,23 @@ pub(crate) fn extend_merkle_from_peaks_with_inactive_peaks<
         )));
     }
 
+    extend_merkle_from_pinned_nodes::<F, H, _>(
+        pinned_nodes,
+        previous_leaves,
+        encoded_operations,
+        inactive_peaks,
+    )
+}
+
+pub(crate) fn extend_merkle_from_pinned_nodes<F: Family, H: Hasher, Op: AsRef<[u8]>>(
+    pinned_nodes: Vec<H::Digest>,
+    previous_leaves: Location<F>,
+    encoded_operations: impl IntoIterator<Item = Op>,
+    inactive_peaks: usize,
+) -> Result<MerkleExtension<F, H::Digest>, QmdbError> {
+    let previous_size = Position::try_from(previous_leaves)
+        .map_err(|e| QmdbError::CorruptData(format!("invalid incremental ops size {e}")))?;
+
     let hasher = commonware_storage::qmdb::hasher::<H>();
     let mem = Mem::<F, H::Digest>::from_components(Vec::new(), previous_leaves, pinned_nodes)
         .map_err(|e| QmdbError::CommonwareMerkle(e.to_string()))?;

--- a/qmdb/rs/src/immutable.rs
+++ b/qmdb/rs/src/immutable.rs
@@ -24,7 +24,7 @@ use crate::core::retry_transient_post_ingest_query;
 use crate::error::QmdbError;
 use crate::proof::{OperationRangeCheckpoint, RawBatchMultiProof, VerifiedOperationRange};
 use crate::storage::KvMerkleStorage;
-use crate::VersionedValue;
+use crate::{VersionedValue, WriterState};
 
 #[derive(Clone)]
 pub struct ImmutableClient<
@@ -109,6 +109,19 @@ where
             let session = self.client.create_session();
             async move { read_latest_auth_watermark::<F>(&session).await }
         })
+        .await
+    }
+
+    /// Recover writer state at the latest published watermark.
+    ///
+    /// Returns empty state when no watermark has been published.
+    pub async fn recover_writer_state(&self) -> Result<WriterState<H::Digest, F>, QmdbError> {
+        crate::recover_writer_state::<F, H, _, _>(
+            self.writer_location_watermark().await?,
+            |watermark, start_location, max_locations| {
+                self.operation_range_checkpoint(watermark, start_location, max_locations)
+            },
+        )
         .await
     }
 

--- a/qmdb/rs/src/keyless.rs
+++ b/qmdb/rs/src/keyless.rs
@@ -21,6 +21,7 @@ use crate::core::retry_transient_post_ingest_query;
 use crate::error::QmdbError;
 use crate::proof::{OperationRangeCheckpoint, RawBatchMultiProof, VerifiedOperationRange};
 use crate::storage::KvMerkleStorage;
+use crate::WriterState;
 
 #[derive(Clone)]
 pub struct KeylessClient<
@@ -100,6 +101,19 @@ where
             let session = self.client.create_session();
             async move { read_latest_auth_watermark::<F>(&session).await }
         })
+        .await
+    }
+
+    /// Recover writer state at the latest published watermark.
+    ///
+    /// Returns empty state when no watermark has been published.
+    pub async fn recover_writer_state(&self) -> Result<WriterState<H::Digest, F>, QmdbError> {
+        crate::recover_writer_state::<F, H, _, _>(
+            self.writer_location_watermark().await?,
+            |watermark, start_location, max_locations| {
+                self.operation_range_checkpoint(watermark, start_location, max_locations)
+            },
+        )
         .await
     }
 

--- a/qmdb/rs/src/lib.rs
+++ b/qmdb/rs/src/lib.rs
@@ -207,6 +207,66 @@ impl<D: Digest, F: Family> WriterState<D, F> {
     }
 }
 
+async fn recover_writer_state<F, H, Fetch, Fut>(
+    watermark: Option<Location<F>>,
+    fetch: Fetch,
+) -> Result<WriterState<H::Digest, F>, QmdbError>
+where
+    F: Graftable,
+    H: Hasher,
+    Fetch: FnOnce(Location<F>, Location<F>, u32) -> Fut,
+    Fut: std::future::Future<Output = Result<OperationRangeCheckpoint<H::Digest, F>, QmdbError>>,
+{
+    let Some(watermark) = watermark else {
+        return Ok(WriterState::empty());
+    };
+
+    let checkpoint = fetch(watermark, watermark, 1).await?;
+    WriterState::from_checkpoint::<H>(&checkpoint)
+}
+
+#[cfg(test)]
+mod recover_writer_state_tests {
+    use super::*;
+    use commonware_cryptography::Sha256;
+    use commonware_storage::merkle::mmr;
+
+    #[test]
+    fn empty_state_skips_checkpoint_fetch() {
+        let fetched = std::cell::Cell::new(false);
+        let state = futures::executor::block_on(recover_writer_state::<mmr::Family, Sha256, _, _>(
+            None,
+            |_, _, _| {
+                fetched.set(true);
+                std::future::ready(Err(QmdbError::EmptyBatch))
+            },
+        ))
+        .expect("recover empty state");
+
+        assert!(!fetched.get());
+        assert!(state.peaks.is_empty());
+        assert_eq!(state.ops_size, Position::new(0));
+        assert_eq!(state.next_location, Location::new(0));
+    }
+
+    #[test]
+    fn fetches_only_the_final_operation() {
+        let watermark = Location::<mmr::Family>::new(7);
+        let result =
+            futures::executor::block_on(recover_writer_state::<mmr::Family, Sha256, _, _>(
+                Some(watermark),
+                |requested_watermark, start_location, max_locations| {
+                    assert_eq!(requested_watermark, watermark);
+                    assert_eq!(start_location, watermark);
+                    assert_eq!(max_locations, 1);
+                    std::future::ready(Err(QmdbError::EmptyBatch))
+                },
+            ));
+
+        assert!(matches!(result, Err(QmdbError::EmptyBatch)));
+    }
+}
+
 /// Current-state rows for one uploaded current batch boundary.
 ///
 /// Current QMDB uploads carry more than the historical op log: each published

--- a/qmdb/rs/src/ordered.rs
+++ b/qmdb/rs/src/ordered.rs
@@ -39,7 +39,7 @@ use crate::proof::{
     VerifiedOperationRange, VerifiedVariantRange,
 };
 use crate::storage::{KvCurrentStorage, KvMerkleStorage};
-use crate::{QmdbVariant, VersionedValue};
+use crate::{QmdbVariant, VersionedValue, WriterState};
 
 const ACTIVE_OPERATION_GET_MANY_BATCH: usize = 1024;
 
@@ -212,6 +212,19 @@ where
 
     pub async fn writer_location_watermark(&self) -> Result<Option<Location<F>>, QmdbError> {
         self.core().writer_location_watermark().await
+    }
+
+    /// Recover writer state at the latest published watermark.
+    ///
+    /// Returns empty state when no watermark has been published.
+    pub async fn recover_writer_state(&self) -> Result<WriterState<H::Digest, F>, QmdbError> {
+        crate::recover_writer_state::<F, H, _, _>(
+            self.writer_location_watermark().await?,
+            |watermark, start_location, max_locations| {
+                self.operation_range_checkpoint(watermark, start_location, max_locations)
+            },
+        )
+        .await
     }
 
     pub async fn root_at(&self, watermark: Location<F>) -> Result<H::Digest, QmdbError> {

--- a/qmdb/rs/src/proof.rs
+++ b/qmdb/rs/src/proof.rs
@@ -54,47 +54,61 @@ impl<D: Digest, F: Graftable> OperationRangeCheckpoint<D, F> {
         )
     }
 
+    /// Reconstruct the writer frontier from an authenticated range ending at the watermark.
     pub fn reconstruct_peaks<H: Hasher<Digest = D>>(
         &self,
     ) -> Result<Vec<(Position<F>, u32, D)>, QmdbError> {
         let size = Position::try_from(self.proof.leaves)
             .map_err(|e| QmdbError::CorruptData(format!("invalid checkpoint leaf count: {e}")))?;
-        let peak_entries: Vec<(Position<F>, u32)> = F::peaks(size).collect();
-        if self.start_location == Location::new(0)
-            && self.encoded_operations.len() as u64 == self.proof.leaves.as_u64()
-        {
-            return Ok(crate::core::extend_merkle_from_peaks::<F, H, _>(
-                Vec::new(),
-                Position::new(0),
-                self.encoded_operations.iter().map(Vec::as_slice),
-            )?
-            .peaks);
+
+        let checkpoint_leaves = self.watermark.checked_add(1).ok_or_else(|| {
+            QmdbError::CorruptData("checkpoint watermark exceeds the location domain".into())
+        })?;
+        if checkpoint_leaves != self.proof.leaves {
+            return Err(QmdbError::CorruptData(format!(
+                "checkpoint watermark implies {checkpoint_leaves} leaves, proof has {}",
+                self.proof.leaves
+            )));
         }
 
-        let hasher = commonware_storage::qmdb::hasher::<H>();
-        let digests = self
-            .proof
-            .verify_range_inclusion_and_extract_digests(
-                &hasher,
-                &self.encoded_operations,
-                self.start_location,
-                &self.root,
-            )
-            .map_err(|e| {
-                QmdbError::CorruptData(format!("reconstruct checkpoint peaks failed: {e}"))
-            })?;
-        let digest_map: std::collections::BTreeMap<Position<F>, D> = digests.into_iter().collect();
-        peak_entries
-            .into_iter()
-            .map(|(pos, height)| {
-                let digest = digest_map.get(&pos).copied().ok_or_else(|| {
-                    QmdbError::CorruptData(format!(
-                        "checkpoint proof did not expose peak digest at position {pos}"
-                    ))
-                })?;
-                Ok((pos, height, digest))
-            })
-            .collect()
+        let operation_count = u64::try_from(self.encoded_operations.len())
+            .map_err(|_| QmdbError::CorruptData("checkpoint operation count exceeds u64".into()))?;
+        let end_location = self
+            .start_location
+            .checked_add(operation_count)
+            .ok_or_else(|| QmdbError::CorruptData("checkpoint range end overflow".into()))?;
+        if end_location != self.proof.leaves {
+            return Err(QmdbError::CorruptData(format!(
+                "checkpoint range ends at {end_location}, expected {}",
+                self.proof.leaves
+            )));
+        }
+
+        if !self.verify::<H>() {
+            return Err(QmdbError::CorruptData(
+                "reconstruct checkpoint peaks failed because the proof or pins are invalid".into(),
+            ));
+        }
+
+        let extension = crate::core::extend_merkle_from_pinned_nodes::<F, H, _>(
+            self.pinned_nodes.clone(),
+            self.start_location,
+            self.encoded_operations.iter().map(Vec::as_slice),
+            self.proof.inactive_peaks,
+        )?;
+        if extension.size != size {
+            return Err(QmdbError::CorruptData(format!(
+                "checkpoint extension size mismatch. Expected {size}, got {}",
+                extension.size
+            )));
+        }
+        if extension.root != self.root {
+            return Err(QmdbError::CorruptData(
+                "checkpoint extension root mismatch".into(),
+            ));
+        }
+
+        Ok(extension.peaks)
     }
 }
 

--- a/qmdb/rs/src/unordered.rs
+++ b/qmdb/rs/src/unordered.rs
@@ -30,7 +30,7 @@ use crate::proof::{
     RawUnorderedKeyValueProof, VerifiedOperationRange, VerifiedUnorderedKeyValue,
 };
 use crate::storage::{KvCurrentStorage, KvMerkleStorage};
-use crate::VersionedValue;
+use crate::{VersionedValue, WriterState};
 
 #[derive(Clone, Debug)]
 struct MaterializedBitmapStatus<const N: usize> {
@@ -202,6 +202,19 @@ where
 
     pub async fn writer_location_watermark(&self) -> Result<Option<Location<F>>, QmdbError> {
         self.core().writer_location_watermark().await
+    }
+
+    /// Recover writer state at the latest published watermark.
+    ///
+    /// Returns empty state when no watermark has been published.
+    pub async fn recover_writer_state(&self) -> Result<WriterState<H::Digest, F>, QmdbError> {
+        crate::recover_writer_state::<F, H, _, _>(
+            self.writer_location_watermark().await?,
+            |watermark, start_location, max_locations| {
+                self.operation_range_checkpoint(watermark, start_location, max_locations)
+            },
+        )
+        .await
     }
 
     pub async fn query_many_at<Q: AsRef<[u8]>>(

--- a/qmdb/rs/tests/e2e_keyless.rs
+++ b/qmdb/rs/tests/e2e_keyless.rs
@@ -14,7 +14,7 @@ use commonware_storage::qmdb::keyless::fixed::{
 };
 use commonware_storage::qmdb::keyless::variable::{Db as Keyless, Operation as KeylessOperation};
 use commonware_utils::{NZUsize, NZU16, NZU64};
-use exoware_qmdb::{KeylessClient, KeylessWriter};
+use exoware_qmdb::{KeylessClient, KeylessWriter, WriterState};
 use exoware_sdk::{PrefixedStoreClient, StoreClient};
 
 use common::retry;
@@ -65,6 +65,9 @@ struct LocalReference<F: Family> {
     latest_location: Location<F>,
     root: Digest,
     operations: Vec<KeylessOperation<F, Vec<u8>>>,
+    continuation_operations: Vec<KeylessOperation<F, Vec<u8>>>,
+    continued_latest_location: Location<F>,
+    continued_root: Digest,
     queried_location: Location<F>,
     queried_value: Vec<u8>,
 }
@@ -92,13 +95,31 @@ where
 
             let first = b"first-value".to_vec();
             let second = b"second-value".to_vec();
+            let third = b"third-value".to_vec();
+            let fourth = b"fourth-value".to_vec();
             let finalized = {
-                let batch = db.new_batch().append(first.clone()).append(second);
+                let batch = db
+                    .new_batch()
+                    .append(first.clone())
+                    .append(second)
+                    .append(third)
+                    .append(fourth)
+                    .append(b"fifth-value".to_vec())
+                    .append(b"sixth-value".to_vec())
+                    .append(b"seventh-value".to_vec());
                 batch
                     .merkleize(&db, None::<Vec<u8>>, db.inactivity_floor_loc())
                     .await
             };
             db.apply_batch(finalized).await.expect("apply");
+
+            let finalized = {
+                let batch = db.new_batch().append(b"eighth-value".to_vec());
+                batch
+                    .merkleize(&db, None::<Vec<u8>>, db.bounds().end - 1)
+                    .await
+            };
+            db.apply_batch(finalized).await.expect("apply second");
 
             let latest = db.bounds().end - 1;
             let n = NonZeroU64::new(*latest + 1).unwrap();
@@ -107,6 +128,23 @@ where
                 .await
                 .expect("proof");
             let root = db.root();
+
+            let finalized = {
+                let batch = db.new_batch().append(b"ninth-value".to_vec());
+                batch
+                    .merkleize(&db, None::<Vec<u8>>, db.bounds().end - 1)
+                    .await
+            };
+            db.apply_batch(finalized).await.expect("apply third");
+
+            let continued_latest_location = db.bounds().end - 1;
+            let n = NonZeroU64::new(*continued_latest_location + 1).unwrap();
+            let (_proof, all_operations) = db
+                .historical_proof(continued_latest_location + 1, Location::<F>::new(0), n)
+                .await
+                .expect("continued proof");
+            let continuation_operations = all_operations[ops.len()..].to_vec();
+            let continued_root = db.root();
             db.destroy().await.expect("destroy");
             let queried_location = ops
                 .iter()
@@ -121,6 +159,9 @@ where
                 latest_location: latest,
                 root,
                 operations: ops,
+                continuation_operations,
+                continued_latest_location,
+                continued_root,
                 queried_location,
                 queried_value: first,
             }
@@ -251,6 +292,15 @@ where
         !malformed_checkpoint.verify::<commonware_cryptography::Sha256>(),
         "zero-start checkpoints must not verify with pinned nodes"
     );
+    assert!(malformed_checkpoint
+        .reconstruct_peaks::<commonware_cryptography::Sha256>()
+        .is_err());
+    assert!(
+        WriterState::<Digest, F>::from_checkpoint::<commonware_cryptography::Sha256>(
+            &malformed_checkpoint,
+        )
+        .is_err()
+    );
     let peaks = checkpoint
         .reconstruct_peaks::<commonware_cryptography::Sha256>()
         .expect("reconstruct_peaks");
@@ -258,11 +308,116 @@ where
     let reconstructed_root = commonware_storage::merkle::hasher::Hasher::<F>::root(
         &hasher,
         checkpoint.proof.leaves,
-        0,
+        checkpoint.proof.inactive_peaks,
         peaks.iter().map(|(_, _, digest)| digest),
     )
     .expect("reconstruct root");
     assert_eq!(reconstructed_root, checkpoint.root);
+
+    let suffix_checkpoint = c
+        .operation_range_checkpoint(local.latest_location, local.latest_location, 1)
+        .await
+        .expect("suffix checkpoint");
+    assert!(suffix_checkpoint.verify::<commonware_cryptography::Sha256>());
+    assert!(!suffix_checkpoint.pinned_nodes.is_empty());
+    assert!(
+        suffix_checkpoint.proof.inactive_peaks > 0,
+        "suffix checkpoint must exercise folded inactive peaks"
+    );
+    let range_digests = suffix_checkpoint
+        .proof
+        .verify_range_inclusion_and_extract_digests(
+            &hasher,
+            &suffix_checkpoint.encoded_operations,
+            suffix_checkpoint.start_location,
+            &suffix_checkpoint.root,
+        )
+        .expect("verify suffix range");
+    assert!(
+        peaks
+            .iter()
+            .any(|(peak, _, _)| !range_digests.iter().any(|(position, _)| position == peak)),
+        "suffix checkpoint must exercise a peak omitted by range extraction"
+    );
+    assert_eq!(
+        suffix_checkpoint
+            .reconstruct_peaks::<commonware_cryptography::Sha256>()
+            .expect("reconstruct suffix peaks"),
+        peaks,
+    );
+
+    let mut suffix_without_pins = suffix_checkpoint.clone();
+    suffix_without_pins.pinned_nodes.clear();
+    let mut suffix_with_wrong_pin = suffix_checkpoint.clone();
+    suffix_with_wrong_pin.pinned_nodes[0] = suffix_with_wrong_pin.root;
+    let mut suffix_with_extra_pin = suffix_checkpoint.clone();
+    suffix_with_extra_pin
+        .pinned_nodes
+        .push(suffix_with_extra_pin.root);
+    for malformed in [
+        &suffix_without_pins,
+        &suffix_with_wrong_pin,
+        &suffix_with_extra_pin,
+    ] {
+        assert!(!malformed.verify::<commonware_cryptography::Sha256>());
+        assert!(malformed
+            .reconstruct_peaks::<commonware_cryptography::Sha256>()
+            .is_err());
+        assert!(
+            WriterState::<Digest, F>::from_checkpoint::<commonware_cryptography::Sha256>(malformed)
+                .is_err()
+        );
+    }
+
+    let mut checkpoint_with_wrong_watermark = suffix_checkpoint.clone();
+    checkpoint_with_wrong_watermark.watermark -= 1;
+    assert!(checkpoint_with_wrong_watermark.verify::<commonware_cryptography::Sha256>());
+    assert!(checkpoint_with_wrong_watermark
+        .reconstruct_peaks::<commonware_cryptography::Sha256>()
+        .is_err());
+    assert!(
+        WriterState::<Digest, F>::from_checkpoint::<commonware_cryptography::Sha256>(
+            &checkpoint_with_wrong_watermark,
+        )
+        .is_err()
+    );
+
+    let middle_checkpoint = c
+        .operation_range_checkpoint(local.latest_location, local.latest_location - 1, 1)
+        .await
+        .expect("middle checkpoint");
+    assert!(middle_checkpoint.verify::<commonware_cryptography::Sha256>());
+    assert!(middle_checkpoint
+        .reconstruct_peaks::<commonware_cryptography::Sha256>()
+        .is_err());
+    assert!(
+        WriterState::<Digest, F>::from_checkpoint::<commonware_cryptography::Sha256>(
+            &middle_checkpoint,
+        )
+        .is_err()
+    );
+
+    let state = WriterState::<Digest, F>::from_checkpoint::<commonware_cryptography::Sha256>(
+        &suffix_checkpoint,
+    )
+    .expect("writer state from suffix checkpoint");
+    let resumed_writer =
+        TestKeylessWriter::<F>::new(PrefixedStoreClient::empty(client.clone()), state);
+    let receipt = common::commit_keyless_upload(&resumed_writer, &local.continuation_operations)
+        .await
+        .expect("continued upload");
+    assert_eq!(receipt.latest_location, local.continued_latest_location);
+
+    let continued_root = retry(
+        || {
+            let c = fresh_keyless::<F>(client.clone());
+            let loc = local.continued_latest_location;
+            async move { c.root_at(loc).await }
+        },
+        "continued root_at",
+    )
+    .await;
+    assert_eq!(continued_root, local.continued_root);
 }
 
 #[tokio::test]

--- a/qmdb/rs/tests/e2e_keyless.rs
+++ b/qmdb/rs/tests/e2e_keyless.rs
@@ -240,6 +240,15 @@ where
     let client = common::local_store_client().await;
     let local = build_local_db::<F>().await;
 
+    let state = fresh_keyless::<F>(client.clone())
+        .recover_writer_state()
+        .await
+        .expect("recover empty writer state");
+    let empty_state = WriterState::empty();
+    assert_eq!(state.peaks, empty_state.peaks);
+    assert_eq!(state.ops_size, empty_state.ops_size);
+    assert_eq!(state.next_location, empty_state.next_location);
+
     let writer = fresh_writer::<F>(client.clone());
     common::commit_keyless_upload(&writer, &local.operations)
         .await
@@ -397,10 +406,18 @@ where
         .is_err()
     );
 
-    let state = WriterState::<Digest, F>::from_checkpoint::<commonware_cryptography::Sha256>(
-        &suffix_checkpoint,
-    )
-    .expect("writer state from suffix checkpoint");
+    let expected_state =
+        WriterState::<Digest, F>::from_checkpoint::<commonware_cryptography::Sha256>(
+            &suffix_checkpoint,
+        )
+        .expect("writer state from suffix checkpoint");
+    let state = c
+        .recover_writer_state()
+        .await
+        .expect("recover writer state");
+    assert_eq!(state.peaks, expected_state.peaks);
+    assert_eq!(state.ops_size, expected_state.ops_size);
+    assert_eq!(state.next_location, expected_state.next_location);
     let resumed_writer =
         TestKeylessWriter::<F>::new(PrefixedStoreClient::empty(client.clone()), state);
     let receipt = common::commit_keyless_upload(&resumed_writer, &local.continuation_operations)


### PR DESCRIPTION
## Summary

- reconstruct writer peaks by extending authenticated pinned nodes through a tail checkpoint
- reject checkpoints with inconsistent watermarks, non-tail ranges, invalid proofs, or invalid pins
- keep Commonware on the released `2026.7.0` dependency

## Motivation

Constantinople recovers QMDB writers by requesting the final operation at the published watermark. Replaying the full operation prefix makes restart cost linear in history size. A tail checkpoint already contains the authenticated pinned frontier at its start location. Exoware can append only the suffix and recover the final peaks without the new Commonware proof-digest extraction API.

See intended usage here: https://github.com/commonwarexyz/constantinople/compare/michael/parameterizable-deploy...michael/qmdb-suffix-recovery

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Merkle checkpoint reconstruction and writer recovery paths used on restart; mistakes could yield wrong peaks or failed resumes, but validation and e2e tests reduce exposure.
> 
> **Overview**
> Adds **suffix-based QMDB writer recovery** so restarts can rebuild the Merkle frontier from a **single authenticated operation at the published watermark**, instead of replaying the full op prefix.
> 
> **`extend_merkle_from_pinned_nodes`** in `core` extends the tree from authenticated pinned digests at a pruning boundary (with inactive peaks). Peak-based extension now delegates to it.
> 
> **`OperationRangeCheckpoint::reconstruct_peaks`** no longer relies on range digest extraction for the general case. It enforces that the checkpoint is a **tail range** (watermark, leaf count, and encoded ops align), verifies proof and pins, then extends via pinned nodes and checks size/root before returning peaks.
> 
> Shared **`recover_writer_state`** loads `(watermark, watermark, 1)` and builds **`WriterState`** via `from_checkpoint`. **`recover_writer_state()`** is exposed on immutable, keyless, ordered, and unordered clients.
> 
> Keyless e2e tests cover suffix checkpoints (pins, inactive peaks), rejection of bad pins/watermarks/non-tail ranges, **`recover_writer_state`**, and **resuming uploads** after recovery.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 700e40dc0751158581d9f9cad96c8a9c345f4ab7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->