### PR TITLE
Parallelize qmdb writer Merkle build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -961,8 +961,7 @@ dependencies = [
 [[package]]
 name = "commonware-actor"
 version = "2026.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beac6262223b45c6843ab70b245b526b28836a8257b1759a509ba5fab24fa4a6"
+source = "git+https://github.com/commonwarexyz/monorepo.git?rev=5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7#5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7"
 dependencies = [
  "cfg-if",
  "commonware-macros",
@@ -975,8 +974,7 @@ dependencies = [
 [[package]]
 name = "commonware-broadcast"
 version = "2026.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a2d7e56dc894ad3f55dbe5726468915492ae8e4650ad2a45c1bcfd138c2037f"
+source = "git+https://github.com/commonwarexyz/monorepo.git?rev=5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7#5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7"
 dependencies = [
  "commonware-actor",
  "commonware-codec",
@@ -992,8 +990,7 @@ dependencies = [
 [[package]]
 name = "commonware-codec"
 version = "2026.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8eb7efe071cea13e8b23a0a7f584398870c401d2b2aabfb6b9ab3634ebcba3a"
+source = "git+https://github.com/commonwarexyz/monorepo.git?rev=5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7#5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -1007,8 +1004,7 @@ dependencies = [
 [[package]]
 name = "commonware-codec-macros"
 version = "2026.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a876bec347344381948901d0f5ec2e9443ebc8dbab99a63bc2db78c2fc2efbdd"
+source = "git+https://github.com/commonwarexyz/monorepo.git?rev=5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7#5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -1019,8 +1015,7 @@ dependencies = [
 [[package]]
 name = "commonware-coding"
 version = "2026.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "409e9997c1bb3273b9570c26ddef4f252327c9bf18968d4439a83cfd1d3e5661"
+source = "git+https://github.com/commonwarexyz/monorepo.git?rev=5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7#5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -1038,8 +1033,7 @@ dependencies = [
 [[package]]
 name = "commonware-consensus"
 version = "2026.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acf15e3402e26f062695d4dd5e4b5967f601dc7303d06b9fafdb20a6485a3a0a"
+source = "git+https://github.com/commonwarexyz/monorepo.git?rev=5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7#5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -1070,8 +1064,7 @@ dependencies = [
 [[package]]
 name = "commonware-cryptography"
 version = "2026.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b842f31e1aaa1af284a1f9dc4f1234761f72d07e70d53cf3f1521b0870ade094"
+source = "git+https://github.com/commonwarexyz/monorepo.git?rev=5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7#5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1112,8 +1105,7 @@ dependencies = [
 [[package]]
 name = "commonware-formatting"
 version = "2026.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab01b7f2798e29b0a4f7b47da5b7f3c106881578af3e69e8d2ee9d89d7c1d4fd"
+source = "git+https://github.com/commonwarexyz/monorepo.git?rev=5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7#5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7"
 dependencies = [
  "commonware-macros",
  "const-hex",
@@ -1122,8 +1114,7 @@ dependencies = [
 [[package]]
 name = "commonware-glue"
 version = "2026.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51acc2739fb44417f638b01401f303dc12216916e073544731dfbdd06e515896"
+source = "git+https://github.com/commonwarexyz/monorepo.git?rev=5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7#5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7"
 dependencies = [
  "bytes",
  "commonware-actor",
@@ -1147,8 +1138,7 @@ dependencies = [
 [[package]]
 name = "commonware-macros"
 version = "2026.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e37a17d5c99ec6711098c6614af1023fd32926aa0414ec0f0613f6bb940278"
+source = "git+https://github.com/commonwarexyz/monorepo.git?rev=5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7#5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7"
 dependencies = [
  "commonware-macros-impl",
  "tokio",
@@ -1157,8 +1147,7 @@ dependencies = [
 [[package]]
 name = "commonware-macros-impl"
 version = "2026.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d44bceee874226efca172f0e9ec9ec4eb486788ba6be1d98710f3f159b807af"
+source = "git+https://github.com/commonwarexyz/monorepo.git?rev=5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7#5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -1170,8 +1159,7 @@ dependencies = [
 [[package]]
 name = "commonware-math"
 version = "2026.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "593fa0c5aa8bd8d350724b9b1ad4e85072845aa85a06b39ca4598998bbec1e00"
+source = "git+https://github.com/commonwarexyz/monorepo.git?rev=5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7#5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -1184,8 +1172,7 @@ dependencies = [
 [[package]]
 name = "commonware-p2p"
 version = "2026.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47f974fcd27c0dad7ae73caeaf00c8330fd29c60f5ff1f679ccc1a51c8ed95bc"
+source = "git+https://github.com/commonwarexyz/monorepo.git?rev=5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7#5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7"
 dependencies = [
  "commonware-actor",
  "commonware-codec",
@@ -1211,8 +1198,7 @@ dependencies = [
 [[package]]
 name = "commonware-parallel"
 version = "2026.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7109817274c671f1fb0ba17cf8aecfbb70672d29379284feeac43fa1b1dc0201"
+source = "git+https://github.com/commonwarexyz/monorepo.git?rev=5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7#5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7"
 dependencies = [
  "cfg-if",
  "commonware-macros",
@@ -1224,8 +1210,7 @@ dependencies = [
 [[package]]
 name = "commonware-resolver"
 version = "2026.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a497cc9e9a2cd205d96474d0d40c7731f29085cd467adbe9ff0f94719659582"
+source = "git+https://github.com/commonwarexyz/monorepo.git?rev=5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7#5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7"
 dependencies = [
  "bytes",
  "commonware-actor",
@@ -1246,8 +1231,7 @@ dependencies = [
 [[package]]
 name = "commonware-runtime"
 version = "2026.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a84bc6cefb099b1ffce3e04705a1e61e91d895b9f09b9e1be14c8ec5823c181"
+source = "git+https://github.com/commonwarexyz/monorepo.git?rev=5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7#5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7"
 dependencies = [
  "ahash",
  "axum",
@@ -1286,8 +1270,7 @@ dependencies = [
 [[package]]
 name = "commonware-runtime-macros"
 version = "2026.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13f7b39ef9fd9f1df4fe4445c9a5ec5ba012d90d1602b12a8b8626a8563ab02c"
+source = "git+https://github.com/commonwarexyz/monorepo.git?rev=5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7#5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -1298,8 +1281,7 @@ dependencies = [
 [[package]]
 name = "commonware-storage"
 version = "2026.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac18e2b696ab7bbecf1059bc3b8d39fc0af002180906d65c7df3112fd9385de"
+source = "git+https://github.com/commonwarexyz/monorepo.git?rev=5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7#5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1323,8 +1305,7 @@ dependencies = [
 [[package]]
 name = "commonware-stream"
 version = "2026.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8890b69e3fa209bc9e87d199ff60ca5a21c88322d32914847511887e6dc5364b"
+source = "git+https://github.com/commonwarexyz/monorepo.git?rev=5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7#5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7"
 dependencies = [
  "chacha20poly1305",
  "commonware-codec",
@@ -1343,8 +1324,7 @@ dependencies = [
 [[package]]
 name = "commonware-utils"
 version = "2026.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a484dd46b738d9b5ba892312425e71e6afaf4320e388d74449bd9ca0ea14cd76"
+source = "git+https://github.com/commonwarexyz/monorepo.git?rev=5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7#5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7"
 dependencies = [
  "ahash",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2649,6 +2649,7 @@ dependencies = [
  "commonware-utils",
  "connectrpc",
  "connectrpc-build",
+ "criterion 0.5.1",
  "exoware-qmdb",
  "exoware-sdk",
  "exoware-server",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,18 +35,18 @@ axum = "0.8.1"
 base64 = "0.22.1"
 hex = "0.4"
 regex = "1"
-commonware-codec = "2026.7.0"
-commonware-actor = "2026.7.0"
-commonware-consensus = "2026.7.0"
-commonware-cryptography = "2026.7.0"
-commonware-glue = "2026.7.0"
-commonware-math = "2026.7.0"
-commonware-parallel = "2026.7.0"
-commonware-p2p = "2026.7.0"
-commonware-resolver = "2026.7.0"
-commonware-runtime = "2026.7.0"
-commonware-storage = "2026.7.0"
-commonware-utils = "2026.7.0"
+commonware-codec = { git = "https://github.com/commonwarexyz/monorepo.git", rev = "5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7" }
+commonware-actor = { git = "https://github.com/commonwarexyz/monorepo.git", rev = "5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7" }
+commonware-consensus = { git = "https://github.com/commonwarexyz/monorepo.git", rev = "5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7" }
+commonware-cryptography = { git = "https://github.com/commonwarexyz/monorepo.git", rev = "5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7" }
+commonware-glue = { git = "https://github.com/commonwarexyz/monorepo.git", rev = "5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7" }
+commonware-math = { git = "https://github.com/commonwarexyz/monorepo.git", rev = "5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7" }
+commonware-parallel = { git = "https://github.com/commonwarexyz/monorepo.git", rev = "5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7" }
+commonware-p2p = { git = "https://github.com/commonwarexyz/monorepo.git", rev = "5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7" }
+commonware-resolver = { git = "https://github.com/commonwarexyz/monorepo.git", rev = "5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7" }
+commonware-runtime = { git = "https://github.com/commonwarexyz/monorepo.git", rev = "5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7" }
+commonware-storage = { git = "https://github.com/commonwarexyz/monorepo.git", rev = "5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7" }
+commonware-utils = { git = "https://github.com/commonwarexyz/monorepo.git", rev = "5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7" }
 rocksdb = "0.24.0"
 mimalloc = "0.1.52"
 rand = "0.10.2"

--- a/integration/tests/multi_instance.rs
+++ b/integration/tests/multi_instance.rs
@@ -157,7 +157,7 @@ async fn commit_qmdb_upload(
     writer: &QmdbWriter,
     ops: &[QmdbOp],
 ) -> Result<exoware_qmdb::UploadReceipt<QmdbFamily>, QmdbError> {
-    let prepared = writer.prepare_upload(ops).await?;
+    let prepared = writer.prepare_upload(ops.to_vec()).await?;
     writer.commit_upload(prepared).await
 }
 
@@ -570,8 +570,8 @@ async fn prepared_sql_and_qmdb_batches_commit_atomically_with_sequence_receipts(
     let ops1 = qops("atomic", 0);
     let ops2 = qops("atomic", 1);
     let (prepared_qmdb_1, prepared_qmdb_2) = tokio::join!(
-        qmdb_writer.prepare_upload(&ops1),
-        qmdb_writer.prepare_upload(&ops2)
+        qmdb_writer.prepare_upload(ops1.clone()),
+        qmdb_writer.prepare_upload(ops2.clone())
     );
     let mut prepared_qmdb_1 = prepared_qmdb_1.expect("prepare qmdb 1");
     let mut prepared_qmdb_2 = prepared_qmdb_2.expect("prepare qmdb 2");

--- a/qmdb/rs/Cargo.toml
+++ b/qmdb/rs/Cargo.toml
@@ -45,9 +45,14 @@ axum = { workspace = true }
 bytes = { workspace = true }
 commonware-glue = { workspace = true }
 commonware-runtime = { workspace = true }
+criterion = { workspace = true }
 exoware-simulator = { path = "../../examples/simulator" }
 exoware-server = { workspace = true }
 hex = { workspace = true }
 reqwest = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
+
+[[bench]]
+name = "writer_merkle"
+harness = false

--- a/qmdb/rs/README.md
+++ b/qmdb/rs/README.md
@@ -460,8 +460,8 @@ not allowed:
 ## Writers
 
 Each backend exposes a `*Writer` helper for sole-writer ingest. Writers hold
-cached Merkle peaks + a pending-batch queue in memory; `prepare_upload` reserves
-writer state and encodes store rows with zero store reads in the hot loop.
+cached Merkle peaks + a pending-batch queue in memory. `prepare_upload` encodes
+store rows with zero store reads in the hot loop.
 Construction always starts from caller-supplied frontier state. Multiple
 `prepare_upload` calls may be issued concurrently against the same writer; the
 writer handles location assignment, in-flight pipelining, and contiguous
@@ -469,6 +469,9 @@ watermark publication internally. Callers own the enclosing `StoreWriteBatch`:
 stage prepared uploads and prepared watermark publications from one or more
 instances, commit once, then mark each prepared handle persisted with the
 returned Store sequence number.
+
+Operation batches are passed by value. This lets preparation yield while it
+encodes and hashes the batch.
 
 The generic Store traits cover the prepared-handle lifecycle:
 
@@ -497,7 +500,7 @@ let writer: Arc<KeylessWriter<mmr::Family, Sha256, Vec<u8>>> =
     Arc::new(KeylessWriter::new(client.clone(), WriterState::empty()));
 
 // Sequential single-instance usage still goes through an explicit Store batch.
-let prepared = writer.prepare_upload(&batch_ops).await?;
+let prepared = writer.prepare_upload(batch_ops).await?;
 let receipt = writer.commit_upload(prepared).await?;
 
 // Pipelined usage — prepare/commit concurrent Store batches up to a bounded depth.
@@ -509,7 +512,7 @@ for batch in batches {
     }
     let w = writer.clone();
     in_flight.push(Box::pin(async move {
-        let prepared = w.prepare_upload(&batch).await?;
+        let prepared = w.prepare_upload(batch).await?;
         w.commit_upload(prepared).await
     }));
 }

--- a/qmdb/rs/benches/writer_merkle.rs
+++ b/qmdb/rs/benches/writer_merkle.rs
@@ -1,0 +1,122 @@
+use std::num::NonZeroUsize;
+use std::time::Duration;
+
+use commonware_cryptography::{sha256::Digest, Sha256};
+use commonware_parallel::{Rayon, Sequential, Strategy};
+use commonware_storage::merkle::{mmr, Location, Position};
+use commonware_storage::qmdb::{any::value::VariableEncoding, keyless::variable::Operation};
+use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion, Throughput};
+use exoware_qmdb::{build_keyless_upload, build_keyless_upload_with_strategy};
+
+type Family = mmr::Family;
+type Value = Vec<u8>;
+type Encoding = VariableEncoding<Value>;
+type BatchOperation = Operation<Family, Value>;
+
+struct Frontier {
+    peaks: Vec<(Position<Family>, u32, Digest)>,
+    size: Position<Family>,
+    next_location: Location<Family>,
+}
+
+fn operations(count: usize, value_size: usize) -> Vec<BatchOperation> {
+    assert!(count > 0);
+
+    let mut operations = Vec::with_capacity(count);
+    for index in 0..count - 1 {
+        let mut value = vec![0u8; value_size];
+        value[..8].copy_from_slice(&(index as u64).to_be_bytes());
+        operations.push(BatchOperation::Append(value));
+    }
+    operations.push(BatchOperation::Commit(None, Location::new(0)));
+    operations
+}
+
+fn frontier() -> Frontier {
+    let operations = operations(1_024, 64);
+    let latest_location = Location::new(operations.len() as u64 - 1);
+    let built = build_keyless_upload::<Family, Sha256, Value, Encoding>(
+        Vec::new(),
+        Position::new(0),
+        latest_location,
+        &operations,
+        None,
+    )
+    .expect("build benchmark frontier");
+
+    Frontier {
+        peaks: built.new_peaks,
+        size: built.new_ops_size,
+        next_location: latest_location + 1,
+    }
+}
+
+fn bench_strategy<S: Strategy>(
+    bencher: &mut criterion::Bencher<'_>,
+    frontier: &Frontier,
+    operations: &[BatchOperation],
+    strategy: &S,
+) {
+    let latest_location = frontier.next_location + operations.len() as u64 - 1;
+    bencher.iter_batched(
+        || frontier.peaks.clone(),
+        |peaks| {
+            build_keyless_upload_with_strategy::<Family, Sha256, Value, Encoding, S>(
+                peaks,
+                frontier.size,
+                latest_location,
+                operations,
+                None,
+                strategy,
+            )
+            .expect("build benchmark batch")
+        },
+        BatchSize::SmallInput,
+    );
+}
+
+fn writer_merkle(criterion: &mut Criterion) {
+    let frontier = frontier();
+    let available = std::thread::available_parallelism()
+        .map(NonZeroUsize::get)
+        .unwrap_or(1);
+    let mut worker_counts = vec![1, 2, 4, 8, available];
+    worker_counts.retain(|workers| *workers <= available);
+    worker_counts.sort_unstable();
+    worker_counts.dedup();
+
+    let mut group = criterion.benchmark_group("qmdb_writer_merkle");
+    group.sample_size(10);
+    group.warm_up_time(Duration::from_secs(3));
+    group.measurement_time(Duration::from_secs(20));
+
+    for count in [100_000usize, 196_000, 256_000] {
+        let operations = operations(count, 64);
+        group.throughput(Throughput::Elements(count as u64));
+        group.bench_with_input(
+            BenchmarkId::new("sequential", count),
+            &operations,
+            |bencher, operations| {
+                bench_strategy(bencher, &frontier, operations, &Sequential);
+            },
+        );
+
+        for workers in &worker_counts {
+            let strategy = Rayon::new(NonZeroUsize::new(*workers).expect("non-zero workers"))
+                .expect("construct Rayon strategy")
+                .manual();
+            group.bench_with_input(
+                BenchmarkId::new(format!("rayon-{workers}"), count),
+                &operations,
+                |bencher, operations| {
+                    bench_strategy(bencher, &frontier, operations, &strategy);
+                },
+            );
+        }
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, writer_merkle);
+criterion_main!(benches);

--- a/qmdb/rs/src/bin/qmdb.rs
+++ b/qmdb/rs/src/bin/qmdb.rs
@@ -74,7 +74,10 @@ async fn commit_ordered_upload(
     ops: &[QmdbOperation<DemoFamily, Vec<u8>, Vec<u8>>],
     boundary: &CurrentBoundaryState<commonware_cryptography::sha256::Digest, N, DemoFamily>,
 ) {
-    let prepared = writer.prepare_upload(ops, boundary).await.expect("prepare");
+    let prepared = writer
+        .prepare_upload(ops.to_vec(), boundary.clone())
+        .await
+        .expect("prepare");
     writer.commit_upload(prepared).await.expect("commit upload");
 }
 

--- a/qmdb/rs/src/core.rs
+++ b/qmdb/rs/src/core.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 
 use commonware_codec::{Codec, Encode};
 use commonware_cryptography::{Digest, Hasher};
+use commonware_parallel::Strategy;
 use commonware_storage::merkle::{
     hasher::Hasher as MerkleHasher, mem::Mem, Family, Graftable, Location, Position,
 };
@@ -478,29 +479,44 @@ pub(crate) struct MerkleExtension<F: Family, D: Digest> {
     pub(crate) new_nodes: Vec<(Position<F>, D)>,
 }
 
-pub(crate) fn extend_merkle_from_peaks<F: Family, H: Hasher, Op: AsRef<[u8]>>(
+pub(crate) fn extend_merkle_from_peaks<F, H, S, I>(
     peaks: Vec<(Position<F>, u32, H::Digest)>,
     previous_size: Position<F>,
-    encoded_operations: impl IntoIterator<Item = Op>,
-) -> Result<MerkleExtension<F, H::Digest>, QmdbError> {
-    extend_merkle_from_peaks_with_inactive_peaks::<F, H, _>(
+    encoded_operations: I,
+    strategy: &S,
+) -> Result<MerkleExtension<F, H::Digest>, QmdbError>
+where
+    F: Family,
+    H: Hasher,
+    S: Strategy,
+    I: IntoIterator + Send,
+    I::Item: AsRef<[u8]> + Send,
+    I::IntoIter: Send,
+{
+    extend_merkle_from_peaks_with_inactive_peaks::<F, H, S, I>(
         peaks,
         previous_size,
         encoded_operations,
         0,
+        strategy,
     )
 }
 
-pub(crate) fn extend_merkle_from_peaks_with_inactive_peaks<
-    F: Family,
-    H: Hasher,
-    Op: AsRef<[u8]>,
->(
+pub(crate) fn extend_merkle_from_peaks_with_inactive_peaks<F, H, S, I>(
     peaks: Vec<(Position<F>, u32, H::Digest)>,
     previous_size: Position<F>,
-    encoded_operations: impl IntoIterator<Item = Op>,
+    encoded_operations: I,
     inactive_peaks: usize,
-) -> Result<MerkleExtension<F, H::Digest>, QmdbError> {
+    strategy: &S,
+) -> Result<MerkleExtension<F, H::Digest>, QmdbError>
+where
+    F: Family,
+    H: Hasher,
+    S: Strategy,
+    I: IntoIterator + Send,
+    I::Item: AsRef<[u8]> + Send,
+    I::IntoIter: Send,
+{
     let previous_leaves = Location::<F>::try_from(previous_size)
         .map_err(|e| QmdbError::CorruptData(format!("invalid incremental ops size: {e}")))?;
     let mut peak_map: std::collections::BTreeMap<Position<F>, (u32, H::Digest)> = peaks
@@ -528,33 +544,57 @@ pub(crate) fn extend_merkle_from_peaks_with_inactive_peaks<
         )));
     }
 
-    extend_merkle_from_pinned_nodes::<F, H, _>(
+    extend_merkle_from_pinned_nodes::<F, H, S, I>(
         pinned_nodes,
         previous_leaves,
         encoded_operations,
         inactive_peaks,
+        strategy,
     )
 }
 
-pub(crate) fn extend_merkle_from_pinned_nodes<F: Family, H: Hasher, Op: AsRef<[u8]>>(
+pub(crate) fn extend_merkle_from_pinned_nodes<F, H, S, I>(
     pinned_nodes: Vec<H::Digest>,
     pruning_boundary: Location<F>,
-    encoded_operations: impl IntoIterator<Item = Op>,
+    encoded_operations: I,
     inactive_peaks: usize,
-) -> Result<MerkleExtension<F, H::Digest>, QmdbError> {
+    strategy: &S,
+) -> Result<MerkleExtension<F, H::Digest>, QmdbError>
+where
+    F: Family,
+    H: Hasher,
+    S: Strategy,
+    I: IntoIterator + Send,
+    I::Item: AsRef<[u8]> + Send,
+    I::IntoIter: Send,
+{
     let previous_size = Position::try_from(pruning_boundary)
         .map_err(|e| QmdbError::CorruptData(format!("invalid incremental ops size {e}")))?;
 
     let hasher = commonware_storage::qmdb::hasher::<H>();
     let mem = Mem::<F, H::Digest>::from_components(Vec::new(), pruning_boundary, pinned_nodes)
         .map_err(|e| QmdbError::CommonwareMerkle(e.to_string()))?;
-    let mut batch = mem.new_batch();
-    for encoded in encoded_operations {
-        let encoded = encoded.as_ref();
-        ensure_encoded_value_size(encoded.len())?;
-        batch = batch.add(&hasher, encoded);
-    }
+    let leaf_digests = strategy.try_map_collect_vec(
+        encoded_operations.into_iter().enumerate(),
+        |(offset, encoded)| {
+            let encoded = encoded.as_ref();
+            ensure_encoded_value_size(encoded.len())?;
+            let offset = u64::try_from(offset)
+                .map_err(|_| QmdbError::CorruptData("operation offset exceeds u64".into()))?;
+            let location = pruning_boundary
+                .checked_add(offset)
+                .ok_or_else(|| QmdbError::CorruptData("operation location overflow".into()))?;
+            let position = Position::try_from(location).map_err(|e| {
+                QmdbError::CorruptData(format!("invalid operation location {location}. {e}"))
+            })?;
+            Ok::<_, QmdbError>(hasher.leaf_digest(position, encoded))
+        },
+    )?;
 
+    let batch = leaf_digests.into_iter().fold(
+        mem.new_batch_with_strategy(strategy.clone()),
+        |batch, digest| batch.add_leaf_digest(digest),
+    );
     let batch = batch.merkleize(&mem, &hasher);
     let size = batch.size();
     let new_nodes = (*previous_size..*size)
@@ -592,7 +632,61 @@ pub(crate) fn extend_merkle_from_pinned_nodes<F: Family, H: Hasher, Op: AsRef<[u
 mod tests {
     use super::*;
     use commonware_cryptography::Sha256;
-    use commonware_storage::merkle::mmr;
+    use commonware_parallel::{Rayon, Sequential};
+    use commonware_storage::merkle::{mmb, mmr};
+    use std::num::NonZeroUsize;
+
+    fn assert_parallel_extension_matches<F: Family>() {
+        let prefix = (0u64..17)
+            .map(|i| format!("prefix-{i}").into_bytes())
+            .collect::<Vec<_>>();
+        let suffix = (0u64..257)
+            .map(|i| format!("suffix-{i}").into_bytes())
+            .collect::<Vec<_>>();
+        let base = extend_merkle_from_peaks::<F, Sha256, Sequential, _>(
+            Vec::new(),
+            Position::new(0),
+            prefix.iter().map(Vec::as_slice),
+            &Sequential,
+        )
+        .expect("build resumed frontier");
+        assert!(!base.peaks.is_empty());
+
+        let sequential = extend_merkle_from_peaks_with_inactive_peaks::<F, Sha256, Sequential, _>(
+            base.peaks.clone(),
+            base.size,
+            suffix.iter().map(Vec::as_slice),
+            1,
+            &Sequential,
+        )
+        .expect("extend sequentially");
+        let parallel_strategy = Rayon::new(NonZeroUsize::new(4).expect("nonzero thread count"))
+            .expect("build rayon strategy")
+            .manual();
+        let parallel = extend_merkle_from_peaks_with_inactive_peaks::<F, Sha256, _, _>(
+            base.peaks,
+            base.size,
+            suffix.iter().map(Vec::as_slice),
+            1,
+            &parallel_strategy,
+        )
+        .expect("extend in parallel");
+
+        assert_eq!(parallel.size, sequential.size);
+        assert_eq!(parallel.peaks, sequential.peaks);
+        assert_eq!(parallel.root, sequential.root);
+        assert_eq!(parallel.new_nodes, sequential.new_nodes);
+    }
+
+    #[test]
+    fn parallel_merkle_extension_matches_sequential_mmr() {
+        assert_parallel_extension_matches::<mmr::Family>();
+    }
+
+    #[test]
+    fn parallel_merkle_extension_matches_sequential_mmb() {
+        assert_parallel_extension_matches::<mmb::Family>();
+    }
 
     #[test]
     fn current_boundary_upload_keys_grafted_nodes_by_grafted_space_position() {

--- a/qmdb/rs/src/core.rs
+++ b/qmdb/rs/src/core.rs
@@ -591,10 +591,9 @@ where
         },
     )?;
 
-    let batch = leaf_digests.into_iter().fold(
-        mem.new_batch_with_strategy(strategy.clone()),
-        |batch, digest| batch.add_leaf_digest(digest),
-    );
+    let batch = mem
+        .new_batch_with_strategy(strategy.clone())
+        .add_leaf_digests(leaf_digests);
     let batch = batch.merkleize(&mem, &hasher);
     let size = batch.size();
     let new_nodes = (*previous_size..*size)

--- a/qmdb/rs/src/immutable.rs
+++ b/qmdb/rs/src/immutable.rs
@@ -2,6 +2,7 @@ use std::marker::PhantomData;
 
 use commonware_codec::{Codec, Decode, Encode, Read as CodecRead};
 use commonware_cryptography::Hasher;
+use commonware_parallel::Strategy;
 use commonware_storage::{
     merkle::{Family, Graftable, Location},
     qmdb::{
@@ -121,6 +122,21 @@ where
             |watermark, start_location, max_locations| {
                 self.operation_range_checkpoint(watermark, start_location, max_locations)
             },
+        )
+        .await
+    }
+
+    /// Recover writer state using `strategy` for Merkle hashing.
+    pub async fn recover_writer_state_with_strategy<S: Strategy>(
+        &self,
+        strategy: &S,
+    ) -> Result<WriterState<H::Digest, F>, QmdbError> {
+        crate::recover_writer_state_with_strategy::<F, H, S, _, _>(
+            self.writer_location_watermark().await?,
+            |watermark, start_location, max_locations| {
+                self.operation_range_checkpoint(watermark, start_location, max_locations)
+            },
+            strategy,
         )
         .await
     }

--- a/qmdb/rs/src/keyless.rs
+++ b/qmdb/rs/src/keyless.rs
@@ -2,6 +2,7 @@ use std::marker::PhantomData;
 
 use commonware_codec::{Codec, Decode, Encode, Read as CodecRead};
 use commonware_cryptography::Hasher;
+use commonware_parallel::Strategy;
 use commonware_storage::{
     merkle::{Family, Graftable, Location},
     qmdb::{
@@ -113,6 +114,21 @@ where
             |watermark, start_location, max_locations| {
                 self.operation_range_checkpoint(watermark, start_location, max_locations)
             },
+        )
+        .await
+    }
+
+    /// Recover writer state using `strategy` for Merkle hashing.
+    pub async fn recover_writer_state_with_strategy<S: Strategy>(
+        &self,
+        strategy: &S,
+    ) -> Result<WriterState<H::Digest, F>, QmdbError> {
+        crate::recover_writer_state_with_strategy::<F, H, S, _, _>(
+            self.writer_location_watermark().await?,
+            |watermark, start_location, max_locations| {
+                self.operation_range_checkpoint(watermark, start_location, max_locations)
+            },
+            strategy,
         )
         .await
     }

--- a/qmdb/rs/src/lib.rs
+++ b/qmdb/rs/src/lib.rs
@@ -59,10 +59,11 @@ pub use proof::{
 };
 pub use unordered::UnorderedClient;
 pub use writer::{
-    build_immutable_upload, build_keyless_upload, build_ordered_upload, build_unordered_upload,
-    BuiltImmutableUpload, BuiltKeylessUpload, BuiltOrderedUpload, BuiltUnorderedUpload,
-    ImmutableWriter, KeylessWriter, OrderedWriter, PreparedUpload, PreparedWatermark,
-    UnorderedWriter,
+    build_immutable_upload, build_immutable_upload_with_strategy, build_keyless_upload,
+    build_keyless_upload_with_strategy, build_ordered_upload, build_ordered_upload_with_strategy,
+    build_unordered_upload, build_unordered_upload_with_strategy, BuiltImmutableUpload,
+    BuiltKeylessUpload, BuiltOrderedUpload, BuiltUnorderedUpload, ImmutableWriter, KeylessWriter,
+    OrderedWriter, PreparedUpload, PreparedWatermark, UnorderedWriter,
 };
 
 pub use boundary::recover_boundary_state;
@@ -79,6 +80,7 @@ pub use connect_client::{
 
 use commonware_codec::Encode;
 use commonware_cryptography::{Digest, Hasher};
+use commonware_parallel::{Sequential, Strategy};
 use commonware_storage::merkle::{self, Family, Graftable, Location, Position, Proof};
 use commonware_storage::qmdb::current::proof::OpsRootWitness;
 
@@ -153,8 +155,21 @@ impl<D: Digest, F: Family> WriterState<D, F> {
     where
         F: Graftable,
     {
+        Self::from_checkpoint_with_strategy::<H, Sequential>(checkpoint, &Sequential)
+    }
+
+    /// Reconstruct writer state using `strategy` for Merkle hashing.
+    pub fn from_checkpoint_with_strategy<H, S>(
+        checkpoint: &OperationRangeCheckpoint<D, F>,
+        strategy: &S,
+    ) -> Result<Self, QmdbError>
+    where
+        F: Graftable,
+        H: Hasher<Digest = D>,
+        S: Strategy,
+    {
         Ok(Self {
-            peaks: checkpoint.reconstruct_peaks::<H>()?,
+            peaks: checkpoint.reconstruct_peaks_with_strategy::<H, S>(strategy)?,
             ops_size: Position::try_from(checkpoint.proof.leaves).map_err(|e| {
                 QmdbError::CorruptData(format!("invalid checkpoint leaf count: {e}"))
             })?,
@@ -175,6 +190,28 @@ impl<D: Digest, F: Family> WriterState<D, F> {
         H: Hasher<Digest = D>,
         Op: Encode,
     {
+        Self::from_proof_with_strategy::<H, Sequential, Op>(
+            watermark,
+            start_location,
+            proof,
+            operations,
+            &Sequential,
+        )
+    }
+
+    /// Reconstruct writer state using `strategy` for Merkle hashing.
+    pub fn from_proof_with_strategy<H, S, Op>(
+        watermark: Location<F>,
+        start_location: Location<F>,
+        proof: &Proof<F, D>,
+        operations: &[Op],
+        strategy: &S,
+    ) -> Result<Self, QmdbError>
+    where
+        H: Hasher<Digest = D>,
+        S: Strategy,
+        Op: Encode,
+    {
         let encoded_operations: Vec<Vec<u8>> =
             operations.iter().map(|op| op.encode().to_vec()).collect();
         if start_location != Location::new(0)
@@ -186,10 +223,11 @@ impl<D: Digest, F: Family> WriterState<D, F> {
         }
         let ops_size = Position::try_from(proof.leaves)
             .map_err(|e| QmdbError::CorruptData(format!("invalid proof leaf count: {e}")))?;
-        let extension = crate::core::extend_merkle_from_peaks::<F, H, _>(
+        let extension = crate::core::extend_merkle_from_peaks::<F, H, S, _>(
             Vec::new(),
             Position::new(0),
             encoded_operations.iter().map(Vec::as_slice),
+            strategy,
         )?;
         if extension.size != ops_size {
             return Err(QmdbError::CorruptData(format!(
@@ -217,12 +255,28 @@ where
     Fetch: FnOnce(Location<F>, Location<F>, u32) -> Fut,
     Fut: std::future::Future<Output = Result<OperationRangeCheckpoint<H::Digest, F>, QmdbError>>,
 {
+    recover_writer_state_with_strategy::<F, H, Sequential, _, _>(watermark, fetch, &Sequential)
+        .await
+}
+
+async fn recover_writer_state_with_strategy<F, H, S, Fetch, Fut>(
+    watermark: Option<Location<F>>,
+    fetch: Fetch,
+    strategy: &S,
+) -> Result<WriterState<H::Digest, F>, QmdbError>
+where
+    F: Graftable,
+    H: Hasher,
+    S: Strategy,
+    Fetch: FnOnce(Location<F>, Location<F>, u32) -> Fut,
+    Fut: std::future::Future<Output = Result<OperationRangeCheckpoint<H::Digest, F>, QmdbError>>,
+{
     let Some(watermark) = watermark else {
         return Ok(WriterState::empty());
     };
 
     let checkpoint = fetch(watermark, watermark, 1).await?;
-    WriterState::from_checkpoint::<H>(&checkpoint)
+    WriterState::from_checkpoint_with_strategy::<H, S>(&checkpoint, strategy)
 }
 
 #[cfg(test)]

--- a/qmdb/rs/src/lib.rs
+++ b/qmdb/rs/src/lib.rs
@@ -212,6 +212,16 @@ impl<D: Digest, F: Family> WriterState<D, F> {
         S: Strategy,
         Op: Encode,
     {
+        let next_location = watermark.checked_add(1).ok_or_else(|| {
+            QmdbError::CorruptData("proof watermark exceeds the location domain".into())
+        })?;
+        if next_location != proof.leaves {
+            return Err(QmdbError::CorruptData(format!(
+                "proof watermark implies {next_location} leaves, proof has {}",
+                proof.leaves
+            )));
+        }
+
         let encoded_operations: Vec<Vec<u8>> =
             operations.iter().map(|op| op.encode().to_vec()).collect();
         if start_location != Location::new(0)
@@ -238,9 +248,7 @@ impl<D: Digest, F: Family> WriterState<D, F> {
         Ok(Self {
             peaks: extension.peaks,
             ops_size,
-            next_location: watermark
-                .checked_add(1)
-                .ok_or_else(|| QmdbError::CorruptData("proof watermark overflow".into()))?,
+            next_location,
         })
     }
 }

--- a/qmdb/rs/src/ordered.rs
+++ b/qmdb/rs/src/ordered.rs
@@ -4,6 +4,7 @@ use std::marker::PhantomData;
 use bytes::Bytes;
 use commonware_codec::{Codec, Decode, DecodeExt, Encode};
 use commonware_cryptography::Hasher;
+use commonware_parallel::Strategy;
 use commonware_storage::{
     merkle::{Family, Graftable, Location},
     qmdb::{
@@ -223,6 +224,21 @@ where
             |watermark, start_location, max_locations| {
                 self.operation_range_checkpoint(watermark, start_location, max_locations)
             },
+        )
+        .await
+    }
+
+    /// Recover writer state using `strategy` for Merkle hashing.
+    pub async fn recover_writer_state_with_strategy<S: Strategy>(
+        &self,
+        strategy: &S,
+    ) -> Result<WriterState<H::Digest, F>, QmdbError> {
+        crate::recover_writer_state_with_strategy::<F, H, S, _, _>(
+            self.writer_location_watermark().await?,
+            |watermark, start_location, max_locations| {
+                self.operation_range_checkpoint(watermark, start_location, max_locations)
+            },
+            strategy,
         )
         .await
     }

--- a/qmdb/rs/src/proof.rs
+++ b/qmdb/rs/src/proof.rs
@@ -1,6 +1,7 @@
 use bytes::Bytes;
 use commonware_codec::{Codec, Encode};
 use commonware_cryptography::{Digest, Hasher};
+use commonware_parallel::{Sequential, Strategy};
 use commonware_storage::{
     merkle::{
         self, storage::Storage as MerkleStorage, Family, Graftable, Location, Position, Proof,
@@ -58,6 +59,18 @@ impl<D: Digest, F: Graftable> OperationRangeCheckpoint<D, F> {
     pub fn reconstruct_peaks<H: Hasher<Digest = D>>(
         &self,
     ) -> Result<Vec<(Position<F>, u32, D)>, QmdbError> {
+        self.reconstruct_peaks_with_strategy::<H, Sequential>(&Sequential)
+    }
+
+    /// Reconstruct the writer frontier using `strategy` for Merkle hashing.
+    pub fn reconstruct_peaks_with_strategy<H, S>(
+        &self,
+        strategy: &S,
+    ) -> Result<Vec<(Position<F>, u32, D)>, QmdbError>
+    where
+        H: Hasher<Digest = D>,
+        S: Strategy,
+    {
         let size = Position::try_from(self.proof.leaves)
             .map_err(|e| QmdbError::CorruptData(format!("invalid checkpoint leaf count: {e}")))?;
 
@@ -90,11 +103,12 @@ impl<D: Digest, F: Graftable> OperationRangeCheckpoint<D, F> {
             ));
         }
 
-        let extension = crate::core::extend_merkle_from_pinned_nodes::<F, H, _>(
+        let extension = crate::core::extend_merkle_from_pinned_nodes::<F, H, S, _>(
             self.pinned_nodes.clone(),
             self.start_location,
             self.encoded_operations.iter().map(Vec::as_slice),
             self.proof.inactive_peaks,
+            strategy,
         )?;
         if extension.size != size {
             return Err(QmdbError::CorruptData(format!(

--- a/qmdb/rs/src/unordered.rs
+++ b/qmdb/rs/src/unordered.rs
@@ -3,6 +3,7 @@ use std::marker::PhantomData;
 
 use commonware_codec::{Codec, Decode, DecodeExt, Encode};
 use commonware_cryptography::Hasher;
+use commonware_parallel::Strategy;
 use commonware_storage::merkle::{Graftable, Location};
 use commonware_storage::qmdb::{
     any::{
@@ -213,6 +214,21 @@ where
             |watermark, start_location, max_locations| {
                 self.operation_range_checkpoint(watermark, start_location, max_locations)
             },
+        )
+        .await
+    }
+
+    /// Recover writer state using `strategy` for Merkle hashing.
+    pub async fn recover_writer_state_with_strategy<S: Strategy>(
+        &self,
+        strategy: &S,
+    ) -> Result<WriterState<H::Digest, F>, QmdbError> {
+        crate::recover_writer_state_with_strategy::<F, H, S, _, _>(
+            self.writer_location_watermark().await?,
+            |watermark, start_location, max_locations| {
+                self.operation_range_checkpoint(watermark, start_location, max_locations)
+            },
+            strategy,
         )
         .await
     }

--- a/qmdb/rs/src/writer/core.rs
+++ b/qmdb/rs/src/writer/core.rs
@@ -24,6 +24,7 @@ use std::collections::VecDeque;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use commonware_cryptography::Digest;
+use commonware_parallel::Strategy;
 use commonware_storage::merkle::{Family, Location, Position};
 use tokio::sync::{Mutex, Notify};
 
@@ -74,8 +75,9 @@ pub(crate) enum State<D: Digest, F: Family> {
     },
 }
 
-pub(crate) struct WriterCore<D: Digest, F: Family> {
+pub(crate) struct WriterCore<D: Digest, F: Family, S: Strategy> {
     state: Mutex<State<D, F>>,
+    strategy: S,
     /// Monotonic counter of `advance` calls — also the next dispatch_id.
     dispatched: AtomicU64,
     /// Monotonic counter of `ack_success` + `ack_failure` calls. Used only
@@ -115,10 +117,11 @@ pub(crate) struct PreparedDispatch<F: Family, R> {
     pub latest_location: Location<F>,
 }
 
-impl<D: Digest, F: Family> WriterCore<D, F> {
-    pub(crate) fn from_cache(cache: Cache<D, F>) -> Self {
+impl<D: Digest, F: Family, S: Strategy> WriterCore<D, F, S> {
+    pub(crate) fn from_cache(cache: Cache<D, F>, strategy: S) -> Self {
         Self {
             state: Mutex::new(State::Ready(cache)),
+            strategy,
             dispatched: AtomicU64::new(0),
             acked: AtomicU64::new(0),
             ack_notify: Notify::new(),
@@ -138,7 +141,7 @@ impl<D: Digest, F: Family> WriterCore<D, F> {
     pub(crate) async fn prepare<R>(
         &self,
         ops_len: u64,
-        build: impl FnOnce(BuildContext<D, F>) -> Result<BuildResult<D, F, R>, QmdbError>,
+        build: impl FnOnce(BuildContext<D, F>, &S) -> Result<BuildResult<D, F, R>, QmdbError>,
     ) -> Result<PreparedDispatch<F, R>, QmdbError> {
         let mut state = self.state.lock().await;
         let cache = match &mut *state {
@@ -171,7 +174,7 @@ impl<D: Digest, F: Family> WriterCore<D, F> {
             latest_location,
             watermark_at,
         };
-        let result = build(ctx)?;
+        let result = build(ctx, &self.strategy)?;
 
         let dispatch_id = self.dispatched.fetch_add(1, Ordering::SeqCst);
         cache.peaks = result.new_peaks;
@@ -389,19 +392,23 @@ impl<D: Digest, F: Family> Cache<D, F> {
 mod tests {
     use super::*;
     use commonware_cryptography::sha256::Digest as Sha256Digest;
+    use commonware_parallel::Sequential;
     use commonware_storage::merkle::mmr;
 
-    fn fresh_core() -> WriterCore<Sha256Digest, mmr::Family> {
-        WriterCore::from_cache(Cache {
-            peaks: Vec::new(),
-            ops_size: Position::new(0),
-            next_location: Location::new(0),
-            latest_published: None,
-            latest_committed_published: None,
-            latest_dispatched: None,
-            pending: VecDeque::new(),
-            latest_contiguous_acked: None,
-        })
+    fn fresh_core() -> WriterCore<Sha256Digest, mmr::Family, Sequential> {
+        WriterCore::from_cache(
+            Cache {
+                peaks: Vec::new(),
+                ops_size: Position::new(0),
+                next_location: Location::new(0),
+                latest_published: None,
+                latest_committed_published: None,
+                latest_dispatched: None,
+                pending: VecDeque::new(),
+                latest_contiguous_acked: None,
+            },
+            Sequential,
+        )
     }
 
     // `await_drain` must complete once `acked >= dispatched`, even when the
@@ -449,6 +456,7 @@ mod tests {
 
     fn passthrough_build(
         ctx: BuildContext<Sha256Digest, mmr::Family>,
+        _strategy: &Sequential,
     ) -> Result<BuildResult<Sha256Digest, mmr::Family, ()>, QmdbError> {
         Ok(BuildResult {
             new_peaks: ctx.peaks,
@@ -459,14 +467,14 @@ mod tests {
 
     #[tokio::test]
     async fn restored_writer_state_reports_committed_watermark_immediately() {
-        let core = WriterCore::from_cache(Cache::from_writer_state(WriterState::<
-            Sha256Digest,
-            mmr::Family,
-        > {
-            peaks: Vec::new(),
-            ops_size: Position::new(8),
-            next_location: loc(8),
-        }));
+        let core = WriterCore::from_cache(
+            Cache::from_writer_state(WriterState::<Sha256Digest, mmr::Family> {
+                peaks: Vec::new(),
+                ops_size: Position::new(8),
+                next_location: loc(8),
+            }),
+            Sequential,
+        );
         assert_eq!(core.latest_published().await, Some(loc(7)));
     }
 
@@ -581,14 +589,14 @@ mod tests {
 
     #[tokio::test]
     async fn seeded_state_flush_path_only_needs_one_tail_publication() {
-        let core = WriterCore::from_cache(Cache::from_writer_state(WriterState::<
-            Sha256Digest,
-            mmr::Family,
-        > {
-            peaks: Vec::new(),
-            ops_size: Position::new(8),
-            next_location: loc(8),
-        }));
+        let core = WriterCore::from_cache(
+            Cache::from_writer_state(WriterState::<Sha256Digest, mmr::Family> {
+                peaks: Vec::new(),
+                ops_size: Position::new(8),
+                next_location: loc(8),
+            }),
+            Sequential,
+        );
 
         let first = core
             .prepare(1, passthrough_build)
@@ -628,7 +636,7 @@ mod tests {
 
     #[tokio::test]
     async fn poisoned_writer_reports_last_committed_not_speculative_watermark() {
-        let core = WriterCore::from_cache(ready_cache(loc(8), Some(loc(7))));
+        let core = WriterCore::from_cache(ready_cache(loc(8), Some(loc(7))), Sequential);
 
         let prepared = core.prepare(1, passthrough_build).await.expect("prepare");
         assert_eq!(

--- a/qmdb/rs/src/writer/core.rs
+++ b/qmdb/rs/src/writer/core.rs
@@ -147,7 +147,7 @@ impl<D: Digest, F: Family, S: Strategy> WriterCore<D, F, S> {
         }
     }
 
-    /// Serialize frontier builds without holding the state mutex during CPU
+    /// Serialize builds without holding the state mutex during CPU
     /// work. State changes only after a successful build, so cancellation or
     /// poisoning leaves the previous frontier intact.
     pub(crate) async fn prepare<R>(

--- a/qmdb/rs/src/writer/core.rs
+++ b/qmdb/rs/src/writer/core.rs
@@ -77,6 +77,9 @@ pub(crate) enum State<D: Digest, F: Family> {
 
 pub(crate) struct WriterCore<D: Digest, F: Family, S: Strategy> {
     state: Mutex<State<D, F>>,
+    /// Serializes live frontier builds so each starts from its predecessor's
+    /// peaks. A cancelled CPU job may finish later but cannot mutate state.
+    build_gate: Mutex<()>,
     strategy: S,
     /// Monotonic counter of `advance` calls — also the next dispatch_id.
     dispatched: AtomicU64,
@@ -117,10 +120,27 @@ pub(crate) struct PreparedDispatch<F: Family, R> {
     pub latest_location: Location<F>,
 }
 
+fn newest_checkpoint<F: Family>(
+    current: Option<PublishedCheckpoint<F>>,
+    candidate: PublishedCheckpoint<F>,
+) -> PublishedCheckpoint<F> {
+    match current {
+        Some(current)
+            if current.location > candidate.location
+                || (current.location == candidate.location
+                    && current.sequence_number >= candidate.sequence_number) =>
+        {
+            current
+        }
+        _ => candidate,
+    }
+}
+
 impl<D: Digest, F: Family, S: Strategy> WriterCore<D, F, S> {
     pub(crate) fn from_cache(cache: Cache<D, F>, strategy: S) -> Self {
         Self {
             state: Mutex::new(State::Ready(cache)),
+            build_gate: Mutex::new(()),
             strategy,
             dispatched: AtomicU64::new(0),
             acked: AtomicU64::new(0),
@@ -128,61 +148,80 @@ impl<D: Digest, F: Family, S: Strategy> WriterCore<D, F, S> {
         }
     }
 
-    /// Atomically reserve a batch slot, run the variant-specific `build`
-    /// closure under the state mutex, and commit the resulting Merkle delta to
-    /// the cache — all in one locked step. This is what prevents the
-    /// `dispatch_id` race: because the cache (peaks, size, next_location,
-    /// pending) is updated inside the same lock that `build` runs under, no
-    /// concurrent `prepare` call can observe stale pre-batch state.
-    ///
-    /// Build phase is therefore serialized across pipelined uploads, but the
-    /// PUT dispatch itself happens AFTER `prepare` returns (i.e. outside the
-    /// lock), so network round-trips still pipeline freely.
+    /// Serialize frontier builds without holding the state mutex during CPU
+    /// work. State changes only after a successful build, so cancellation or
+    /// poisoning leaves the previous frontier intact.
     pub(crate) async fn prepare<R>(
         &self,
         ops_len: u64,
-        build: impl FnOnce(BuildContext<D, F>, &S) -> Result<BuildResult<D, F, R>, QmdbError>,
-    ) -> Result<PreparedDispatch<F, R>, QmdbError> {
+        build: impl FnOnce(BuildContext<D, F>, S) -> Result<BuildResult<D, F, R>, QmdbError>
+            + Send
+            + 'static,
+    ) -> Result<PreparedDispatch<F, R>, QmdbError>
+    where
+        R: Send + 'static,
+    {
+        if ops_len == 0 {
+            return Err(QmdbError::EmptyBatch);
+        }
+
+        let _build_slot = self.build_gate.lock().await;
+
+        let ctx = {
+            let mut state = self.state.lock().await;
+            let cache = match &mut *state {
+                State::Ready(c) => c,
+                State::Uninit => unreachable!("writer core is always constructed with state"),
+                State::Poisoned { msg, .. } => return Err(QmdbError::WriterPoisoned(msg.clone())),
+            };
+            let latest_location = cache
+                .next_location
+                .checked_add(ops_len - 1)
+                .ok_or_else(|| QmdbError::CorruptData("next_location overflow".to_string()))?;
+
+            // Safe watermark:
+            // - Pipeline empty: our own latest_location (we're the only in-flight PUT).
+            // - Pipeline non-empty: latest_contiguous_acked (last fully-acked prefix location).
+            // - Don't re-publish what's already out.
+            let candidate = if cache.pending.is_empty() {
+                Some(latest_location)
+            } else {
+                cache.latest_contiguous_acked
+            };
+            let watermark_at = candidate.filter(|c| cache.latest_published.is_none_or(|p| *c > p));
+
+            BuildContext {
+                peaks: cache.peaks.clone(),
+                ops_size: cache.ops_size,
+                latest_location,
+                watermark_at,
+            }
+        };
+        let latest_location = ctx.latest_location;
+        let watermark_at = ctx.watermark_at;
+
+        let result = self
+            .strategy
+            .spawn(move |strategy| build(ctx, strategy))
+            .await?;
+
         let mut state = self.state.lock().await;
         let cache = match &mut *state {
             State::Ready(c) => c,
             State::Uninit => unreachable!("writer core is always constructed with state"),
             State::Poisoned { msg, .. } => return Err(QmdbError::WriterPoisoned(msg.clone())),
         };
-        if ops_len == 0 {
-            return Err(QmdbError::EmptyBatch);
-        }
-        let latest_location = cache
-            .next_location
-            .checked_add(ops_len - 1)
-            .ok_or_else(|| QmdbError::CorruptData("next_location overflow".to_string()))?;
-
-        // Safe watermark:
-        // - Pipeline empty: our own latest_location (we're the only in-flight PUT).
-        // - Pipeline non-empty: latest_contiguous_acked (last fully-acked prefix location).
-        // - Don't re-publish what's already out.
-        let candidate = if cache.pending.is_empty() {
-            Some(latest_location)
-        } else {
-            cache.latest_contiguous_acked
-        };
-        let watermark_at = candidate.filter(|c| cache.latest_published.is_none_or(|p| *c > p));
-
-        let ctx = BuildContext {
-            peaks: cache.peaks.clone(),
-            ops_size: cache.ops_size,
-            latest_location,
-            watermark_at,
-        };
-        let result = build(ctx, &self.strategy)?;
-
         let dispatch_id = self.dispatched.fetch_add(1, Ordering::SeqCst);
         cache.peaks = result.new_peaks;
         cache.ops_size = result.new_ops_size;
         cache.next_location = latest_location + 1;
         cache.latest_dispatched = Some(latest_location);
+
+        // Flush can advance the watermark while the build runs.
         if let Some(wm) = watermark_at {
-            cache.latest_published = Some(wm);
+            if cache.latest_published.is_none_or(|p| wm > p) {
+                cache.latest_published = Some(wm);
+            }
         }
         cache.pending.push_back(PendingBatch {
             id: dispatch_id,
@@ -219,11 +258,10 @@ impl<D: Digest, F: Family, S: Strategy> WriterCore<D, F, S> {
                             location: wm,
                             sequence_number,
                         };
-                        cache.latest_committed_published =
-                            Some(match cache.latest_committed_published {
-                                Some(cur) if cur.location > checkpoint.location => cur,
-                                _ => checkpoint,
-                            });
+                        cache.latest_committed_published = Some(newest_checkpoint(
+                            cache.latest_committed_published,
+                            checkpoint,
+                        ));
                     }
                     matched = true;
                 }
@@ -343,11 +381,15 @@ impl<D: Digest, F: Family, S: Strategy> WriterCore<D, F, S> {
     ) {
         let mut state = self.state.lock().await;
         if let State::Ready(c) = &mut *state {
-            c.latest_published = Some(location);
-            c.latest_committed_published = Some(PublishedCheckpoint {
+            if c.latest_published.is_none_or(|current| location > current) {
+                c.latest_published = Some(location);
+            }
+            let checkpoint = PublishedCheckpoint {
                 location,
                 sequence_number,
-            });
+            };
+            c.latest_committed_published =
+                Some(newest_checkpoint(c.latest_committed_published, checkpoint));
         }
     }
 
@@ -390,9 +432,13 @@ impl<D: Digest, F: Family> Cache<D, F> {
 
 #[cfg(test)]
 mod tests {
+    use std::num::NonZeroUsize;
+    use std::sync::{mpsc, Arc};
+    use std::time::Duration;
+
     use super::*;
     use commonware_cryptography::sha256::Digest as Sha256Digest;
-    use commonware_parallel::Sequential;
+    use commonware_parallel::{Rayon, Sequential};
     use commonware_storage::merkle::mmr;
 
     fn fresh_core() -> WriterCore<Sha256Digest, mmr::Family, Sequential> {
@@ -456,7 +502,24 @@ mod tests {
 
     fn passthrough_build(
         ctx: BuildContext<Sha256Digest, mmr::Family>,
-        _strategy: &Sequential,
+        _strategy: Sequential,
+    ) -> Result<BuildResult<Sha256Digest, mmr::Family, ()>, QmdbError> {
+        Ok(BuildResult {
+            new_peaks: ctx.peaks,
+            new_ops_size: ctx.ops_size,
+            output: (),
+        })
+    }
+
+    fn rayon_core() -> WriterCore<Sha256Digest, mmr::Family, Rayon> {
+        let strategy =
+            Rayon::new(NonZeroUsize::new(2).expect("non-zero")).expect("construct Rayon strategy");
+        WriterCore::from_cache(ready_cache(loc(0), None), strategy)
+    }
+
+    fn rayon_passthrough_build(
+        ctx: BuildContext<Sha256Digest, mmr::Family>,
+        _strategy: Rayon,
     ) -> Result<BuildResult<Sha256Digest, mmr::Family, ()>, QmdbError> {
         Ok(BuildResult {
             new_peaks: ctx.peaks,
@@ -635,6 +698,66 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn stale_flush_completion_does_not_regress_published_checkpoint() {
+        let core = fresh_core();
+        let first = core
+            .prepare(1, passthrough_build)
+            .await
+            .expect("prepare first");
+        let second = core
+            .prepare(1, passthrough_build)
+            .await
+            .expect("prepare second");
+        let third = core
+            .prepare(1, passthrough_build)
+            .await
+            .expect("prepare third");
+
+        core.ack_success(first.dispatch_id, 10).await;
+        core.ack_success(second.dispatch_id, 11).await;
+        let stale_flush = core
+            .pending_watermark()
+            .await
+            .expect("prepare stale flush")
+            .expect("stale flush target");
+        assert_eq!(stale_flush, loc(1));
+
+        core.ack_success(third.dispatch_id, 12).await;
+        let fourth = core
+            .prepare(1, passthrough_build)
+            .await
+            .expect("prepare fourth");
+        assert_eq!(fourth.watermark_at, Some(loc(3)));
+        core.ack_success(fourth.dispatch_id, 13).await;
+
+        core.mark_watermark_published(stale_flush, 14).await;
+        assert_eq!(core.latest_published().await, Some(loc(3)));
+        assert_eq!(
+            core.latest_published_checkpoint().await,
+            Some(PublishedCheckpoint {
+                location: loc(3),
+                sequence_number: 13,
+            })
+        );
+
+        core.mark_watermark_published(loc(3), 12).await;
+        assert_eq!(
+            core.latest_published_checkpoint()
+                .await
+                .map(|checkpoint| checkpoint.sequence_number),
+            Some(13)
+        );
+
+        core.mark_watermark_published(loc(3), 15).await;
+        assert_eq!(
+            core.latest_published_checkpoint()
+                .await
+                .map(|checkpoint| checkpoint.sequence_number),
+            Some(15)
+        );
+    }
+
+    #[tokio::test]
     async fn poisoned_writer_reports_last_committed_not_speculative_watermark() {
         let core = WriterCore::from_cache(ready_cache(loc(8), Some(loc(7))), Sequential);
 
@@ -655,6 +778,184 @@ mod tests {
             core.latest_published().await,
             Some(loc(7)),
             "poisoned recovery helper must not expose the speculative watermark from the failed PUT",
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn cancelled_build_does_not_reserve_frontier_state() {
+        let core = Arc::new(rayon_core());
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+        let (finished_tx, finished_rx) = tokio::sync::oneshot::channel();
+
+        let build_core = core.clone();
+        let build = tokio::spawn(async move {
+            build_core
+                .prepare(1, move |ctx, _strategy| {
+                    started_tx.send(()).expect("report build start");
+                    release_rx.recv().expect("release cancelled build");
+                    finished_tx.send(()).expect("report build completion");
+                    Ok(BuildResult {
+                        new_peaks: ctx.peaks,
+                        new_ops_size: ctx.ops_size,
+                        output: (),
+                    })
+                })
+                .await
+        });
+
+        started_rx.await.expect("build started");
+        let watermark = tokio::time::timeout(Duration::from_secs(1), core.latest_published())
+            .await
+            .expect("watermark read waited for CPU work");
+        assert_eq!(watermark, None);
+
+        build.abort();
+        let join_error = match build.await {
+            Ok(_) => panic!("build task was not cancelled"),
+            Err(error) => error,
+        };
+        assert!(join_error.is_cancelled());
+
+        let prepared = tokio::time::timeout(
+            Duration::from_secs(1),
+            core.prepare(1, rayon_passthrough_build),
+        )
+        .await
+        .expect("replacement prepare waited for cancelled CPU work")
+        .expect("prepare replacement");
+        assert_eq!(prepared.dispatch_id, 0);
+        assert_eq!(prepared.latest_location, loc(0));
+
+        release_tx.send(()).expect("release cancelled build");
+        finished_rx.await.expect("cancelled CPU work finished");
+
+        let state = core.state.lock().await;
+        let cache = match &*state {
+            State::Ready(cache) => cache,
+            other => panic!("unexpected writer state: {other:?}"),
+        };
+        assert_eq!(cache.next_location, loc(1));
+        assert_eq!(cache.pending.len(), 1);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn concurrent_builds_commit_frontiers_in_prepare_order() {
+        let core = Arc::new(rayon_core());
+        let (first_started_tx, first_started_rx) = tokio::sync::oneshot::channel();
+        let (release_first_tx, release_first_rx) = mpsc::channel();
+
+        let first_core = core.clone();
+        let first = tokio::spawn(async move {
+            first_core
+                .prepare(1, move |ctx, _strategy| {
+                    first_started_tx.send(()).expect("report first start");
+                    release_first_rx.recv().expect("release first build");
+                    let latest_location = ctx.latest_location;
+                    Ok(BuildResult {
+                        new_peaks: ctx.peaks,
+                        new_ops_size: ctx.ops_size,
+                        output: latest_location,
+                    })
+                })
+                .await
+        });
+        first_started_rx.await.expect("first build started");
+
+        let (second_entered_tx, second_entered_rx) = tokio::sync::oneshot::channel();
+        let (second_started_tx, mut second_started_rx) = tokio::sync::oneshot::channel();
+        let second_core = core.clone();
+        let second = tokio::spawn(async move {
+            second_entered_tx.send(()).expect("report second prepare");
+            second_core
+                .prepare(1, move |ctx, _strategy| {
+                    second_started_tx.send(()).expect("report second start");
+                    let latest_location = ctx.latest_location;
+                    Ok(BuildResult {
+                        new_peaks: ctx.peaks,
+                        new_ops_size: ctx.ops_size,
+                        output: latest_location,
+                    })
+                })
+                .await
+        });
+        second_entered_rx.await.expect("second prepare started");
+
+        assert!(
+            tokio::time::timeout(Duration::from_millis(25), &mut second_started_rx)
+                .await
+                .is_err(),
+            "second build started from an uncommitted frontier"
+        );
+
+        release_first_tx.send(()).expect("release first build");
+        tokio::time::timeout(Duration::from_secs(1), &mut second_started_rx)
+            .await
+            .expect("second build did not start")
+            .expect("report second start");
+
+        let first = first
+            .await
+            .expect("first task")
+            .expect("prepare first batch");
+        let second = second
+            .await
+            .expect("second task")
+            .expect("prepare second batch");
+        assert_eq!(first.dispatch_id, 0);
+        assert_eq!(first.latest_location, loc(0));
+        assert_eq!(first.output, loc(0));
+        assert_eq!(second.dispatch_id, 1);
+        assert_eq!(second.latest_location, loc(1));
+        assert_eq!(second.output, loc(1));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn poisoned_writer_discards_inflight_build() {
+        let core = Arc::new(rayon_core());
+        let first = core
+            .prepare(1, rayon_passthrough_build)
+            .await
+            .expect("prepare first batch");
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+
+        let build_core = core.clone();
+        let build = tokio::spawn(async move {
+            build_core
+                .prepare(1, move |ctx, _strategy| {
+                    started_tx.send(()).expect("report build start");
+                    release_rx.recv().expect("release build");
+                    Ok(BuildResult {
+                        new_peaks: ctx.peaks,
+                        new_ops_size: ctx.ops_size,
+                        output: (),
+                    })
+                })
+                .await
+        });
+
+        started_rx.await.expect("build started");
+        core.ack_failure("first upload failed".to_string()).await;
+        release_tx.send(()).expect("release build");
+
+        let error = match build.await.expect("build task") {
+            Ok(_) => panic!("poisoned build committed"),
+            Err(error) => error,
+        };
+        assert!(matches!(error, QmdbError::WriterPoisoned(_)));
+        assert_eq!(core.dispatched.load(Ordering::SeqCst), 1);
+
+        let state = core.state.lock().await;
+        let cache = match &*state {
+            State::Poisoned { cache, .. } => cache,
+            other => panic!("unexpected writer state: {other:?}"),
+        };
+        assert_eq!(cache.next_location, loc(1));
+        assert_eq!(cache.pending.len(), 1);
+        assert_eq!(
+            cache.pending.front().map(|pending| pending.id),
+            Some(first.dispatch_id)
         );
     }
 }

--- a/qmdb/rs/src/writer/core.rs
+++ b/qmdb/rs/src/writer/core.rs
@@ -45,7 +45,6 @@ pub(crate) struct Cache<D: Digest, F: Family> {
     /// successful `flush()` watermark PUT). Recovery helpers must report this
     /// value, not the speculative `latest_published`.
     pub latest_committed_published: Option<PublishedCheckpoint<F>>,
-    pub latest_dispatched: Option<Location<F>>,
     /// Dispatched-but-not-yet-ACKd batches, in dispatch order. Per-batch
     /// `acked` lets us handle out-of-order ACKs correctly: we only advance
     /// `latest_contiguous_acked` when the FRONT of the queue has ACKd (and
@@ -215,8 +214,6 @@ impl<D: Digest, F: Family, S: Strategy> WriterCore<D, F, S> {
         cache.peaks = result.new_peaks;
         cache.ops_size = result.new_ops_size;
         cache.next_location = latest_location + 1;
-        cache.latest_dispatched = Some(latest_location);
-
         // Flush can advance the watermark while the build runs.
         if let Some(wm) = watermark_at {
             if cache.latest_published.is_none_or(|p| wm > p) {
@@ -423,7 +420,6 @@ impl<D: Digest, F: Family> Cache<D, F> {
             next_location: state.next_location,
             latest_published: latest_committed,
             latest_committed_published,
-            latest_dispatched: None,
             pending: VecDeque::new(),
             latest_contiguous_acked: latest_committed,
         }
@@ -449,7 +445,6 @@ mod tests {
                 next_location: Location::new(0),
                 latest_published: None,
                 latest_committed_published: None,
-                latest_dispatched: None,
                 pending: VecDeque::new(),
                 latest_contiguous_acked: None,
             },
@@ -494,7 +489,6 @@ mod tests {
                 location,
                 sequence_number: 0,
             }),
-            latest_dispatched: latest_published,
             pending: VecDeque::new(),
             latest_contiguous_acked: latest_published,
         }

--- a/qmdb/rs/src/writer/immutable.rs
+++ b/qmdb/rs/src/writer/immutable.rs
@@ -5,6 +5,7 @@ use std::marker::PhantomData;
 
 use commonware_codec::{Codec, Decode, Encode};
 use commonware_cryptography::Hasher;
+use commonware_parallel::{Sequential, Strategy};
 use commonware_storage::merkle::{Family, Location, Position};
 use commonware_storage::qmdb::{
     any::value::{ValueEncoding, VariableEncoding},
@@ -52,16 +53,45 @@ where
     E: ValueEncoding<Value = V>,
     immutable::Operation<F, K, E>: Encode,
 {
+    build_immutable_upload_with_strategy::<F, H, K, V, E, Sequential>(
+        peaks,
+        prev_ops_size,
+        latest_location,
+        ops,
+        watermark_at,
+        &Sequential,
+    )
+}
+
+/// Strategy-aware form of [`build_immutable_upload`].
+pub fn build_immutable_upload_with_strategy<F, H, K, V, E, S>(
+    peaks: Vec<(Position<F>, u32, H::Digest)>,
+    prev_ops_size: Position<F>,
+    latest_location: Location<F>,
+    ops: &[immutable::Operation<F, K, E>],
+    watermark_at: Option<Location<F>>,
+    strategy: &S,
+) -> Result<BuiltImmutableUpload<H::Digest, F>, QmdbError>
+where
+    F: Family,
+    H: Hasher,
+    K: Array + Codec + Clone + AsRef<[u8]>,
+    V: Codec + Clone + Send + Sync,
+    E: ValueEncoding<Value = V>,
+    S: Strategy,
+    immutable::Operation<F, K, E>: Encode,
+{
     if ops.is_empty() {
         return Err(QmdbError::EmptyBatch);
     }
     let prepared = build_auth_immutable_upload_rows(latest_location, ops)?;
     let inactive_peaks = immutable_inactive_peaks(latest_location, ops)?;
-    let ext = extend_merkle_from_peaks_with_inactive_peaks::<F, H, _>(
+    let ext = extend_merkle_from_peaks_with_inactive_peaks::<F, H, S, _>(
         peaks,
         prev_ops_size,
         prepared.op_bytes(),
         inactive_peaks,
+        strategy,
     )?;
     let keyed_operation_count = prepared.keyed_operation_count;
     let mut rows = prepared.into_all_rows();
@@ -113,13 +143,14 @@ pub struct ImmutableWriter<
     K: Array + Codec,
     V: Codec + Clone + Send + Sync,
     E: ValueEncoding<Value = V> = VariableEncoding<V>,
+    S: Strategy = Sequential,
 > {
     client: PrefixedStoreClient,
-    core: WriterCore<H::Digest, F>,
+    core: WriterCore<H::Digest, F, S>,
     _marker: PhantomData<(F, K, E)>,
 }
 
-impl<F, H, K, V, E> ImmutableWriter<F, H, K, V, E>
+impl<F, H, K, V, E, S> ImmutableWriter<F, H, K, V, E, S>
 where
     F: Family,
     H: Hasher,
@@ -128,22 +159,27 @@ where
     V::Cfg: Clone,
     K::Cfg: Clone,
     E: ValueEncoding<Value = V>,
+    S: Strategy,
     immutable::Operation<F, K, E>: Encode + Decode + Clone,
 {
     /// Construct a writer over `client`'s namespace prefix from caller-supplied
     /// frontier state (no store I/O).
-    pub fn new(client: PrefixedStoreClient, state: WriterState<H::Digest, F>) -> Self {
+    pub fn new_with_strategy(
+        client: PrefixedStoreClient,
+        state: WriterState<H::Digest, F>,
+        strategy: S,
+    ) -> Self {
         Self {
             client,
-            core: WriterCore::from_cache(Cache::from_writer_state(state)),
+            core: WriterCore::from_cache(Cache::from_writer_state(state), strategy),
             _marker: PhantomData,
         }
     }
 
     /// Construct a fresh writer over `client`'s namespace prefix with empty
     /// frontier state (no prior published checkpoint).
-    pub fn fresh(client: PrefixedStoreClient) -> Self {
-        Self::new(client, WriterState::empty())
+    pub fn fresh_with_strategy(client: PrefixedStoreClient, strategy: S) -> Self {
+        Self::new_with_strategy(client, WriterState::empty(), strategy)
     }
 
     pub async fn latest_published_watermark(&self) -> Option<Location<F>> {
@@ -160,13 +196,14 @@ where
     ) -> Result<super::PreparedUpload<F>, QmdbError> {
         let prepared = self
             .core
-            .prepare(ops.len() as u64, |ctx| {
-                let built = build_immutable_upload::<F, H, K, V, E>(
+            .prepare(ops.len() as u64, |ctx, strategy| {
+                let built = build_immutable_upload_with_strategy::<F, H, K, V, E, S>(
                     ctx.peaks,
                     ctx.ops_size,
                     ctx.latest_location,
                     ops,
                     ctx.watermark_at,
+                    strategy,
                 )?;
                 Ok(crate::writer::core::BuildResult {
                     new_peaks: built.new_peaks,
@@ -280,20 +317,45 @@ where
     }
 }
 
-impl<F, H, K, V, E> std::fmt::Debug for ImmutableWriter<F, H, K, V, E>
+impl<F, H, K, V, E> ImmutableWriter<F, H, K, V, E, Sequential>
+where
+    F: Family,
+    H: Hasher,
+    K: Array + Codec + Clone + AsRef<[u8]>,
+    V: Codec + Clone + Send + Sync,
+    V::Cfg: Clone,
+    K::Cfg: Clone,
+    E: ValueEncoding<Value = V>,
+    immutable::Operation<F, K, E>: Encode + Decode + Clone,
+{
+    /// Construct a writer over `client`'s namespace prefix from caller-supplied
+    /// frontier state (no store I/O).
+    pub fn new(client: PrefixedStoreClient, state: WriterState<H::Digest, F>) -> Self {
+        Self::new_with_strategy(client, state, Sequential)
+    }
+
+    /// Construct a fresh writer over `client`'s namespace prefix with empty
+    /// frontier state (no prior published checkpoint).
+    pub fn fresh(client: PrefixedStoreClient) -> Self {
+        Self::fresh_with_strategy(client, Sequential)
+    }
+}
+
+impl<F, H, K, V, E, S> std::fmt::Debug for ImmutableWriter<F, H, K, V, E, S>
 where
     F: Family,
     H: Hasher,
     K: Array + Codec,
     V: Codec + Clone + Send + Sync,
     E: ValueEncoding<Value = V>,
+    S: Strategy,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ImmutableWriter").finish_non_exhaustive()
     }
 }
 
-impl<F, H, K, V, E> StoreBatchUpload for ImmutableWriter<F, H, K, V, E>
+impl<F, H, K, V, E, S> StoreBatchUpload for ImmutableWriter<F, H, K, V, E, S>
 where
     F: Family,
     H: Hasher + Sync,
@@ -302,6 +364,7 @@ where
     V::Cfg: Clone,
     K::Cfg: Clone,
     E: ValueEncoding<Value = V> + Sync,
+    S: Strategy,
     immutable::Operation<F, K, E>: Encode + Decode + Clone,
 {
     type Prepared = super::PreparedUpload<F>;
@@ -353,7 +416,7 @@ where
     }
 }
 
-impl<F, H, K, V, E> StoreBatchPublication for ImmutableWriter<F, H, K, V, E>
+impl<F, H, K, V, E, S> StoreBatchPublication for ImmutableWriter<F, H, K, V, E, S>
 where
     F: Family,
     H: Hasher + Sync,
@@ -362,6 +425,7 @@ where
     V::Cfg: Clone,
     K::Cfg: Clone,
     E: ValueEncoding<Value = V> + Sync,
+    S: Strategy,
     immutable::Operation<F, K, E>: Encode + Decode + Clone,
 {
     type PreparedPublication = super::PreparedWatermark<F>;
@@ -399,7 +463,7 @@ where
     }
 }
 
-impl<F, H, K, V, E> StorePublicationFrontierWriter for ImmutableWriter<F, H, K, V, E>
+impl<F, H, K, V, E, S> StorePublicationFrontierWriter for ImmutableWriter<F, H, K, V, E, S>
 where
     F: Family,
     H: Hasher + Sync,
@@ -408,6 +472,7 @@ where
     V::Cfg: Clone,
     K::Cfg: Clone,
     E: ValueEncoding<Value = V> + Sync,
+    S: Strategy,
     immutable::Operation<F, K, E>: Encode + Decode + Clone,
 {
     fn latest_publication_receipt<'a>(&'a self) -> BoxFuture<'a, Option<PublishedCheckpoint<F>>>
@@ -433,5 +498,63 @@ where
         Self: Sync + 'a,
     {
         Box::pin(async move { ImmutableWriter::flush_with_receipt(self).await })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use commonware_cryptography::Sha256;
+    use commonware_parallel::Rayon;
+    use commonware_storage::merkle::mmr;
+    use commonware_utils::sequence::FixedBytes;
+    use std::num::NonZeroUsize;
+
+    type TestEncoding = VariableEncoding<Vec<u8>>;
+    type TestOp = immutable::Operation<mmr::Family, FixedBytes<32>, TestEncoding>;
+
+    #[test]
+    fn sequential_and_parallel_builds_match() {
+        let ops = vec![
+            TestOp::Set(FixedBytes::new([1; 32]), b"one".to_vec()),
+            TestOp::Set(FixedBytes::new([2; 32]), b"two".to_vec()),
+            TestOp::Commit(None, Location::new(0)),
+        ];
+        let sequential =
+            build_immutable_upload::<mmr::Family, Sha256, FixedBytes<32>, Vec<u8>, TestEncoding>(
+                Vec::new(),
+                Position::new(0),
+                Location::new(2),
+                &ops,
+                Some(Location::new(2)),
+            )
+            .expect("sequential");
+        let strategy = Rayon::new(NonZeroUsize::new(2).expect("non-zero threads"))
+            .expect("construct Rayon strategy")
+            .manual();
+        let parallel = build_immutable_upload_with_strategy::<
+            mmr::Family,
+            Sha256,
+            FixedBytes<32>,
+            Vec<u8>,
+            TestEncoding,
+            _,
+        >(
+            Vec::new(),
+            Position::new(0),
+            Location::new(2),
+            &ops,
+            Some(Location::new(2)),
+            &strategy,
+        )
+        .expect("parallel");
+        assert_eq!(sequential.rows, parallel.rows);
+        assert_eq!(sequential.new_peaks, parallel.new_peaks);
+        assert_eq!(sequential.new_ops_size, parallel.new_ops_size);
+        assert_eq!(sequential.new_root, parallel.new_root);
+        assert_eq!(
+            sequential.keyed_operation_count,
+            parallel.keyed_operation_count
+        );
     }
 }

--- a/qmdb/rs/src/writer/immutable.rs
+++ b/qmdb/rs/src/writer/immutable.rs
@@ -192,18 +192,18 @@ where
 
     pub async fn prepare_upload(
         &self,
-        ops: &[immutable::Operation<F, K, E>],
+        ops: Vec<immutable::Operation<F, K, E>>,
     ) -> Result<super::PreparedUpload<F>, QmdbError> {
         let prepared = self
             .core
-            .prepare(ops.len() as u64, |ctx, strategy| {
+            .prepare(ops.len() as u64, move |ctx, strategy| {
                 let built = build_immutable_upload_with_strategy::<F, H, K, V, E, S>(
                     ctx.peaks,
                     ctx.ops_size,
                     ctx.latest_location,
-                    ops,
+                    &ops,
                     ctx.watermark_at,
-                    strategy,
+                    &strategy,
                 )?;
                 Ok(crate::writer::core::BuildResult {
                     new_peaks: built.new_peaks,

--- a/qmdb/rs/src/writer/keyless.rs
+++ b/qmdb/rs/src/writer/keyless.rs
@@ -4,6 +4,7 @@ use std::marker::PhantomData;
 
 use commonware_codec::{Codec, Encode};
 use commonware_cryptography::Hasher;
+use commonware_parallel::{Sequential, Strategy};
 use commonware_storage::merkle::{Family, Location, Position};
 use commonware_storage::qmdb::{
     any::value::{ValueEncoding, VariableEncoding},
@@ -56,17 +57,45 @@ where
     E: ValueEncoding<Value = V>,
     keyless::Operation<F, E>: Encode,
 {
+    build_keyless_upload_with_strategy::<F, H, V, E, Sequential>(
+        peaks,
+        prev_ops_size,
+        latest_location,
+        ops,
+        watermark_at,
+        &Sequential,
+    )
+}
+
+/// Strategy-aware form of [`build_keyless_upload`].
+pub fn build_keyless_upload_with_strategy<F, H, V, E, S>(
+    peaks: Vec<(Position<F>, u32, H::Digest)>,
+    prev_ops_size: Position<F>,
+    latest_location: Location<F>,
+    ops: &[keyless::Operation<F, E>],
+    watermark_at: Option<Location<F>>,
+    strategy: &S,
+) -> Result<BuiltKeylessUpload<H::Digest, F>, QmdbError>
+where
+    F: Family,
+    H: Hasher,
+    V: Codec + Clone + Send + Sync,
+    E: ValueEncoding<Value = V>,
+    S: Strategy,
+    keyless::Operation<F, E>: Encode,
+{
     if ops.is_empty() {
         return Err(QmdbError::EmptyBatch);
     }
     let encoded: Vec<Vec<u8>> = ops.iter().map(|op| op.encode().to_vec()).collect();
     let prepared = build_auth_upload_rows(latest_location, encoded)?;
     let inactive_peaks = keyless_inactive_peaks(latest_location, ops)?;
-    let ext = extend_merkle_from_peaks_with_inactive_peaks::<F, H, _>(
+    let ext = extend_merkle_from_peaks_with_inactive_peaks::<F, H, S, _>(
         peaks,
         prev_ops_size,
         prepared.op_bytes(),
         inactive_peaks,
+        strategy,
     )?;
     let operation_count = prepared.operation_count;
     let mut rows = prepared.into_all_rows();
@@ -150,34 +179,40 @@ pub struct KeylessWriter<
     H: Hasher,
     V: Codec + Clone + Send + Sync,
     E: ValueEncoding<Value = V> = VariableEncoding<V>,
+    S: Strategy = Sequential,
 > {
     client: PrefixedStoreClient,
-    core: WriterCore<H::Digest, F>,
+    core: WriterCore<H::Digest, F, S>,
     _marker: PhantomData<(F, E)>,
 }
 
-impl<F, H, V, E> KeylessWriter<F, H, V, E>
+impl<F, H, V, E, S> KeylessWriter<F, H, V, E, S>
 where
     F: Family,
     H: Hasher,
     V: Codec + Clone + Send + Sync,
     E: ValueEncoding<Value = V>,
+    S: Strategy,
     keyless::Operation<F, E>: Encode,
 {
     /// Construct a writer over `client`'s namespace prefix from caller-supplied
     /// frontier state (no store I/O).
-    pub fn new(client: PrefixedStoreClient, state: WriterState<H::Digest, F>) -> Self {
+    pub fn new_with_strategy(
+        client: PrefixedStoreClient,
+        state: WriterState<H::Digest, F>,
+        strategy: S,
+    ) -> Self {
         Self {
             client,
-            core: WriterCore::from_cache(Cache::from_writer_state(state)),
+            core: WriterCore::from_cache(Cache::from_writer_state(state), strategy),
             _marker: PhantomData,
         }
     }
 
     /// Construct a fresh writer over `client`'s namespace prefix with empty
     /// frontier state (no prior published checkpoint).
-    pub fn fresh(client: PrefixedStoreClient) -> Self {
-        Self::new(client, WriterState::empty())
+    pub fn fresh_with_strategy(client: PrefixedStoreClient, strategy: S) -> Self {
+        Self::new_with_strategy(client, WriterState::empty(), strategy)
     }
 
     pub async fn latest_published_watermark(&self) -> Option<Location<F>> {
@@ -194,13 +229,14 @@ where
     ) -> Result<super::PreparedUpload<F>, QmdbError> {
         let prepared = self
             .core
-            .prepare(ops.len() as u64, |ctx| {
-                let built = build_keyless_upload::<F, H, V, E>(
+            .prepare(ops.len() as u64, |ctx, strategy| {
+                let built = build_keyless_upload_with_strategy::<F, H, V, E, S>(
                     ctx.peaks,
                     ctx.ops_size,
                     ctx.latest_location,
                     ops,
                     ctx.watermark_at,
+                    strategy,
                 )?;
                 Ok(crate::writer::core::BuildResult {
                     new_peaks: built.new_peaks,
@@ -314,24 +350,47 @@ where
     }
 }
 
-impl<F, H, V, E> std::fmt::Debug for KeylessWriter<F, H, V, E>
+impl<F, H, V, E> KeylessWriter<F, H, V, E, Sequential>
 where
     F: Family,
     H: Hasher,
     V: Codec + Clone + Send + Sync,
     E: ValueEncoding<Value = V>,
+    keyless::Operation<F, E>: Encode,
+{
+    /// Construct a writer over `client`'s namespace prefix from caller-supplied
+    /// frontier state (no store I/O).
+    pub fn new(client: PrefixedStoreClient, state: WriterState<H::Digest, F>) -> Self {
+        Self::new_with_strategy(client, state, Sequential)
+    }
+
+    /// Construct a fresh writer over `client`'s namespace prefix with empty
+    /// frontier state (no prior published checkpoint).
+    pub fn fresh(client: PrefixedStoreClient) -> Self {
+        Self::fresh_with_strategy(client, Sequential)
+    }
+}
+
+impl<F, H, V, E, S> std::fmt::Debug for KeylessWriter<F, H, V, E, S>
+where
+    F: Family,
+    H: Hasher,
+    V: Codec + Clone + Send + Sync,
+    E: ValueEncoding<Value = V>,
+    S: Strategy,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("KeylessWriter").finish_non_exhaustive()
     }
 }
 
-impl<F, H, V, E> StoreBatchUpload for KeylessWriter<F, H, V, E>
+impl<F, H, V, E, S> StoreBatchUpload for KeylessWriter<F, H, V, E, S>
 where
     F: Family,
     H: Hasher + Sync,
     V: Codec + Clone + Send + Sync,
     E: ValueEncoding<Value = V> + Sync,
+    S: Strategy,
     keyless::Operation<F, E>: Encode,
 {
     type Prepared = super::PreparedUpload<F>;
@@ -383,12 +442,13 @@ where
     }
 }
 
-impl<F, H, V, E> StoreBatchPublication for KeylessWriter<F, H, V, E>
+impl<F, H, V, E, S> StoreBatchPublication for KeylessWriter<F, H, V, E, S>
 where
     F: Family,
     H: Hasher + Sync,
     V: Codec + Clone + Send + Sync,
     E: ValueEncoding<Value = V> + Sync,
+    S: Strategy,
     keyless::Operation<F, E>: Encode,
 {
     type PreparedPublication = super::PreparedWatermark<F>;
@@ -426,12 +486,13 @@ where
     }
 }
 
-impl<F, H, V, E> StorePublicationFrontierWriter for KeylessWriter<F, H, V, E>
+impl<F, H, V, E, S> StorePublicationFrontierWriter for KeylessWriter<F, H, V, E, S>
 where
     F: Family,
     H: Hasher + Sync,
     V: Codec + Clone + Send + Sync,
     E: ValueEncoding<Value = V> + Sync,
+    S: Strategy,
     keyless::Operation<F, E>: Encode,
 {
     fn latest_publication_receipt<'a>(&'a self) -> BoxFuture<'a, Option<PublishedCheckpoint<F>>>
@@ -464,7 +525,9 @@ where
 mod tests {
     use super::*;
     use commonware_cryptography::Sha256;
+    use commonware_parallel::Rayon;
     use commonware_storage::merkle::mmr;
+    use std::num::NonZeroUsize;
 
     type TestEncoding = VariableEncoding<Vec<u8>>;
     type TestOp = keyless::Operation<mmr::Family, TestEncoding>;
@@ -517,28 +580,33 @@ mod tests {
     }
 
     #[test]
-    fn build_is_deterministic_on_same_inputs() {
+    fn sequential_and_parallel_builds_match() {
         let ops = vec![op(b"a"), op(b"b"), op(b"c"), op(b"d"), commit(0)];
-        let a = build_keyless_upload::<mmr::Family, Sha256, Vec<u8>, TestEncoding>(
+        let sequential = build_keyless_upload::<mmr::Family, Sha256, Vec<u8>, TestEncoding>(
             Vec::new(),
             Position::new(0),
             Location::new(4),
             &ops,
             Some(Location::new(4)),
         )
-        .expect("a");
-        let b = build_keyless_upload::<mmr::Family, Sha256, Vec<u8>, TestEncoding>(
-            Vec::new(),
-            Position::new(0),
-            Location::new(4),
-            &ops,
-            Some(Location::new(4)),
-        )
-        .expect("b");
-        assert_eq!(a.rows, b.rows);
-        assert_eq!(a.new_peaks, b.new_peaks);
-        assert_eq!(a.new_ops_size, b.new_ops_size);
-        assert_eq!(a.new_root, b.new_root);
+        .expect("sequential");
+        let strategy = Rayon::new(NonZeroUsize::new(2).expect("non-zero threads"))
+            .expect("construct Rayon strategy")
+            .manual();
+        let parallel =
+            build_keyless_upload_with_strategy::<mmr::Family, Sha256, Vec<u8>, TestEncoding, _>(
+                Vec::new(),
+                Position::new(0),
+                Location::new(4),
+                &ops,
+                Some(Location::new(4)),
+                &strategy,
+            )
+            .expect("parallel");
+        assert_eq!(sequential.rows, parallel.rows);
+        assert_eq!(sequential.new_peaks, parallel.new_peaks);
+        assert_eq!(sequential.new_ops_size, parallel.new_ops_size);
+        assert_eq!(sequential.new_root, parallel.new_root);
     }
 
     #[test]

--- a/qmdb/rs/src/writer/keyless.rs
+++ b/qmdb/rs/src/writer/keyless.rs
@@ -143,6 +143,8 @@ where
 /// Multiple [`prepare_upload`](Self::prepare_upload) calls can be in flight
 /// simultaneously — the writer's mutex is released before any Store write
 /// awaits, so independent Store batches can run concurrently on the transport.
+/// Preparation yields during CPU work. ACK and watermark processing remain
+/// responsive while another batch is being prepared.
 ///
 /// Each dispatched batch's PUT carries a watermark row at the **latest safe
 /// location**:
@@ -225,18 +227,18 @@ where
 
     pub async fn prepare_upload(
         &self,
-        ops: &[keyless::Operation<F, E>],
+        ops: Vec<keyless::Operation<F, E>>,
     ) -> Result<super::PreparedUpload<F>, QmdbError> {
         let prepared = self
             .core
-            .prepare(ops.len() as u64, |ctx, strategy| {
+            .prepare(ops.len() as u64, move |ctx, strategy| {
                 let built = build_keyless_upload_with_strategy::<F, H, V, E, S>(
                     ctx.peaks,
                     ctx.ops_size,
                     ctx.latest_location,
-                    ops,
+                    &ops,
                     ctx.watermark_at,
-                    strategy,
+                    &strategy,
                 )?;
                 Ok(crate::writer::core::BuildResult {
                     new_peaks: built.new_peaks,

--- a/qmdb/rs/src/writer/mod.rs
+++ b/qmdb/rs/src/writer/mod.rs
@@ -25,10 +25,20 @@ mod keyless;
 mod ordered;
 mod unordered;
 
-pub use immutable::{build_immutable_upload, BuiltImmutableUpload, ImmutableWriter};
-pub use keyless::{build_keyless_upload, BuiltKeylessUpload, KeylessWriter};
-pub use ordered::{build_ordered_upload, BuiltOrderedUpload, OrderedWriter};
-pub use unordered::{build_unordered_upload, BuiltUnorderedUpload, UnorderedWriter};
+pub use immutable::{
+    build_immutable_upload, build_immutable_upload_with_strategy, BuiltImmutableUpload,
+    ImmutableWriter,
+};
+pub use keyless::{
+    build_keyless_upload, build_keyless_upload_with_strategy, BuiltKeylessUpload, KeylessWriter,
+};
+pub use ordered::{
+    build_ordered_upload, build_ordered_upload_with_strategy, BuiltOrderedUpload, OrderedWriter,
+};
+pub use unordered::{
+    build_unordered_upload, build_unordered_upload_with_strategy, BuiltUnorderedUpload,
+    UnorderedWriter,
+};
 
 use std::borrow::Borrow;
 

--- a/qmdb/rs/src/writer/mod.rs
+++ b/qmdb/rs/src/writer/mod.rs
@@ -9,10 +9,10 @@
 //! plus batch-local flush preparation for atomic multi-upload Store batches.
 //!
 //! Multiple `prepare_upload` calls may be issued concurrently against the same
-//! writer instance. The writer serializes frontier assignment under its
-//! internal mutex, then releases that lock before any network I/O, so
-//! independent Store batches can be in flight at the same time while watermark
-//! publication still follows the contiguous-committed prefix.
+//! writer instance. Preparation yields during Merkle build work, so ACK and
+//! watermark processing remains responsive. No lock is held during network
+//! I/O, so independent Store batches can be in flight at the same time while
+//! watermark publication still follows the contiguous-committed prefix.
 //!
 //! Callers own durability. On any PUT error the writer poisons; the caller must
 //! construct a fresh writer from a caller-owned committed frontier. Since PUT

--- a/qmdb/rs/src/writer/ordered.rs
+++ b/qmdb/rs/src/writer/ordered.rs
@@ -32,6 +32,7 @@ use std::marker::PhantomData;
 
 use commonware_codec::{Codec, Decode, Encode};
 use commonware_cryptography::Hasher;
+use commonware_parallel::{Sequential, Strategy};
 use commonware_storage::merkle::{Graftable, Location, Position};
 use commonware_storage::qmdb::{
     any::{
@@ -88,17 +89,48 @@ where
     E: ValueEncoding<Value = V>,
     ordered::Operation<F, K, E>: Encode,
 {
+    build_ordered_upload_with_strategy::<F, H, K, V, N, E, Sequential>(
+        peaks,
+        prev_ops_size,
+        latest_location,
+        ops,
+        current_boundary,
+        watermark_at,
+        &Sequential,
+    )
+}
+
+/// Strategy-aware form of [`build_ordered_upload`].
+pub fn build_ordered_upload_with_strategy<F, H, K, V, const N: usize, E, S>(
+    peaks: Vec<(Position<F>, u32, H::Digest)>,
+    prev_ops_size: Position<F>,
+    latest_location: Location<F>,
+    ops: &[ordered::Operation<F, K, E>],
+    current_boundary: &CurrentBoundaryState<H::Digest, N, F>,
+    watermark_at: Option<Location<F>>,
+    strategy: &S,
+) -> Result<BuiltOrderedUpload<H::Digest, F>, QmdbError>
+where
+    F: Graftable,
+    H: Hasher,
+    K: QmdbKey + Codec,
+    V: Codec + Clone + Send + Sync,
+    E: ValueEncoding<Value = V>,
+    S: Strategy,
+    ordered::Operation<F, K, E>: Encode,
+{
     if ops.is_empty() {
         return Err(QmdbError::EmptyBatch);
     }
     let prepared_ops = CorePreparedUpload::build(latest_location, ops)?;
     let prepared_current = PreparedCurrentBoundaryUpload::build(latest_location, current_boundary)?;
     let inactive_peaks = ordered_inactive_peaks(latest_location, ops)?;
-    let ext = extend_merkle_from_peaks_with_inactive_peaks::<F, H, _>(
+    let ext = extend_merkle_from_peaks_with_inactive_peaks::<F, H, S, _>(
         peaks,
         prev_ops_size,
         prepared_ops.op_bytes(),
         inactive_peaks,
+        strategy,
     )?;
     let operation_count = prepared_ops.operation_count;
     let keyed_operation_count = prepared_ops.keyed_operation_count;
@@ -160,13 +192,14 @@ pub struct OrderedWriter<
     V: Codec + Clone + Send + Sync,
     const N: usize,
     E: ValueEncoding<Value = V> = VariableEncoding<V>,
+    S: Strategy = Sequential,
 > {
     client: PrefixedStoreClient,
-    core: WriterCore<H::Digest, F>,
+    core: WriterCore<H::Digest, F, S>,
     _marker: PhantomData<(F, K, V, E)>,
 }
 
-impl<F, H, K, V, const N: usize, E> OrderedWriter<F, H, K, V, N, E>
+impl<F, H, K, V, const N: usize, E, S> OrderedWriter<F, H, K, V, N, E, S>
 where
     F: Graftable,
     H: Hasher,
@@ -174,22 +207,27 @@ where
     V: Codec + Clone + Send + Sync,
     V::Cfg: Clone,
     E: ValueEncoding<Value = V>,
+    S: Strategy,
     ordered::Operation<F, K, E>: Encode + Decode,
 {
     /// Construct a writer over `client`'s namespace prefix from caller-supplied
     /// frontier state (no store I/O).
-    pub fn new(client: PrefixedStoreClient, state: WriterState<H::Digest, F>) -> Self {
+    pub fn new_with_strategy(
+        client: PrefixedStoreClient,
+        state: WriterState<H::Digest, F>,
+        strategy: S,
+    ) -> Self {
         Self {
             client,
-            core: WriterCore::from_cache(Cache::from_writer_state(state)),
+            core: WriterCore::from_cache(Cache::from_writer_state(state), strategy),
             _marker: PhantomData,
         }
     }
 
     /// Construct a fresh writer over `client`'s namespace prefix with empty
     /// frontier state (no prior published checkpoint).
-    pub fn fresh(client: PrefixedStoreClient) -> Self {
-        Self::new(client, WriterState::empty())
+    pub fn fresh_with_strategy(client: PrefixedStoreClient, strategy: S) -> Self {
+        Self::new_with_strategy(client, WriterState::empty(), strategy)
     }
 
     pub async fn latest_published_watermark(&self) -> Option<Location<F>> {
@@ -218,14 +256,15 @@ where
     ) -> Result<super::PreparedUpload<F>, QmdbError> {
         let prepared = self
             .core
-            .prepare(ops.len() as u64, |ctx| {
-                let built = build_ordered_upload::<F, H, K, V, N, E>(
+            .prepare(ops.len() as u64, |ctx, strategy| {
+                let built = build_ordered_upload_with_strategy::<F, H, K, V, N, E, S>(
                     ctx.peaks,
                     ctx.ops_size,
                     ctx.latest_location,
                     ops,
                     current_boundary,
                     ctx.watermark_at,
+                    strategy,
                 )?;
                 Ok(crate::writer::core::BuildResult {
                     new_peaks: built.new_peaks,
@@ -339,20 +378,44 @@ where
     }
 }
 
-impl<F, H, K, V, const N: usize, E> std::fmt::Debug for OrderedWriter<F, H, K, V, N, E>
+impl<F, H, K, V, const N: usize, E> OrderedWriter<F, H, K, V, N, E, Sequential>
+where
+    F: Graftable,
+    H: Hasher,
+    K: QmdbKey + Codec,
+    V: Codec + Clone + Send + Sync,
+    V::Cfg: Clone,
+    E: ValueEncoding<Value = V>,
+    ordered::Operation<F, K, E>: Encode + Decode,
+{
+    /// Construct a writer over `client`'s namespace prefix from caller-supplied
+    /// frontier state (no store I/O).
+    pub fn new(client: PrefixedStoreClient, state: WriterState<H::Digest, F>) -> Self {
+        Self::new_with_strategy(client, state, Sequential)
+    }
+
+    /// Construct a fresh writer over `client`'s namespace prefix with empty
+    /// frontier state (no prior published checkpoint).
+    pub fn fresh(client: PrefixedStoreClient) -> Self {
+        Self::fresh_with_strategy(client, Sequential)
+    }
+}
+
+impl<F, H, K, V, const N: usize, E, S> std::fmt::Debug for OrderedWriter<F, H, K, V, N, E, S>
 where
     F: Graftable,
     H: Hasher,
     K: QmdbKey + Codec,
     V: Codec + Clone + Send + Sync,
     E: ValueEncoding<Value = V>,
+    S: Strategy,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("OrderedWriter").finish_non_exhaustive()
     }
 }
 
-impl<F, H, K, V, const N: usize, E> StoreBatchUpload for OrderedWriter<F, H, K, V, N, E>
+impl<F, H, K, V, const N: usize, E, S> StoreBatchUpload for OrderedWriter<F, H, K, V, N, E, S>
 where
     F: Graftable,
     H: Hasher + Sync,
@@ -360,6 +423,7 @@ where
     V: Codec + Clone + Send + Sync,
     V::Cfg: Clone,
     E: ValueEncoding<Value = V> + Sync,
+    S: Strategy,
     ordered::Operation<F, K, E>: Encode + Decode,
 {
     type Prepared = super::PreparedUpload<F>;
@@ -411,7 +475,7 @@ where
     }
 }
 
-impl<F, H, K, V, const N: usize, E> StoreBatchPublication for OrderedWriter<F, H, K, V, N, E>
+impl<F, H, K, V, const N: usize, E, S> StoreBatchPublication for OrderedWriter<F, H, K, V, N, E, S>
 where
     F: Graftable,
     H: Hasher + Sync,
@@ -419,6 +483,7 @@ where
     V: Codec + Clone + Send + Sync,
     V::Cfg: Clone,
     E: ValueEncoding<Value = V> + Sync,
+    S: Strategy,
     ordered::Operation<F, K, E>: Encode + Decode,
 {
     type PreparedPublication = super::PreparedWatermark<F>;
@@ -456,8 +521,8 @@ where
     }
 }
 
-impl<F, H, K, V, const N: usize, E> StorePublicationFrontierWriter
-    for OrderedWriter<F, H, K, V, N, E>
+impl<F, H, K, V, const N: usize, E, S> StorePublicationFrontierWriter
+    for OrderedWriter<F, H, K, V, N, E, S>
 where
     F: Graftable,
     H: Hasher + Sync,
@@ -465,6 +530,7 @@ where
     V: Codec + Clone + Send + Sync,
     V::Cfg: Clone,
     E: ValueEncoding<Value = V> + Sync,
+    S: Strategy,
     ordered::Operation<F, K, E>: Encode + Decode,
 {
     fn latest_publication_receipt<'a>(&'a self) -> BoxFuture<'a, Option<PublishedCheckpoint<F>>>

--- a/qmdb/rs/src/writer/ordered.rs
+++ b/qmdb/rs/src/writer/ordered.rs
@@ -251,20 +251,23 @@ where
     /// correct contiguous watermark semantics internally.
     pub async fn prepare_upload(
         &self,
-        ops: &[ordered::Operation<F, K, E>],
-        current_boundary: &CurrentBoundaryState<H::Digest, N, F>,
-    ) -> Result<super::PreparedUpload<F>, QmdbError> {
+        ops: Vec<ordered::Operation<F, K, E>>,
+        current_boundary: CurrentBoundaryState<H::Digest, N, F>,
+    ) -> Result<super::PreparedUpload<F>, QmdbError>
+    where
+        F::PendingChunk<H::Digest>: 'static,
+    {
         let prepared = self
             .core
-            .prepare(ops.len() as u64, |ctx, strategy| {
+            .prepare(ops.len() as u64, move |ctx, strategy| {
                 let built = build_ordered_upload_with_strategy::<F, H, K, V, N, E, S>(
                     ctx.peaks,
                     ctx.ops_size,
                     ctx.latest_location,
-                    ops,
-                    current_boundary,
+                    &ops,
+                    &current_boundary,
                     ctx.watermark_at,
-                    strategy,
+                    &strategy,
                 )?;
                 Ok(crate::writer::core::BuildResult {
                     new_peaks: built.new_peaks,

--- a/qmdb/rs/src/writer/unordered.rs
+++ b/qmdb/rs/src/writer/unordered.rs
@@ -5,6 +5,7 @@ use std::marker::PhantomData;
 
 use commonware_codec::{Codec, Encode};
 use commonware_cryptography::Hasher;
+use commonware_parallel::{Sequential, Strategy};
 use commonware_storage::merkle::{Graftable, Location, Position};
 use commonware_storage::qmdb::{
     any::{
@@ -60,16 +61,45 @@ where
     E: ValueEncoding<Value = V>,
     unordered::Operation<F, K, E>: Encode,
 {
+    build_unordered_upload_with_strategy::<F, H, K, V, E, Sequential>(
+        peaks,
+        prev_ops_size,
+        latest_location,
+        ops,
+        watermark_at,
+        &Sequential,
+    )
+}
+
+/// Strategy-aware form of [`build_unordered_upload`].
+pub fn build_unordered_upload_with_strategy<F, H, K, V, E, S>(
+    peaks: Vec<(Position<F>, u32, H::Digest)>,
+    prev_ops_size: Position<F>,
+    latest_location: Location<F>,
+    ops: &[unordered::Operation<F, K, E>],
+    watermark_at: Option<Location<F>>,
+    strategy: &S,
+) -> Result<BuiltUnorderedUpload<H::Digest, F>, QmdbError>
+where
+    F: Graftable,
+    H: Hasher,
+    K: QmdbKey + Codec,
+    V: Codec + Clone + Send + Sync,
+    E: ValueEncoding<Value = V>,
+    S: Strategy,
+    unordered::Operation<F, K, E>: Encode,
+{
     if ops.is_empty() {
         return Err(QmdbError::EmptyBatch);
     }
     let prepared = CorePreparedUpload::build_unordered(latest_location, ops)?;
     let inactive_peaks = unordered_inactive_peaks(latest_location, ops)?;
-    let ext = extend_merkle_from_peaks_with_inactive_peaks::<F, H, _>(
+    let ext = extend_merkle_from_peaks_with_inactive_peaks::<F, H, S, _>(
         peaks,
         prev_ops_size,
         prepared.op_bytes(),
         inactive_peaks,
+        strategy,
     )?;
     let operation_count = prepared.operation_count;
     let keyed_operation_count = prepared.keyed_operation_count;
@@ -117,13 +147,14 @@ where
     ))
 }
 
-pub fn build_unordered_current_upload<F, H, K, V, const N: usize, E>(
+fn build_unordered_current_upload_with_strategy<F, H, K, V, const N: usize, E, S>(
     peaks: Vec<(Position<F>, u32, H::Digest)>,
     prev_ops_size: Position<F>,
     latest_location: Location<F>,
     ops: &[unordered::Operation<F, K, E>],
     current_boundary: &CurrentBoundaryState<H::Digest, N, F>,
     watermark_at: Option<Location<F>>,
+    strategy: &S,
 ) -> Result<BuiltUnorderedUpload<H::Digest, F>, QmdbError>
 where
     F: Graftable,
@@ -131,14 +162,16 @@ where
     K: QmdbKey + Codec,
     V: Codec + Clone + Send + Sync,
     E: ValueEncoding<Value = V>,
+    S: Strategy,
     unordered::Operation<F, K, E>: Encode,
 {
-    let mut built = build_unordered_upload::<F, H, K, V, E>(
+    let mut built = build_unordered_upload_with_strategy::<F, H, K, V, E, S>(
         peaks,
         prev_ops_size,
         latest_location,
         ops,
         watermark_at,
+        strategy,
     )?;
     let prepared_current = PreparedCurrentBoundaryUpload::build(latest_location, current_boundary)?;
     built.rows.extend(prepared_current.rows);
@@ -154,13 +187,14 @@ pub struct UnorderedWriter<
     K: QmdbKey + Codec,
     V: Codec + Clone + Send + Sync,
     E: ValueEncoding<Value = V> = VariableEncoding<V>,
+    S: Strategy = Sequential,
 > {
     client: PrefixedStoreClient,
-    core: WriterCore<H::Digest, F>,
+    core: WriterCore<H::Digest, F, S>,
     _marker: PhantomData<(F, K, V, E)>,
 }
 
-impl<F, H, K, V, E> UnorderedWriter<F, H, K, V, E>
+impl<F, H, K, V, E, S> UnorderedWriter<F, H, K, V, E, S>
 where
     F: Graftable,
     H: Hasher,
@@ -168,22 +202,27 @@ where
     V: Codec + Clone + Send + Sync,
     V::Cfg: Clone,
     E: ValueEncoding<Value = V>,
+    S: Strategy,
     unordered::Operation<F, K, E>: Encode,
 {
     /// Construct a writer over `client`'s namespace prefix from caller-supplied
     /// frontier state (no store I/O).
-    pub fn new(client: PrefixedStoreClient, state: WriterState<H::Digest, F>) -> Self {
+    pub fn new_with_strategy(
+        client: PrefixedStoreClient,
+        state: WriterState<H::Digest, F>,
+        strategy: S,
+    ) -> Self {
         Self {
             client,
-            core: WriterCore::from_cache(Cache::from_writer_state(state)),
+            core: WriterCore::from_cache(Cache::from_writer_state(state), strategy),
             _marker: PhantomData,
         }
     }
 
     /// Construct a fresh writer over `client`'s namespace prefix with empty
     /// frontier state (no prior published checkpoint).
-    pub fn fresh(client: PrefixedStoreClient) -> Self {
-        Self::new(client, WriterState::empty())
+    pub fn fresh_with_strategy(client: PrefixedStoreClient, strategy: S) -> Self {
+        Self::new_with_strategy(client, WriterState::empty(), strategy)
     }
 
     pub async fn latest_published_watermark(&self) -> Option<Location<F>> {
@@ -200,13 +239,14 @@ where
     ) -> Result<super::PreparedUpload<F>, QmdbError> {
         let prepared = self
             .core
-            .prepare(ops.len() as u64, |ctx| {
-                let built = build_unordered_upload::<F, H, K, V, E>(
+            .prepare(ops.len() as u64, |ctx, strategy| {
+                let built = build_unordered_upload_with_strategy::<F, H, K, V, E, S>(
                     ctx.peaks,
                     ctx.ops_size,
                     ctx.latest_location,
                     ops,
                     ctx.watermark_at,
+                    strategy,
                 )?;
                 Ok(crate::writer::core::BuildResult {
                     new_peaks: built.new_peaks,
@@ -230,14 +270,15 @@ where
     ) -> Result<super::PreparedUpload<F>, QmdbError> {
         let prepared = self
             .core
-            .prepare(ops.len() as u64, |ctx| {
-                let built = build_unordered_current_upload::<F, H, K, V, N, E>(
+            .prepare(ops.len() as u64, |ctx, strategy| {
+                let built = build_unordered_current_upload_with_strategy::<F, H, K, V, N, E, S>(
                     ctx.peaks,
                     ctx.ops_size,
                     ctx.latest_location,
                     ops,
                     current_boundary,
                     ctx.watermark_at,
+                    strategy,
                 )?;
                 Ok(crate::writer::core::BuildResult {
                     new_peaks: built.new_peaks,
@@ -351,20 +392,44 @@ where
     }
 }
 
-impl<F, H, K, V, E> std::fmt::Debug for UnorderedWriter<F, H, K, V, E>
+impl<F, H, K, V, E> UnorderedWriter<F, H, K, V, E, Sequential>
+where
+    F: Graftable,
+    H: Hasher,
+    K: QmdbKey + Codec,
+    V: Codec + Clone + Send + Sync,
+    V::Cfg: Clone,
+    E: ValueEncoding<Value = V>,
+    unordered::Operation<F, K, E>: Encode,
+{
+    /// Construct a writer over `client`'s namespace prefix from caller-supplied
+    /// frontier state (no store I/O).
+    pub fn new(client: PrefixedStoreClient, state: WriterState<H::Digest, F>) -> Self {
+        Self::new_with_strategy(client, state, Sequential)
+    }
+
+    /// Construct a fresh writer over `client`'s namespace prefix with empty
+    /// frontier state (no prior published checkpoint).
+    pub fn fresh(client: PrefixedStoreClient) -> Self {
+        Self::fresh_with_strategy(client, Sequential)
+    }
+}
+
+impl<F, H, K, V, E, S> std::fmt::Debug for UnorderedWriter<F, H, K, V, E, S>
 where
     F: Graftable,
     H: Hasher,
     K: QmdbKey + Codec,
     V: Codec + Clone + Send + Sync,
     E: ValueEncoding<Value = V>,
+    S: Strategy,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("UnorderedWriter").finish_non_exhaustive()
     }
 }
 
-impl<F, H, K, V, E> StoreBatchUpload for UnorderedWriter<F, H, K, V, E>
+impl<F, H, K, V, E, S> StoreBatchUpload for UnorderedWriter<F, H, K, V, E, S>
 where
     F: Graftable,
     H: Hasher + Sync,
@@ -372,6 +437,7 @@ where
     V: Codec + Clone + Send + Sync,
     V::Cfg: Clone,
     E: ValueEncoding<Value = V> + Sync,
+    S: Strategy,
     unordered::Operation<F, K, E>: Encode,
 {
     type Prepared = super::PreparedUpload<F>;
@@ -423,7 +489,7 @@ where
     }
 }
 
-impl<F, H, K, V, E> StoreBatchPublication for UnorderedWriter<F, H, K, V, E>
+impl<F, H, K, V, E, S> StoreBatchPublication for UnorderedWriter<F, H, K, V, E, S>
 where
     F: Graftable,
     H: Hasher + Sync,
@@ -431,6 +497,7 @@ where
     V: Codec + Clone + Send + Sync,
     V::Cfg: Clone,
     E: ValueEncoding<Value = V> + Sync,
+    S: Strategy,
     unordered::Operation<F, K, E>: Encode,
 {
     type PreparedPublication = super::PreparedWatermark<F>;
@@ -468,7 +535,7 @@ where
     }
 }
 
-impl<F, H, K, V, E> StorePublicationFrontierWriter for UnorderedWriter<F, H, K, V, E>
+impl<F, H, K, V, E, S> StorePublicationFrontierWriter for UnorderedWriter<F, H, K, V, E, S>
 where
     F: Graftable,
     H: Hasher + Sync,
@@ -476,6 +543,7 @@ where
     V: Codec + Clone + Send + Sync,
     V::Cfg: Clone,
     E: ValueEncoding<Value = V> + Sync,
+    S: Strategy,
     unordered::Operation<F, K, E>: Encode,
 {
     fn latest_publication_receipt<'a>(&'a self) -> BoxFuture<'a, Option<PublishedCheckpoint<F>>>

--- a/qmdb/rs/src/writer/unordered.rs
+++ b/qmdb/rs/src/writer/unordered.rs
@@ -574,3 +574,121 @@ where
         Box::pin(async move { UnorderedWriter::flush_with_receipt(self).await })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use commonware_cryptography::Sha256;
+    use commonware_parallel::Rayon;
+    use commonware_storage::merkle::{mmr, Unused};
+    use commonware_storage::qmdb::current::proof::OpsRootWitness;
+    use exoware_sdk::StoreClient;
+    use std::num::NonZeroUsize;
+
+    type TestEncoding = VariableEncoding<Vec<u8>>;
+    type TestOp = unordered::Operation<mmr::Family, Vec<u8>, TestEncoding>;
+
+    #[tokio::test]
+    async fn sequential_and_parallel_current_builds_match() {
+        let ops = vec![
+            TestOp::Delete(b"alpha".to_vec()),
+            TestOp::Delete(b"beta".to_vec()),
+            TestOp::CommitFloor(None, Location::new(0)),
+        ];
+        let digest = Sha256::fill(0x7A);
+        let boundary = CurrentBoundaryState::<_, 32, mmr::Family> {
+            root: digest,
+            pruned_chunks: 0,
+            ops_root_witness: OpsRootWitness {
+                grafted_root: digest,
+                pending_chunk_digest: Unused,
+                partial_chunk: None,
+            },
+            chunks: Vec::new(),
+            grafted_nodes: Vec::new(),
+        };
+
+        let sequential = build_unordered_current_upload_with_strategy::<
+            mmr::Family,
+            Sha256,
+            Vec<u8>,
+            Vec<u8>,
+            32,
+            TestEncoding,
+            _,
+        >(
+            Vec::new(),
+            Position::new(0),
+            Location::new(2),
+            &ops,
+            &boundary,
+            Some(Location::new(2)),
+            &Sequential,
+        )
+        .expect("build sequentially");
+
+        let strategy = Rayon::new(NonZeroUsize::new(2).expect("non-zero thread count"))
+            .expect("construct Rayon strategy")
+            .manual();
+        let parallel = build_unordered_current_upload_with_strategy::<
+            mmr::Family,
+            Sha256,
+            Vec<u8>,
+            Vec<u8>,
+            32,
+            TestEncoding,
+            _,
+        >(
+            Vec::new(),
+            Position::new(0),
+            Location::new(2),
+            &ops,
+            &boundary,
+            Some(Location::new(2)),
+            &strategy,
+        )
+        .expect("build in parallel");
+
+        assert_eq!(sequential.rows, parallel.rows);
+        assert_eq!(sequential.new_peaks, parallel.new_peaks);
+        assert_eq!(sequential.new_ops_size, parallel.new_ops_size);
+        assert_eq!(sequential.new_root, parallel.new_root);
+
+        let sequential_writer =
+            UnorderedWriter::<mmr::Family, Sha256, Vec<u8>, Vec<u8>, TestEncoding>::fresh(
+                PrefixedStoreClient::empty(StoreClient::new("http://127.0.0.1:9")),
+            );
+        let parallel_writer = UnorderedWriter::<
+            mmr::Family,
+            Sha256,
+            Vec<u8>,
+            Vec<u8>,
+            TestEncoding,
+            _,
+        >::fresh_with_strategy(
+            PrefixedStoreClient::empty(StoreClient::new("http://127.0.0.1:9")),
+            strategy,
+        );
+
+        let sequential_prepared = sequential_writer
+            .prepare_current_upload(ops.clone(), boundary.clone())
+            .await
+            .expect("prepare sequentially");
+        let parallel_prepared = parallel_writer
+            .prepare_current_upload(ops, boundary)
+            .await
+            .expect("prepare in parallel");
+
+        assert_eq!(sequential_prepared.rows, parallel_prepared.rows);
+        assert_eq!(sequential_prepared.rows, sequential.rows);
+        assert_eq!(parallel_prepared.rows, parallel.rows);
+        assert_eq!(
+            sequential_prepared.writer_location_watermark,
+            parallel_prepared.writer_location_watermark
+        );
+        assert_eq!(
+            sequential_prepared.latest_location,
+            parallel_prepared.latest_location
+        );
+    }
+}

--- a/qmdb/rs/src/writer/unordered.rs
+++ b/qmdb/rs/src/writer/unordered.rs
@@ -235,18 +235,18 @@ where
 
     pub async fn prepare_upload(
         &self,
-        ops: &[unordered::Operation<F, K, E>],
+        ops: Vec<unordered::Operation<F, K, E>>,
     ) -> Result<super::PreparedUpload<F>, QmdbError> {
         let prepared = self
             .core
-            .prepare(ops.len() as u64, |ctx, strategy| {
+            .prepare(ops.len() as u64, move |ctx, strategy| {
                 let built = build_unordered_upload_with_strategy::<F, H, K, V, E, S>(
                     ctx.peaks,
                     ctx.ops_size,
                     ctx.latest_location,
-                    ops,
+                    &ops,
                     ctx.watermark_at,
-                    strategy,
+                    &strategy,
                 )?;
                 Ok(crate::writer::core::BuildResult {
                     new_peaks: built.new_peaks,
@@ -265,20 +265,23 @@ where
 
     pub async fn prepare_current_upload<const N: usize>(
         &self,
-        ops: &[unordered::Operation<F, K, E>],
-        current_boundary: &CurrentBoundaryState<H::Digest, N, F>,
-    ) -> Result<super::PreparedUpload<F>, QmdbError> {
+        ops: Vec<unordered::Operation<F, K, E>>,
+        current_boundary: CurrentBoundaryState<H::Digest, N, F>,
+    ) -> Result<super::PreparedUpload<F>, QmdbError>
+    where
+        F::PendingChunk<H::Digest>: 'static,
+    {
         let prepared = self
             .core
-            .prepare(ops.len() as u64, |ctx, strategy| {
+            .prepare(ops.len() as u64, move |ctx, strategy| {
                 let built = build_unordered_current_upload_with_strategy::<F, H, K, V, N, E, S>(
                     ctx.peaks,
                     ctx.ops_size,
                     ctx.latest_location,
-                    ops,
-                    current_boundary,
+                    &ops,
+                    &current_boundary,
                     ctx.watermark_at,
-                    strategy,
+                    &strategy,
                 )?;
                 Ok(crate::writer::core::BuildResult {
                     new_peaks: built.new_peaks,

--- a/qmdb/rs/tests/common/mod.rs
+++ b/qmdb/rs/tests/common/mod.rs
@@ -172,8 +172,8 @@ where
 }
 
 #[allow(dead_code)]
-pub async fn commit_keyless_upload<F, H, V, E>(
-    writer: &KeylessWriter<F, H, V, E>,
+pub async fn commit_keyless_upload<F, H, V, E, S>(
+    writer: &KeylessWriter<F, H, V, E, S>,
     ops: &[keyless::Operation<F, E>],
 ) -> Result<UploadReceipt<F>, QmdbError>
 where
@@ -181,6 +181,7 @@ where
     H: Hasher + Sync,
     V: Codec + Clone + Send + Sync,
     E: ValueEncoding<Value = V> + Sync,
+    S: commonware_parallel::Strategy,
     keyless::Operation<F, E>: Encode,
 {
     let prepared = writer.prepare_upload(ops).await?;
@@ -188,8 +189,8 @@ where
 }
 
 #[allow(dead_code)]
-pub async fn commit_unordered_upload<F, H, K, V, E>(
-    writer: &UnorderedWriter<F, H, K, V, E>,
+pub async fn commit_unordered_upload<F, H, K, V, E, S>(
+    writer: &UnorderedWriter<F, H, K, V, E, S>,
     ops: &[unordered::Operation<F, K, E>],
 ) -> Result<UploadReceipt<F>, QmdbError>
 where
@@ -199,6 +200,7 @@ where
     V: Codec + Clone + Send + Sync,
     V::Cfg: Clone,
     E: ValueEncoding<Value = V> + Sync,
+    S: commonware_parallel::Strategy,
     unordered::Operation<F, K, E>: Encode,
 {
     let prepared = writer.prepare_upload(ops).await?;
@@ -206,8 +208,8 @@ where
 }
 
 #[allow(dead_code)]
-pub async fn commit_unordered_current_upload<F, H, K, V, const N: usize, E>(
-    writer: &UnorderedWriter<F, H, K, V, E>,
+pub async fn commit_unordered_current_upload<F, H, K, V, const N: usize, E, S>(
+    writer: &UnorderedWriter<F, H, K, V, E, S>,
     ops: &[unordered::Operation<F, K, E>],
     current_boundary: &CurrentBoundaryState<H::Digest, N, F>,
 ) -> Result<UploadReceipt<F>, QmdbError>
@@ -218,6 +220,7 @@ where
     V: Codec + Clone + Send + Sync,
     V::Cfg: Clone,
     E: ValueEncoding<Value = V> + Sync,
+    S: commonware_parallel::Strategy,
     unordered::Operation<F, K, E>: Encode,
 {
     let prepared = writer.prepare_current_upload(ops, current_boundary).await?;
@@ -225,8 +228,8 @@ where
 }
 
 #[allow(dead_code)]
-pub async fn commit_ordered_upload<F, H, K, V, const N: usize, E>(
-    writer: &OrderedWriter<F, H, K, V, N, E>,
+pub async fn commit_ordered_upload<F, H, K, V, const N: usize, E, S>(
+    writer: &OrderedWriter<F, H, K, V, N, E, S>,
     ops: &[ordered::Operation<F, K, E>],
     current_boundary: &CurrentBoundaryState<H::Digest, N, F>,
 ) -> Result<UploadReceipt<F>, QmdbError>
@@ -237,6 +240,7 @@ where
     V: Codec + Clone + Send + Sync,
     V::Cfg: Clone,
     E: ValueEncoding<Value = V> + Sync,
+    S: commonware_parallel::Strategy,
     ordered::Operation<F, K, E>: Encode + Decode,
 {
     let prepared = writer.prepare_upload(ops, current_boundary).await?;
@@ -244,8 +248,8 @@ where
 }
 
 #[allow(dead_code)]
-pub async fn commit_immutable_upload<F, H, K, V, E>(
-    writer: &ImmutableWriter<F, H, K, V, E>,
+pub async fn commit_immutable_upload<F, H, K, V, E, S>(
+    writer: &ImmutableWriter<F, H, K, V, E, S>,
     ops: &[immutable::Operation<F, K, E>],
 ) -> Result<UploadReceipt<F>, QmdbError>
 where
@@ -256,6 +260,7 @@ where
     V::Cfg: Clone,
     K::Cfg: Clone,
     E: ValueEncoding<Value = V> + Sync,
+    S: commonware_parallel::Strategy,
     immutable::Operation<F, K, E>: Encode + Decode + Clone,
 {
     let prepared = writer.prepare_upload(ops).await?;

--- a/qmdb/rs/tests/common/mod.rs
+++ b/qmdb/rs/tests/common/mod.rs
@@ -184,7 +184,7 @@ where
     S: commonware_parallel::Strategy,
     keyless::Operation<F, E>: Encode,
 {
-    let prepared = writer.prepare_upload(ops).await?;
+    let prepared = writer.prepare_upload(ops.to_vec()).await?;
     writer.commit_upload(prepared).await
 }
 
@@ -203,7 +203,7 @@ where
     S: commonware_parallel::Strategy,
     unordered::Operation<F, K, E>: Encode,
 {
-    let prepared = writer.prepare_upload(ops).await?;
+    let prepared = writer.prepare_upload(ops.to_vec()).await?;
     writer.commit_upload(prepared).await
 }
 
@@ -222,8 +222,11 @@ where
     E: ValueEncoding<Value = V> + Sync,
     S: commonware_parallel::Strategy,
     unordered::Operation<F, K, E>: Encode,
+    F::PendingChunk<H::Digest>: 'static,
 {
-    let prepared = writer.prepare_current_upload(ops, current_boundary).await?;
+    let prepared = writer
+        .prepare_current_upload(ops.to_vec(), current_boundary.clone())
+        .await?;
     writer.commit_upload(prepared).await
 }
 
@@ -242,8 +245,11 @@ where
     E: ValueEncoding<Value = V> + Sync,
     S: commonware_parallel::Strategy,
     ordered::Operation<F, K, E>: Encode + Decode,
+    F::PendingChunk<H::Digest>: 'static,
 {
-    let prepared = writer.prepare_upload(ops, current_boundary).await?;
+    let prepared = writer
+        .prepare_upload(ops.to_vec(), current_boundary.clone())
+        .await?;
     writer.commit_upload(prepared).await
 }
 
@@ -263,7 +269,7 @@ where
     S: commonware_parallel::Strategy,
     immutable::Operation<F, K, E>: Encode + Decode + Clone,
 {
-    let prepared = writer.prepare_upload(ops).await?;
+    let prepared = writer.prepare_upload(ops.to_vec()).await?;
     writer.commit_upload(prepared).await
 }
 

--- a/qmdb/rs/tests/e2e_immutable_writer.rs
+++ b/qmdb/rs/tests/e2e_immutable_writer.rs
@@ -4,11 +4,13 @@
 
 mod common;
 
-use std::num::NonZeroU64;
+use std::num::{NonZeroU64, NonZeroUsize};
 use std::sync::Arc;
 
+use commonware_parallel::Strategy as _;
 use commonware_runtime::{deterministic, Runner as _};
 use commonware_storage::merkle::{mmr, Location};
+use commonware_storage::qmdb::any::value::VariableEncoding;
 use commonware_storage::qmdb::immutable::variable::{
     Db as Immutable, Operation as ImmutableOperation,
 };
@@ -161,6 +163,39 @@ async fn sequential_upload_matches_local_root() {
             let r = fresh_reader(client.clone());
             let latest = local.latest_location;
             async move { r.root_at(latest).await }
+        },
+        "root_at",
+    )
+    .await;
+    assert_eq!(got_root, local.root);
+}
+
+#[tokio::test]
+async fn parallel_upload_matches_local_root() {
+    let client = common::local_store_client().await;
+    let local =
+        build_local_reference(vec![vec![(FixedBytes::new([0x11; 32]), b"alpha".to_vec())]]).await;
+    let strategy =
+        commonware_parallel::Rayon::new(NonZeroUsize::new(4).expect("non-zero thread count"))
+            .expect("construct Rayon strategy")
+            .manual();
+    let writer = ImmutableWriter::<
+        mmr::Family,
+        commonware_cryptography::Sha256,
+        K,
+        V,
+        VariableEncoding<V>,
+        _,
+    >::fresh_with_strategy(PrefixedStoreClient::empty(client.clone()), strategy);
+
+    common::commit_immutable_upload(&writer, &local.operations)
+        .await
+        .expect("upload");
+    let got_root = retry(
+        || {
+            let reader = fresh_reader(client.clone());
+            let latest = local.latest_location;
+            async move { reader.root_at(latest).await }
         },
         "root_at",
     )

--- a/qmdb/rs/tests/e2e_keyless_writer.rs
+++ b/qmdb/rs/tests/e2e_keyless_writer.rs
@@ -4,11 +4,13 @@
 
 mod common;
 
-use std::num::NonZeroU64;
+use std::num::{NonZeroU64, NonZeroUsize};
 use std::sync::Arc;
 
+use commonware_parallel::Strategy as _;
 use commonware_runtime::{deterministic, Runner as _};
 use commonware_storage::merkle::{mmr, Location, Proof};
+use commonware_storage::qmdb::any::value::VariableEncoding;
 use commonware_storage::qmdb::keyless::variable::{Db as Keyless, Operation as KeylessOperation};
 use commonware_utils::{NZUsize, NZU16, NZU64};
 use exoware_qmdb::{KeylessClient, KeylessWriter};
@@ -187,6 +189,37 @@ async fn sequential_upload_matches_local_root() {
         .expect("proof");
     assert_eq!(proof.root, local_root);
     assert_eq!(proof.operations, writer_ops);
+}
+
+#[tokio::test]
+async fn parallel_upload_matches_local_root() {
+    let client = common::local_store_client().await;
+    let (local_root, _proof, operations, latest) =
+        build_local_reference(vec![vec![b"alpha".to_vec(), b"beta".to_vec()]]).await;
+    let strategy =
+        commonware_parallel::Rayon::new(NonZeroUsize::new(4).expect("non-zero thread count"))
+            .expect("construct Rayon strategy")
+            .manual();
+    let writer = KeylessWriter::<
+        mmr::Family,
+        commonware_cryptography::Sha256,
+        Vec<u8>,
+        VariableEncoding<Vec<u8>>,
+        _,
+    >::fresh_with_strategy(PrefixedStoreClient::empty(client.clone()), strategy);
+
+    common::commit_keyless_upload(&writer, &operations)
+        .await
+        .expect("upload");
+    let got_root = retry(
+        || {
+            let reader = fresh_reader(client.clone());
+            async move { reader.root_at(latest).await }
+        },
+        "root_at",
+    )
+    .await;
+    assert_eq!(got_root, local_root);
 }
 
 // Multiple sequential batches: each call completes before the next starts.

--- a/qmdb/rs/tests/e2e_ordered_writer.rs
+++ b/qmdb/rs/tests/e2e_ordered_writer.rs
@@ -11,14 +11,15 @@ use commonware_cryptography::Sha256;
 use commonware_parallel::Strategy as _;
 use commonware_runtime::tokio as cw_tokio;
 use commonware_runtime::Runner as _;
-use commonware_storage::merkle::{mmr, Location, Proof};
+use commonware_storage::merkle::{mmr, Location, Position, Proof};
 use commonware_storage::qmdb::any::ordered::variable::Operation as QmdbOperation;
 use commonware_storage::qmdb::any::value::VariableEncoding;
 use commonware_storage::qmdb::current::ordered::variable::Db as LocalQmdbDb;
 use commonware_storage::translator::TwoCap;
 use commonware_utils::{NZUsize, NZU16, NZU64};
 use exoware_qmdb::{
-    recover_boundary_state, CurrentBoundaryState, OrderedClient, OrderedWriter, MAX_OPERATION_SIZE,
+    build_ordered_upload, recover_boundary_state, CurrentBoundaryState, OrderedClient,
+    OrderedWriter, MAX_OPERATION_SIZE,
 };
 use exoware_sdk::{PrefixedStoreClient, StoreClient};
 
@@ -241,6 +242,34 @@ async fn parallel_upload_matches_local_root() {
     )
     .await;
     assert_eq!(got_root, local.root);
+
+    let expected_ops_root = build_ordered_upload::<
+        mmr::Family,
+        Sha256,
+        Vec<u8>,
+        Vec<u8>,
+        N,
+        VariableEncoding<Vec<u8>>,
+    >(
+        Vec::new(),
+        Position::new(0),
+        local.latest_location,
+        &local.operations,
+        &local.current_boundary,
+        None,
+    )
+    .expect("sequential reference build")
+    .new_ops_root;
+    let got_ops_root = retry(
+        || {
+            let reader = fresh_reader(client.clone());
+            let latest = local.latest_location;
+            async move { reader.root_at(latest).await }
+        },
+        "root_at",
+    )
+    .await;
+    assert_eq!(got_ops_root, expected_ops_root);
 }
 
 // Pipelined burst for ordered: each batch must carry its own current-boundary

--- a/qmdb/rs/tests/e2e_ordered_writer.rs
+++ b/qmdb/rs/tests/e2e_ordered_writer.rs
@@ -4,14 +4,16 @@
 
 mod common;
 
-use std::num::NonZeroU64;
+use std::num::{NonZeroU64, NonZeroUsize};
 use std::sync::Arc;
 
 use commonware_cryptography::Sha256;
+use commonware_parallel::Strategy as _;
 use commonware_runtime::tokio as cw_tokio;
 use commonware_runtime::Runner as _;
 use commonware_storage::merkle::{mmr, Location, Proof};
 use commonware_storage::qmdb::any::ordered::variable::Operation as QmdbOperation;
+use commonware_storage::qmdb::any::value::VariableEncoding;
 use commonware_storage::qmdb::current::ordered::variable::Db as LocalQmdbDb;
 use commonware_storage::translator::TwoCap;
 use commonware_utils::{NZUsize, NZU16, NZU64};
@@ -194,6 +196,46 @@ async fn sequential_upload_matches_local_root() {
             let r = fresh_reader(client.clone());
             let latest = local.latest_location;
             async move { r.current_root_at(latest).await }
+        },
+        "current_root_at",
+    )
+    .await;
+    assert_eq!(got_root, local.root);
+}
+
+#[tokio::test]
+async fn parallel_upload_matches_local_root() {
+    let client = common::local_store_client().await;
+    let local = build_local_reference(
+        vec![vec![
+            (b"alpha".to_vec(), Some(b"one".to_vec())),
+            (b"beta".to_vec(), Some(b"two".to_vec())),
+        ]],
+        None,
+    )
+    .await;
+    let strategy =
+        commonware_parallel::Rayon::new(NonZeroUsize::new(4).expect("non-zero thread count"))
+            .expect("construct Rayon strategy")
+            .manual();
+    let writer = OrderedWriter::<
+        mmr::Family,
+        Sha256,
+        Vec<u8>,
+        Vec<u8>,
+        N,
+        VariableEncoding<Vec<u8>>,
+        _,
+    >::fresh_with_strategy(PrefixedStoreClient::empty(client.clone()), strategy);
+
+    common::commit_ordered_upload(&writer, &local.operations, &local.current_boundary)
+        .await
+        .expect("upload");
+    let got_root = retry(
+        || {
+            let reader = fresh_reader(client.clone());
+            let latest = local.latest_location;
+            async move { reader.current_root_at(latest).await }
         },
         "current_root_at",
     )

--- a/qmdb/rs/tests/e2e_recovery_strategy.rs
+++ b/qmdb/rs/tests/e2e_recovery_strategy.rs
@@ -1,0 +1,212 @@
+mod common;
+
+use std::num::{NonZeroU64, NonZeroUsize};
+
+use commonware_codec::{Codec, Read as CodecRead};
+use commonware_parallel::Strategy as _;
+use commonware_runtime::{deterministic, Runner as _};
+use commonware_storage::merkle::{mmb, mmr, Family, Graftable, Location};
+use commonware_storage::qmdb::any::value::VariableEncoding;
+use commonware_storage::qmdb::keyless::variable::{Db as Keyless, Operation as KeylessOperation};
+use commonware_utils::{NZUsize, NZU16, NZU64};
+use exoware_qmdb::{KeylessClient, KeylessWriter};
+use exoware_sdk::{PrefixedStoreClient, StoreClient};
+
+use common::retry;
+
+type Digest = commonware_cryptography::sha256::Digest;
+type LocalDb<F> = Keyless<
+    F,
+    deterministic::Context,
+    Vec<u8>,
+    commonware_cryptography::Sha256,
+    commonware_parallel::Sequential,
+>;
+type TestKeylessClient<F> = KeylessClient<F, commonware_cryptography::Sha256, Vec<u8>>;
+type SequentialWriter<F> = KeylessWriter<F, commonware_cryptography::Sha256, Vec<u8>>;
+type RayonWriter<F> = KeylessWriter<
+    F,
+    commonware_cryptography::Sha256,
+    Vec<u8>,
+    VariableEncoding<Vec<u8>>,
+    commonware_parallel::Manual<commonware_parallel::Rayon>,
+>;
+
+fn fresh_keyless<F: Graftable>(client: StoreClient) -> TestKeylessClient<F> {
+    TestKeylessClient::new(
+        PrefixedStoreClient::empty(client),
+        ((0..=10_000).into(), ()),
+    )
+}
+
+fn rayon_strategy() -> commonware_parallel::Manual<commonware_parallel::Rayon> {
+    commonware_parallel::Rayon::new(NonZeroUsize::new(4).expect("non-zero thread count"))
+        .expect("construct Rayon strategy")
+        .manual()
+}
+
+struct LocalReference<F: Family> {
+    latest_location: Location<F>,
+    operations: Vec<KeylessOperation<F, Vec<u8>>>,
+    continuation_operations: Vec<KeylessOperation<F, Vec<u8>>>,
+    continued_latest_location: Location<F>,
+    continued_root: Digest,
+}
+
+async fn build_local_reference<F: Graftable>() -> LocalReference<F>
+where
+    KeylessOperation<F, Vec<u8>>: Codec<Cfg = <Vec<u8> as CodecRead>::Cfg> + Clone,
+{
+    tokio::task::spawn_blocking(|| {
+        deterministic::Runner::default().start(|context| async move {
+            use commonware_runtime::{buffer::paged::CacheRef, Supervisor as _};
+
+            let page_cache = CacheRef::from_pooler(&context, NZU16!(64), NZUsize!(8));
+            let config = common::keyless_config(
+                "keyless_recovery_strategy",
+                page_cache,
+                ((0..=10_000).into(), ()),
+                NZU64!(7),
+            );
+            let mut db: LocalDb<F> = LocalDb::init(context.child("db"), config)
+                .await
+                .expect("init local keyless DB");
+
+            let initial = db
+                .new_batch()
+                .append(b"first-value".to_vec())
+                .append(b"second-value".to_vec())
+                .append(b"third-value".to_vec())
+                .append(b"fourth-value".to_vec())
+                .append(b"fifth-value".to_vec())
+                .append(b"sixth-value".to_vec())
+                .append(b"seventh-value".to_vec())
+                .merkleize(&db, None::<Vec<u8>>, db.inactivity_floor_loc())
+                .await;
+            db.apply_batch(initial).await.expect("apply initial batch");
+
+            let checkpoint_batch = db
+                .new_batch()
+                .append(b"eighth-value".to_vec())
+                .merkleize(&db, None::<Vec<u8>>, db.bounds().end - 1)
+                .await;
+            db.apply_batch(checkpoint_batch)
+                .await
+                .expect("apply checkpoint batch");
+
+            let latest_location = db.bounds().end - 1;
+            let count = NonZeroU64::new(*latest_location + 1).expect("nonzero operation count");
+            let (_, operations) = db
+                .historical_proof(latest_location + 1, Location::<F>::new(0), count)
+                .await
+                .expect("checkpoint historical proof");
+
+            let continuation = db
+                .new_batch()
+                .append(b"ninth-value".to_vec())
+                .merkleize(&db, None::<Vec<u8>>, db.bounds().end - 1)
+                .await;
+            db.apply_batch(continuation)
+                .await
+                .expect("apply continuation batch");
+
+            let continued_latest_location = db.bounds().end - 1;
+            let count = NonZeroU64::new(*continued_latest_location + 1)
+                .expect("nonzero continued operation count");
+            let (_, all_operations) = db
+                .historical_proof(continued_latest_location + 1, Location::<F>::new(0), count)
+                .await
+                .expect("continued historical proof");
+            let continuation_operations = all_operations[operations.len()..].to_vec();
+            let continued_root = db.root();
+            db.destroy().await.expect("destroy local keyless DB");
+
+            LocalReference {
+                latest_location,
+                operations,
+                continuation_operations,
+                continued_latest_location,
+                continued_root,
+            }
+        })
+    })
+    .await
+    .expect("join local keyless task")
+}
+
+async fn recovery_strategy_round_trip<F: Graftable>()
+where
+    KeylessOperation<F, Vec<u8>>: Codec<Cfg = <Vec<u8> as CodecRead>::Cfg> + Clone,
+{
+    let client = common::local_store_client().await;
+    let local = build_local_reference::<F>().await;
+
+    let writer = SequentialWriter::<F>::fresh(PrefixedStoreClient::empty(client.clone()));
+    common::commit_keyless_upload(&writer, &local.operations)
+        .await
+        .expect("commit checkpoint upload");
+
+    let checkpoint = retry(
+        || {
+            let reader = fresh_keyless::<F>(client.clone());
+            let latest_location = local.latest_location;
+            async move {
+                reader
+                    .operation_range_checkpoint(latest_location, latest_location, 1)
+                    .await
+            }
+        },
+        "suffix checkpoint",
+    )
+    .await;
+    assert_eq!(checkpoint.start_location, local.latest_location);
+    assert_ne!(checkpoint.start_location, Location::new(0));
+    assert!(!checkpoint.pinned_nodes.is_empty());
+    assert!(checkpoint.proof.inactive_peaks > 0);
+
+    let reader = fresh_keyless::<F>(client.clone());
+    let strategy = rayon_strategy();
+    let recovered = reader
+        .recover_writer_state_with_strategy(&strategy)
+        .await
+        .expect("recover with Rayon");
+    let sequential = reader
+        .recover_writer_state()
+        .await
+        .expect("recover sequentially");
+    assert_eq!(recovered.peaks, sequential.peaks);
+    assert_eq!(recovered.ops_size, sequential.ops_size);
+    assert_eq!(recovered.next_location, sequential.next_location);
+    assert_eq!(recovered.next_location, local.latest_location + 1);
+
+    let resumed = RayonWriter::<F>::new_with_strategy(
+        PrefixedStoreClient::empty(client.clone()),
+        recovered,
+        strategy,
+    );
+    let receipt = common::commit_keyless_upload(&resumed, &local.continuation_operations)
+        .await
+        .expect("commit continued upload");
+    assert_eq!(receipt.latest_location, local.continued_latest_location);
+
+    let continued_root = retry(
+        || {
+            let reader = fresh_keyless::<F>(client.clone());
+            let latest_location = local.continued_latest_location;
+            async move { reader.root_at(latest_location).await }
+        },
+        "continued root_at",
+    )
+    .await;
+    assert_eq!(continued_root, local.continued_root);
+}
+
+#[tokio::test]
+async fn parallel_recovery_round_trip_mmr() {
+    recovery_strategy_round_trip::<mmr::Family>().await;
+}
+
+#[tokio::test]
+async fn parallel_recovery_round_trip_mmb() {
+    recovery_strategy_round_trip::<mmb::Family>().await;
+}

--- a/qmdb/rs/tests/e2e_unordered_connect.rs
+++ b/qmdb/rs/tests/e2e_unordered_connect.rs
@@ -441,7 +441,7 @@ async fn commit_mmb_upload(client: &StoreClient, batch: &MmbLocalBatch) {
 async fn commit_fixed_upload(client: &StoreClient, batch: &FixedLocalBatch) {
     let writer: UnorderedWriter<mmr::Family, Sha256, Digest, Vec<u8>> =
         UnorderedWriter::fresh(PrefixedStoreClient::empty(client.clone()));
-    common::commit_unordered_current_upload::<_, _, _, _, N, _>(
+    common::commit_unordered_current_upload::<_, _, _, _, N, _, _>(
         &writer,
         &batch.operations,
         &batch.current_boundary,

--- a/qmdb/rs/tests/e2e_unordered_writer.rs
+++ b/qmdb/rs/tests/e2e_unordered_writer.rs
@@ -4,15 +4,17 @@
 
 mod common;
 
-use std::num::NonZeroU64;
+use std::num::{NonZeroU64, NonZeroUsize};
 use std::sync::Arc;
 
 use commonware_cryptography::Sha256;
+use commonware_parallel::Strategy as _;
 use commonware_runtime::tokio as cw_tokio;
 use commonware_runtime::Runner as _;
 use commonware_storage::merkle::{mmr, Location, Proof};
 use commonware_storage::qmdb::any::unordered::variable::Db as LocalUnorderedDb;
 use commonware_storage::qmdb::any::unordered::variable::Operation as UnorderedQmdbOperation;
+use commonware_storage::qmdb::any::value::VariableEncoding;
 use commonware_storage::translator::TwoCap;
 use commonware_utils::{NZUsize, NZU16, NZU64};
 use exoware_qmdb::{UnorderedClient, UnorderedWriter, MAX_OPERATION_SIZE};
@@ -133,6 +135,42 @@ async fn sequential_upload_matches_local_root() {
             let r = fresh_reader(client.clone());
             let latest = local.latest_location;
             async move { r.root_at(latest).await }
+        },
+        "root_at",
+    )
+    .await;
+    assert_eq!(got_root, local.root);
+}
+
+#[tokio::test]
+async fn parallel_upload_matches_local_root() {
+    let client = common::local_store_client().await;
+    let local = build_local_reference(vec![vec![
+        (b"alpha".to_vec(), Some(b"one".to_vec())),
+        (b"beta".to_vec(), Some(b"two".to_vec())),
+    ]])
+    .await;
+    let strategy =
+        commonware_parallel::Rayon::new(NonZeroUsize::new(4).expect("non-zero thread count"))
+            .expect("construct Rayon strategy")
+            .manual();
+    let writer = UnorderedWriter::<
+        mmr::Family,
+        Sha256,
+        Vec<u8>,
+        Vec<u8>,
+        VariableEncoding<Vec<u8>>,
+        _,
+    >::fresh_with_strategy(PrefixedStoreClient::empty(client.clone()), strategy);
+
+    common::commit_unordered_upload(&writer, &local.operations)
+        .await
+        .expect("upload");
+    let got_root = retry(
+        || {
+            let reader = fresh_reader(client.clone());
+            let latest = local.latest_location;
+            async move { reader.root_at(latest).await }
         },
         "root_at",
     )

--- a/qmdb/rs/tests/writer_prepare_stall.rs
+++ b/qmdb/rs/tests/writer_prepare_stall.rs
@@ -1,0 +1,130 @@
+//! Regression coverage for executor and lock stalls during `prepare_upload`.
+//!
+//! The writer core runs the variant build (encoding, leaf hashing,
+//! merklization) through the strategy's `spawn` boundary and only takes the
+//! writer state mutex to snapshot and commit frontier state. If the build
+//! ever moves back inline under that mutex, these tests fail. The first
+//! observes the event loop stalling for the build's duration and the second
+//! observes a cheap watermark read queued behind an in-flight build.
+
+use std::num::NonZeroUsize;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use commonware_parallel::Strategy as _;
+use commonware_storage::merkle::{mmr, Location};
+use commonware_storage::qmdb::any::value::VariableEncoding;
+use commonware_storage::qmdb::keyless;
+use exoware_qmdb::KeylessWriter;
+use exoware_sdk::{PrefixedStoreClient, StoreClient};
+
+type Op = keyless::Operation<mmr::Family, VariableEncoding<Vec<u8>>>;
+type Writer = KeylessWriter<
+    mmr::Family,
+    commonware_cryptography::Sha256,
+    Vec<u8>,
+    VariableEncoding<Vec<u8>>,
+    commonware_parallel::Manual<commonware_parallel::Rayon>,
+>;
+
+// Debug hashing is slow enough to reproduce the stall with a smaller batch.
+#[cfg(debug_assertions)]
+const OPS: usize = 200_000;
+
+// Release hashing needs the full reported workload to cross the threshold.
+#[cfg(not(debug_assertions))]
+const OPS: usize = 1_000_000;
+
+fn operations(count: usize) -> Vec<Op> {
+    let mut ops = Vec::with_capacity(count);
+    for i in 0..count - 1 {
+        let mut value = vec![0u8; 64];
+        value[..8].copy_from_slice(&(i as u64).to_be_bytes());
+        ops.push(Op::Append(value));
+    }
+    ops.push(Op::Commit(None, Location::new(0)));
+    ops
+}
+
+fn rayon_writer() -> Writer {
+    let strategy = commonware_parallel::Rayon::new(NonZeroUsize::new(4).expect("non-zero"))
+        .expect("construct Rayon strategy")
+        .manual();
+
+    // prepare_upload never touches the network, so a dummy endpoint suffices.
+    let client = StoreClient::new("http://127.0.0.1:9");
+    Writer::fresh_with_strategy(PrefixedStoreClient::empty(client), strategy)
+}
+
+// The event loop must stay responsive while a batch merklizes on the Rayon
+// pool. If the build runs inline under the writer mutex, this current_thread
+// executor parks inside the pool and the heartbeat gap grows to the full
+// build time.
+#[tokio::test]
+async fn prepare_upload_keeps_event_loop_responsive() {
+    let writer = rayon_writer();
+    let ops = operations(OPS);
+
+    let max_gap_us = Arc::new(AtomicU64::new(0));
+    let gap = max_gap_us.clone();
+    let heartbeat = tokio::spawn(async move {
+        let mut last = Instant::now();
+        loop {
+            tokio::time::sleep(Duration::from_millis(1)).await;
+            let now = Instant::now();
+            gap.fetch_max(
+                now.duration_since(last).as_micros() as u64,
+                Ordering::Relaxed,
+            );
+            last = now;
+        }
+    });
+
+    // Let the heartbeat establish its baseline before the build starts.
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    let started = Instant::now();
+    let _prepared = writer.prepare_upload(ops).await.expect("prepare");
+    let build = started.elapsed();
+
+    // Let the heartbeat tick once more so a stalled gap is recorded.
+    tokio::time::sleep(Duration::from_millis(10)).await;
+    heartbeat.abort();
+
+    let max_gap = Duration::from_micros(max_gap_us.load(Ordering::Relaxed));
+    println!("build took {build:?}, max heartbeat gap {max_gap:?}");
+    assert!(
+        max_gap < Duration::from_millis(100),
+        "event loop stalled for {max_gap:?} during a {build:?} prepare_upload"
+    );
+}
+
+// A cheap read that takes the writer state mutex must not queue behind an
+// in-flight build. If the build holds the mutex, this probe waits for the
+// build's remainder.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn watermark_read_is_not_delayed_by_inflight_build() {
+    let writer = Arc::new(rayon_writer());
+    let ops = operations(OPS);
+
+    let build_writer = writer.clone();
+    let build = tokio::spawn(async move {
+        let started = Instant::now();
+        let _ = build_writer.prepare_upload(ops).await.expect("prepare");
+        started.elapsed()
+    });
+
+    // Probe mid-build.
+    tokio::time::sleep(Duration::from_millis(30)).await;
+    let probe_started = Instant::now();
+    let _ = writer.latest_published_watermark().await;
+    let probe = probe_started.elapsed();
+    let build = build.await.expect("build task");
+
+    println!("build took {build:?}, watermark probe waited {probe:?}");
+    assert!(
+        probe < Duration::from_millis(50),
+        "watermark read waited {probe:?} behind an in-flight {build:?} build"
+    );
+}

--- a/qmdb/rs/tests/writer_state_from_proof_watermark.rs
+++ b/qmdb/rs/tests/writer_state_from_proof_watermark.rs
@@ -1,0 +1,59 @@
+use commonware_cryptography::Sha256;
+use commonware_storage::merkle::{mmr, Location, Proof};
+use commonware_storage::qmdb::keyless::variable::Operation as KeylessOperation;
+use exoware_qmdb::{QmdbError, WriterState};
+
+type Family = mmr::Family;
+type Digest = commonware_cryptography::sha256::Digest;
+type Operation = KeylessOperation<Family, Vec<u8>>;
+
+fn operations(count: usize) -> Vec<Operation> {
+    let mut operations = Vec::with_capacity(count);
+    for i in 0..count - 1 {
+        operations.push(Operation::Append(format!("value-{i}").into_bytes()));
+    }
+    operations.push(Operation::Commit(None, Location::new(0)));
+    operations
+}
+
+fn proof(leaves: u64) -> Proof<Family, Digest> {
+    Proof {
+        leaves: Location::new(leaves),
+        inactive_peaks: 0,
+        digests: Vec::new(),
+    }
+}
+
+#[test]
+fn from_proof_accepts_consistent_watermark() {
+    let operations = operations(8);
+    let state = WriterState::from_proof::<Sha256, _>(
+        Location::new(7),
+        Location::new(0),
+        &proof(8),
+        &operations,
+    )
+    .expect("consistent watermark");
+
+    assert_eq!(state.next_location, Location::new(8));
+}
+
+#[test]
+fn from_proof_rejects_inconsistent_watermarks() {
+    let operations = operations(8);
+
+    for watermark in [5, 10] {
+        let error = WriterState::from_proof::<Sha256, _>(
+            Location::new(watermark),
+            Location::new(0),
+            &proof(8),
+            &operations,
+        )
+        .expect_err("inconsistent watermark");
+
+        assert!(matches!(
+            error,
+            QmdbError::CorruptData(message) if message.starts_with("proof watermark implies")
+        ));
+    }
+}


### PR DESCRIPTION
Fix #117 

See https://github.com/commonwarexyz/constantinople/pull/46 for its intended usage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches core Merkle/writer frontier logic and switches all commonware dependencies from crates.io to a pinned git revision, which affects consensus/storage behavior across the workspace.
> 
> **Overview**
> **Parallelizes QMDB upload preparation** by routing Merkle leaf hashing and tree extension through `commonware_parallel::Strategy` (default `Sequential`, optional `Rayon`), and pins the `commonware-*` crates to a specific git revision that exposes the parallel Merkle batch APIs.
> 
> **Writer API and behavior:** `prepare_upload` now takes **owned** operation batches (`Vec`) so encoding/hashing can run off the async task. Writers gain `new_with_strategy` / `fresh_with_strategy`; `WriterCore` runs builds via `strategy.spawn` behind a **build gate** so frontiers commit in order without holding the state mutex during CPU work. Watermark/checkpoint updates are tightened so stale flush completions cannot regress published state.
> 
> **Call-site updates:** Integration tests, CLI, and test helpers pass `ops.to_vec()` (and owned boundary state where required). Docs note that preparation may yield during the batch.
> 
> **Validation:** Adds a `writer_merkle` Criterion bench (sequential vs Rayon worker counts), unit/e2e tests that parallel output matches sequential, recovery with `recover_writer_state_with_strategy`, stall regressions for the event loop and watermark reads, and `WriterState::from_proof` watermark consistency checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22734c63c0cd3387552ef12298267264ed996296. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->