### PR TITLE
support env auth in ts client

### DIFF
--- a/sdk/ts/README.md
+++ b/sdk/ts/README.md
@@ -8,6 +8,17 @@ Interact with the Exoware API in TypeScript.
 
 `@exowarexyz/sdk` is **ALPHA** software and is not yet recommended for production use. Developers should expect breaking changes and occasional instability.
 
+## Credentials
+
+An auth token can be provided when constructing the client:
+
+```ts
+const client = new Client('https://query.<deployment>.<domain>', '<token>');
+```
+
+Or under Node the token may come from the `EXOWARE_API_KEY` environment variable instead, read when no token is passed to the client constructor.
+Browsers have no environment, so a browser client must be given its token explicitly.
+
 ## Store Key Prefixes
 
 Use `StoreKeyPrefix` when multiple logical QMDB, SQL, or raw KV instances share one Store database. The prefix is applied by the SDK, so higher-level clients keep using their normal logical keys:

--- a/sdk/ts/__tests__/credential.test.ts
+++ b/sdk/ts/__tests__/credential.test.ts
@@ -1,0 +1,165 @@
+import { Code, ConnectError } from '@connectrpc/connect';
+
+import { Client } from '../src/client';
+import {
+    API_KEY_ENV,
+    InvalidApiKeyError,
+    credentialRemedy,
+    resolveCredential,
+    withoutHtmlBody,
+} from '../src/credential';
+import { HttpError } from '../src/error';
+import { StoreClient } from '../src/store';
+
+/** The 401 body an ALB serves when it rejects a token, verbatim. */
+const PROXY_REJECTION =
+    'HTTP error 401: <html>\r\n<head><title>401 Authorization Required</title></head>\r\n<body>\r\n<center><h1>401 Authorization Required</h1></center>\r\n</body>\r\n</html>\r\n';
+
+/** A byte no base64url token contains, so the value is broken config rather than a near-miss. */
+const UNUSABLE = 'has\nnewline';
+
+describe('resolveCredential', () => {
+    test('an explicit token wins over the environment', () => {
+        expect(resolveCredential('explicit', 'from-env')).toEqual({
+            token: 'explicit',
+            credential: 'sent',
+        });
+    });
+
+    test('the environment supplies one when no token is given', () => {
+        expect(resolveCredential(undefined, 'from-env')).toEqual({
+            token: 'from-env',
+            credential: 'sent',
+        });
+    });
+
+    test('no token anywhere sends no header', () => {
+        // A deployment with no load balancer in front of it authenticates nothing, so this has to
+        // keep working rather than demand a credential.
+        expect(resolveCredential(undefined, undefined)).toEqual({ credential: 'absent' });
+    });
+
+    test('surrounding whitespace is trimmed rather than rejected', () => {
+        // A key reaching the environment through $(cat token) carries a trailing newline.
+        expect(resolveCredential(undefined, '  padded-token\n')).toEqual({
+            token: 'padded-token',
+            credential: 'sent',
+        });
+    });
+
+    test.each([
+        ['empty', ''],
+        ['only whitespace', '   \n'],
+    ])('a variable that is %s is an unset one', (_label, value) => {
+        expect(resolveCredential(undefined, value)).toEqual({ credential: 'absent' });
+    });
+
+    test('an unusable environment value names the variable', () => {
+        expect(() => resolveCredential(undefined, UNUSABLE)).toThrow(InvalidApiKeyError);
+        expect(() => resolveCredential(undefined, UNUSABLE)).toThrow(API_KEY_ENV);
+    });
+
+    test('an unusable explicit token does not blame the environment', () => {
+        expect(() => resolveCredential(UNUSABLE, undefined)).toThrow(InvalidApiKeyError);
+        expect(() => resolveCredential(UNUSABLE, undefined)).not.toThrow(API_KEY_ENV);
+    });
+
+    test('a non-ASCII token is rejected', () => {
+        expect(() => resolveCredential('tokén', undefined)).toThrow(InvalidApiKeyError);
+    });
+});
+
+describe('credentialRemedy', () => {
+    test('a missing credential is told how to supply one', () => {
+        const remedy = credentialRemedy('absent');
+        expect(remedy).toContain('none was sent');
+        expect(remedy).toContain(API_KEY_ENV);
+    });
+
+    test('a refused credential is told why rather than how to set one', () => {
+        // A caller that sent a credential must not be told to supply the one it already sent.
+        const remedy = credentialRemedy('sent');
+        expect(remedy).toContain('refused');
+        expect(remedy).toContain('expired');
+        expect(remedy).not.toContain(API_KEY_ENV);
+    });
+});
+
+describe('withoutHtmlBody', () => {
+    test('keeps the status and drops the page', () => {
+        expect(withoutHtmlBody(PROXY_REJECTION)).toBe('HTTP error 401');
+    });
+
+    test('recognizes a doctype and a message that is only markup', () => {
+        expect(withoutHtmlBody('HTTP error 502: <!DOCTYPE html><html></html>')).toBe(
+            'HTTP error 502',
+        );
+        expect(withoutHtmlBody('<html>bare</html>')).toBeUndefined();
+    });
+
+    test('a service message survives untouched', () => {
+        // Service errors are the common case, and nothing about them should be trimmed.
+        const message = 'key not found: a < b';
+        expect(withoutHtmlBody(message)).toBe(message);
+    });
+});
+
+describe('Client credential', () => {
+    test('records whether a credential will be sent', () => {
+        expect(new Client('http://localhost:10000', 'token-abc').credential).toBe('sent');
+        expect(new Client('http://localhost:10000').credential).toBe('absent');
+    });
+
+    test('an unusable token fails construction', () => {
+        expect(() => new Client('http://localhost:10000', UNUSABLE)).toThrow(InvalidApiKeyError);
+    });
+});
+
+describe('a rejected request', () => {
+    /**
+     * Drives the real error path by making the transport reject, which is the only way a
+     * `ConnectError` reaches `mapConnectToHttpError`.
+     */
+    async function rejectionFrom(client: Client, message: string): Promise<HttpError> {
+        client.query.get = () => {
+            throw new ConnectError(message, Code.Unauthenticated);
+        };
+        try {
+            await new StoreClient(client).get(new Uint8Array([1]));
+        } catch (err) {
+            return err as HttpError;
+        }
+        throw new Error('the call should have thrown');
+    }
+
+    test('drops the proxy page and explains a missing credential', async () => {
+        const err = await rejectionFrom(new Client('http://localhost:10000'), PROXY_REJECTION);
+
+        expect(err).toBeInstanceOf(HttpError);
+        expect(err.connectCode).toBe(Code.Unauthenticated);
+        expect(err.message).not.toContain('<');
+        expect(err.message).toContain('HTTP error 401');
+        expect(err.message).toContain(API_KEY_ENV);
+    });
+
+    test('tells a client that sent one that it was refused', async () => {
+        const err = await rejectionFrom(
+            new Client('http://localhost:10000', 'token-abc'),
+            PROXY_REJECTION,
+        );
+
+        expect(err.message).toContain('refused');
+        expect(err.message).not.toContain(API_KEY_ENV);
+    });
+
+    test('other codes carry no credential remedy', async () => {
+        const client = new Client('http://localhost:10000');
+        client.query.get = () => {
+            throw new ConnectError('no such key', Code.NotFound);
+        };
+
+        await expect(new StoreClient(client).get(new Uint8Array([1]))).rejects.toThrow(
+            /no such key$/,
+        );
+    });
+});

--- a/sdk/ts/__tests__/credential.test.ts
+++ b/sdk/ts/__tests__/credential.test.ts
@@ -5,6 +5,7 @@ import {
     API_KEY_ENV,
     InvalidApiKeyError,
     credentialRemedy,
+    environmentApiKey,
     resolveCredential,
     withoutHtmlBody,
 } from '../src/credential';
@@ -112,6 +113,75 @@ describe('Client credential', () => {
 
     test('an unusable token fails construction', () => {
         expect(() => new Client('http://localhost:10000', UNUSABLE)).toThrow(InvalidApiKeyError);
+    });
+});
+
+describe('the Authorization header actually sent', () => {
+    const realFetch = globalThis.fetch;
+
+    afterEach(() => {
+        globalThis.fetch = realFetch;
+    });
+
+    /**
+     * Captures what reaches the network. The stub is installed before the client is built, because
+     * the transport resolves `fetch` once at construction.
+     */
+    function captureAuthorization(): () => string | null {
+        let seen: string | null = null;
+        globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+            const headers = new Headers(
+                init?.headers ?? (input instanceof Request ? input.headers : undefined),
+            );
+            seen = headers.get('authorization');
+            return new Response('{"code":"unauthenticated","message":"stub"}', {
+                status: 401,
+                headers: { 'content-type': 'application/json' },
+            });
+        }) as typeof fetch;
+        return () => seen;
+    }
+
+    async function get(client: Client, headers?: Record<string, string>): Promise<void> {
+        // The stub always rejects, so the assertion is on the request rather than the result.
+        await expect(
+            client.query.get({ key: new Uint8Array([1]) }, headers ? { headers } : undefined),
+        ).rejects.toThrow();
+    }
+
+    test("the client's token is sent when the caller supplies none", async () => {
+        const sent = captureAuthorization();
+        await get(new Client('http://localhost:10000', 'client-token'));
+
+        expect(sent()).toBe('Bearer client-token');
+    });
+
+    test('a caller-supplied credential is left alone', async () => {
+        // What lets one client reach a deployment expecting a different credential on one call.
+        const sent = captureAuthorization();
+        await get(new Client('http://localhost:10000', 'client-token'), {
+            Authorization: 'Bearer caller-token',
+        });
+
+        expect(sent()).toBe('Bearer caller-token');
+    });
+
+    test('a caller-supplied credential survives a token from the environment', async () => {
+        // The regression this guards: an ambient variable must not replace a per-call credential.
+        const sent = captureAuthorization();
+        const client = new Client('http://localhost:10000', {
+            token: environmentApiKey() ?? 'from-env',
+        });
+        await get(client, { Authorization: 'Bearer caller-token' });
+
+        expect(sent()).toBe('Bearer caller-token');
+    });
+
+    test('no credential anywhere sends no header', async () => {
+        const sent = captureAuthorization();
+        await get(new Client('http://localhost:10000'));
+
+        expect(sent()).toBeNull();
     });
 });
 

--- a/sdk/ts/__tests__/credential.test.ts
+++ b/sdk/ts/__tests__/credential.test.ts
@@ -1,5 +1,14 @@
 import { Code, ConnectError } from '@connectrpc/connect';
 
+/**
+ * Stands in for the environment lookup, so no assertion here depends on whether the developer
+ * running the suite happens to have `EXOWARE_API_KEY` exported.
+ */
+jest.mock('../src/credential', () => ({
+    ...jest.requireActual('../src/credential'),
+    environmentApiKey: jest.fn(),
+}));
+
 import { Client } from '../src/client';
 import {
     API_KEY_ENV,
@@ -18,6 +27,16 @@ const PROXY_REJECTION =
 
 /** A byte no base64url token contains, so the value is broken config rather than a near-miss. */
 const UNUSABLE = 'has\nnewline';
+
+/** Sets what the environment appears to hold for the rest of the current test. */
+function givenEnvironmentKey(key: string | undefined): void {
+    jest.mocked(environmentApiKey).mockReturnValue(key);
+}
+
+// Every test starts from an environment holding nothing, and says so when it wants otherwise.
+beforeEach(() => {
+    givenEnvironmentKey(undefined);
+});
 
 describe('resolveCredential', () => {
     test('an explicit token wins over the environment', () => {
@@ -111,6 +130,12 @@ describe('Client credential', () => {
         expect(new Client('http://localhost:10000').credential).toBe('absent');
     });
 
+    test('a token from the environment counts as one that will be sent', () => {
+        givenEnvironmentKey('from-env');
+
+        expect(new Client('http://localhost:10000').credential).toBe('sent');
+    });
+
     test('an unusable token fails construction', () => {
         expect(() => new Client('http://localhost:10000', UNUSABLE)).toThrow(InvalidApiKeyError);
     });
@@ -166,13 +191,22 @@ describe('the Authorization header actually sent', () => {
         expect(sent()).toBe('Bearer caller-token');
     });
 
-    test('a caller-supplied credential survives a token from the environment', async () => {
-        // The regression this guards: an ambient variable must not replace a per-call credential.
+    test('a token from the environment is sent when the caller supplies none', async () => {
+        givenEnvironmentKey('from-env');
         const sent = captureAuthorization();
-        const client = new Client('http://localhost:10000', {
-            token: environmentApiKey() ?? 'from-env',
+        await get(new Client('http://localhost:10000'));
+
+        expect(sent()).toBe('Bearer from-env');
+    });
+
+    test('a caller-supplied credential survives a token from the environment', async () => {
+        // The regression this guards: a variable the caller never passed, and may not know is set,
+        // must not replace the credential they attached to this call.
+        givenEnvironmentKey('from-env');
+        const sent = captureAuthorization();
+        await get(new Client('http://localhost:10000'), {
+            Authorization: 'Bearer caller-token',
         });
-        await get(client, { Authorization: 'Bearer caller-token' });
 
         expect(sent()).toBe('Bearer caller-token');
     });

--- a/sdk/ts/__tests__/sdk.test.ts
+++ b/sdk/ts/__tests__/sdk.test.ts
@@ -2,6 +2,17 @@ import * as path from 'path';
 import * as fs from 'fs';
 import * as os from 'os';
 import { create } from '@bufbuild/protobuf';
+
+/**
+ * These tests reach a local simulator that authenticates nothing, so the client is built without a
+ * credential regardless of what the developer running them has exported. `credential.test.ts` is
+ * where the environment lookup itself is covered.
+ */
+jest.mock('../src/credential', () => ({
+    ...jest.requireActual('../src/credential'),
+    environmentApiKey: () => undefined,
+}));
+
 import { Client } from '../src/client';
 import { StoreKeyPrefix, StoreWriteBatch, TraversalMode } from '../src/store';
 import {

--- a/sdk/ts/src/client.ts
+++ b/sdk/ts/src/client.ts
@@ -81,7 +81,11 @@ function transportWithCredential(
     const interceptors: Interceptor[] = [];
     if (token !== undefined) {
         interceptors.push((next) => async (req) => {
-            req.header.set('Authorization', `Bearer ${token}`);
+            // Connect seeds req.header from CallOptions.headers before interceptors run, so a
+            // caller-supplied credential is already here and takes precedence.
+            if (!req.header.has('Authorization')) {
+                req.header.set('Authorization', `Bearer ${token}`);
+            }
             return next(req);
         });
     }

--- a/sdk/ts/src/client.ts
+++ b/sdk/ts/src/client.ts
@@ -1,6 +1,7 @@
 import { createClient, type Client as ConnectClient, type Interceptor, Code, ConnectError } from '@connectrpc/connect';
 import { createConnectTransport } from '@connectrpc/connect-web';
 import { CookieJar, fetchWithCookieJar } from './cookies.js';
+import { environmentApiKey, resolveCredential, type Credential } from './credential.js';
 import { StoreClient, type StoreKeyPrefix } from './store.js';
 import { Service as IngestService } from './gen/ts/log/v1/ingest_pb.js';
 import { Service as PruneService } from './gen/ts/store/v1/prune_pb.js';
@@ -67,23 +68,40 @@ function normalizeClientOptions(tokenOrOptions?: string | ClientOptions): Client
     return typeof tokenOrOptions === 'string' ? { token: tokenOrOptions } : tokenOrOptions ?? {};
 }
 
-export function createTransport(baseUrl: string, tokenOrOptions?: string | ClientOptions) {
-    const opts = normalizeClientOptions(tokenOrOptions);
+/**
+ * Builds the transport and reports whether it carries a credential, so a `Client` resolves the
+ * token once rather than reading the environment again.
+ */
+function transportWithCredential(
+    baseUrl: string,
+    opts: ClientOptions,
+): { transport: ReturnType<typeof createConnectTransport>; credential: Credential } {
     const retryConfig = opts.retry ?? DEFAULT_RETRY_CONFIG;
+    const { token, credential } = resolveCredential(opts.token, environmentApiKey());
     const interceptors: Interceptor[] = [];
-    if (opts.token !== undefined) {
-        const token = opts.token;
+    if (token !== undefined) {
         interceptors.push((next) => async (req) => {
             req.header.set('Authorization', `Bearer ${token}`);
             return next(req);
         });
     }
     interceptors.push(makeRetryInterceptor(retryConfig));
-    return createConnectTransport({
-        baseUrl: baseUrl.replace(/\/$/, ''),
-        interceptors,
-        fetch: fetchWithCookieJar(new CookieJar()),
-    });
+    return {
+        transport: createConnectTransport({
+            baseUrl: baseUrl.replace(/\/$/, ''),
+            interceptors,
+            fetch: fetchWithCookieJar(new CookieJar()),
+        }),
+        credential,
+    };
+}
+
+/**
+ * Takes the API key from `EXOWARE_API_KEY` when running under Node and no `token` is given, and
+ * throws `InvalidApiKeyError` if either cannot be an HTTP header.
+ */
+export function createTransport(baseUrl: string, tokenOrOptions?: string | ClientOptions) {
+    return transportWithCredential(baseUrl, normalizeClientOptions(tokenOrOptions)).transport;
 }
 
 export class Client {
@@ -94,12 +112,15 @@ export class Client {
     public readonly retention: ConnectClient<typeof RetentionService>;
     public readonly stream: ConnectClient<typeof StreamService>;
     public readonly retryConfig: RetryConfig;
+    /** Whether this client sends a credential, which is what makes a 401 explicable. */
+    public readonly credential: Credential;
 
     constructor(baseUrl: string, tokenOrOptions?: string | ClientOptions) {
         const opts = normalizeClientOptions(tokenOrOptions);
         this.baseUrl = baseUrl.replace(/\/$/, '');
         this.retryConfig = opts.retry ?? DEFAULT_RETRY_CONFIG;
-        const transport = createTransport(this.baseUrl, opts);
+        const { transport, credential } = transportWithCredential(this.baseUrl, opts);
+        this.credential = credential;
         this.ingest = createClient(IngestService, transport);
         this.prune = createClient(PruneService, transport);
         this.query = createClient(QueryService, transport);

--- a/sdk/ts/src/credential.ts
+++ b/sdk/ts/src/credential.ts
@@ -1,0 +1,114 @@
+/**
+ * The API key a client presents, and what a rejection tells the caller to do about it.
+ *
+ * A client cannot tell from its configuration whether the endpoint requires a credential, since a
+ * deployment behind a load balancer authenticates every RPC and one without authenticates none. It
+ * sends whatever it has and explains itself when a call is rejected.
+ */
+
+import { ExowareError } from './error.js';
+
+/** Environment variable read for the API key, in Node, when no token is passed to the client. */
+export const API_KEY_ENV = 'EXOWARE_API_KEY';
+
+/**
+ * Whether a client sends a credential with every request. A rejection reads the same either way,
+ * so only the client can tell a missing credential from a refused one.
+ */
+export type Credential = 'sent' | 'absent';
+
+/** Thrown when a configured API key cannot be sent as an HTTP header. */
+export class InvalidApiKeyError extends ExowareError {
+    constructor(message: string) {
+        super(message);
+        this.name = 'InvalidApiKeyError';
+    }
+}
+
+export type ResolvedCredential = {
+    token?: string;
+    credential: Credential;
+};
+
+/** Header field values are tab and visible ASCII, so anything else cannot be sent. */
+const USABLE_HEADER_VALUE = /^[\t\x20-\x7e]*$/;
+
+/**
+ * Reads the API key from the environment, or `undefined` in a browser.
+ *
+ * A browser has no environment, so this is the Node half of the same split `cookies.ts` makes for
+ * cookie jars.
+ */
+export function environmentApiKey(): string | undefined {
+    if (typeof process === 'undefined') {
+        return undefined;
+    }
+    return process.env?.[API_KEY_ENV];
+}
+
+/**
+ * Chooses between an explicitly configured token and one found in the environment, and throws
+ * `InvalidApiKeyError` if the chosen one cannot be an HTTP header.
+ *
+ * Takes the environment lookup as an argument rather than reading it, so that every case is
+ * reachable without touching a process-wide variable.
+ */
+export function resolveCredential(
+    explicit: string | undefined,
+    fromEnvironment: string | undefined,
+): ResolvedCredential {
+    const isFromEnvironment = explicit === undefined;
+    const candidate = explicit ?? fromEnvironment;
+
+    // Surrounding whitespace is trimmed rather than rejected. A key routinely arrives as
+    // EXOWARE_API_KEY=$(cat token), which carries a trailing newline that is no part of it.
+    const token = candidate?.trim();
+    if (token === undefined || token === '') {
+        return { credential: 'absent' };
+    }
+
+    if (!USABLE_HEADER_VALUE.test(token)) {
+        throw new InvalidApiKeyError(
+            isFromEnvironment
+                ? `${API_KEY_ENV} is set to a value that cannot be an HTTP header. Remove any control or non-ASCII characters from it`
+                : 'The API key given to this client cannot be an HTTP header (check for control or non-ASCII characters)',
+        );
+    }
+
+    return { token, credential: 'sent' };
+}
+
+/**
+ * Advice for an unauthenticated rejection.
+ *
+ * Neither case names a symbol, because whoever reads this may not be whoever wrote the call.
+ */
+export function credentialRemedy(credential: Credential): string {
+    return credential === 'absent'
+        ? `This endpoint requires a credential and none was sent. Supply one when constructing the client, or in Node through the ${API_KEY_ENV} environment variable`
+        : 'The credential sent with this request was refused. It may have expired, or been issued for a different deployment, or lack the scope this call needs';
+}
+
+/**
+ * Drops an HTML error page from a message, keeping whatever preceded it.
+ *
+ * A proxy that rejects a request before it reaches a service answers with a page rather than a
+ * ConnectRPC error, and the whole page arrives in the message. Returns `undefined` when nothing but
+ * markup was there.
+ */
+export function withoutHtmlBody(message: string): string | undefined {
+    const lowercase = message.toLowerCase();
+    const starts = ['<html', '<!doctype']
+        .map((marker) => lowercase.indexOf(marker))
+        .filter((index) => index >= 0);
+    if (starts.length === 0) {
+        return message;
+    }
+
+    const kept = message
+        .slice(0, Math.min(...starts))
+        .trimEnd()
+        .replace(/:+$/, '')
+        .trimEnd();
+    return kept === '' ? undefined : kept;
+}

--- a/sdk/ts/src/index.ts
+++ b/sdk/ts/src/index.ts
@@ -1,4 +1,5 @@
 export { Client, createTransport, type ClientOptions, type RetryConfig } from './client.js';
+export { API_KEY_ENV, InvalidApiKeyError, type Credential } from './credential.js';
 export { CookieJar, fetchWithCookieJar } from './cookies.js';
 export {
     SerializableReadSession,

--- a/sdk/ts/src/store.ts
+++ b/sdk/ts/src/store.ts
@@ -2,6 +2,7 @@ import { create, type MessageInitShape } from '@bufbuild/protobuf';
 import { Code, ConnectError } from '@connectrpc/connect';
 import type { CallOptions } from '@connectrpc/connect';
 import type { Client } from './client.js';
+import { credentialRemedy, withoutHtmlBody, type Credential } from './credential.js';
 import { HttpError } from './error.js';
 import { PruneRequestSchema } from './gen/ts/store/v1/prune_pb.js';
 import type { Policy } from './gen/ts/store/v1/prune_pb.js';
@@ -222,10 +223,19 @@ function normalizeMinSequenceNumber(value?: bigint): bigint | undefined {
     return value !== undefined && value > 0n ? value : undefined;
 }
 
-function mapConnectToHttpError(err: unknown): never {
+/**
+ * Presents an RPC failure to the caller, dropping any page a proxy answered with and telling a
+ * rejected caller what to do about their credential.
+ */
+function mapConnectToHttpError(err: unknown, credential: Credential): never {
     if (err instanceof ConnectError) {
         const status = connectCodeToHttpStatus(err.code);
-        throw new HttpError(status, err.message || String(err.code), err.code, err);
+        let message = withoutHtmlBody(err.message);
+        if (err.code === Code.Unauthenticated) {
+            const remedy = credentialRemedy(credential);
+            message = message === undefined ? remedy : `${message}. ${remedy}`;
+        }
+        throw new HttpError(status, message || String(err.code), err.code, err);
     }
     throw err;
 }
@@ -462,7 +472,7 @@ async function performGet(
         }
         return { value: res.value };
     } catch (e) {
-        mapConnectToHttpError(e);
+        mapConnectToHttpError(e, client.credential);
     }
 }
 
@@ -502,7 +512,7 @@ async function performGetMany(
         }
         return results;
     } catch (e) {
-        mapConnectToHttpError(e);
+        mapConnectToHttpError(e, client.credential);
     }
 }
 
@@ -540,7 +550,7 @@ async function performQuery(
         }
         return { results };
     } catch (e) {
-        mapConnectToHttpError(e);
+        mapConnectToHttpError(e, client.credential);
     }
 }
 
@@ -568,7 +578,7 @@ async function performReduce(
         }
         return res;
     } catch (e) {
-        mapConnectToHttpError(e);
+        mapConnectToHttpError(e, client.credential);
     }
 }
 
@@ -589,7 +599,7 @@ async function performGetBatch(
         ) {
             return null;
         }
-        mapConnectToHttpError(e);
+        mapConnectToHttpError(e, client.credential);
     }
 }
 
@@ -623,7 +633,7 @@ async function* performSubscribe(
             yield batch;
         }
     } catch (e) {
-        mapConnectToHttpError(e);
+        mapConnectToHttpError(e, client.credential);
     }
 }
 
@@ -827,7 +837,7 @@ export class StoreClient {
             const res = await this.client.ingest.put(req);
             return res.sequenceNumber;
         } catch (e) {
-            mapConnectToHttpError(e);
+            mapConnectToHttpError(e, this.client.credential);
         }
     }
 
@@ -844,7 +854,7 @@ export class StoreClient {
             const res = await this.client.ingest.put(req);
             return res.sequenceNumber;
         } catch (e) {
-            mapConnectToHttpError(e);
+            mapConnectToHttpError(e, this.client.credential);
         }
     }
 
@@ -861,7 +871,7 @@ export class StoreClient {
             const res = await this.client.ingest.put(req);
             return res.sequenceNumber;
         } catch (e) {
-            mapConnectToHttpError(e);
+            mapConnectToHttpError(e, this.client.credential);
         }
     }
 
@@ -912,7 +922,7 @@ export class StoreClient {
         try {
             await this.client.prune.prune(req);
         } catch (e) {
-            mapConnectToHttpError(e);
+            mapConnectToHttpError(e, this.client.credential);
         }
     }
 


### PR DESCRIPTION
When running in Node, support `EXOWARE_API_KEY`. Also improve error message when receiving a 401.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> SDK-only auth and error-message changes with broad tests; behavior change is additive (env fallback) and still allows unauthenticated local use when no key is set.
> 
> **Overview**
> Adds **credential resolution** for the TypeScript client: in Node, `EXOWARE_API_KEY` is used when no constructor token is passed; explicit tokens win, values are trimmed and validated as HTTP-safe ASCII, and clients with no key still send no `Authorization` header (for unauthenticated deployments).
> 
> The transport only sets `Bearer` when the request does not already have `Authorization`, and `Client` exposes a **`credential`** flag (`sent` | `absent`) so errors can distinguish missing vs refused keys. **401 / Unauthenticated** handling strips proxy HTML from messages and appends targeted guidance (`EXOWARE_API_KEY` vs expired/wrong deployment). New exports: `API_KEY_ENV`, `InvalidApiKeyError`, `Credential`. README documents credentials; integration tests mock env lookup; dedicated `credential.test.ts` covers resolution, headers, and error text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a69545aec11b9f4523718e36fbe6e01791c70764. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->