### PR TITLE
validation: bench performance imrovements

### DIFF
--- a/.github/actions/run-validation/action.yml
+++ b/.github/actions/run-validation/action.yml
@@ -324,6 +324,7 @@ runs:
             ("Seed", report["seed"]),
             ("Operations", report["operations"]),
             ("Write batch size", config["batch_size"]),
+            ("Request compression", config["request_compression"]),
             ("Errors", report["errors"]),
             ("Reads", report["reads"]),
             ("Read misses", report["read_misses"]),

--- a/.github/actions/run-validation/action.yml
+++ b/.github/actions/run-validation/action.yml
@@ -324,7 +324,7 @@ runs:
             ("Seed", report["seed"]),
             ("Operations", report["operations"]),
             ("Write batch size", config["batch_size"]),
-            ("Request compression", config["request_compression"]),
+            ("Request compression", config.get("request_compression", "none")),
             ("Errors", report["errors"]),
             ("Reads", report["reads"]),
             ("Read misses", report["read_misses"]),

--- a/validation/README.md
+++ b/validation/README.md
@@ -73,7 +73,7 @@ Benchmark JSON reports include the normalized config, seed, counters, and per-op
 
 Generated load and benchmark keys open with a byte derived from the logical index, so a run's keys spread across the entire physical key range instead of sharing a fixed prefix. Standard validation instead uses its own contiguous key layout, keeping its whole-keyspace range checks bounded to the rows it owns.
 
-`bench` reports `scan_rows` as every physical row returned by the store, including rows from other namespaces in the sampled interval. Compare scan latency and row counts only between runs against the same controlled fixture; the action's simulator reports are functionality artifacts, not cross-environment performance evidence.
+`bench` scans seek forward from one sampled key and bound their work by the row limit (`--scan-length`); because keys spread across the physical range, a window between two sampled keys would span an arbitrarily large fraction of the store. `scan_rows` counts every physical row returned, including rows from other namespaces past the seek point. Compare scan latency and row counts only between runs against the same controlled fixture; the action's simulator reports are functionality artifacts, not cross-environment performance evidence.
 
 `load`, `bench`, and `validate` accept `--value-size` (bytes, default 160) to control generated value size. Pass the same `--value-size` to `load` and a reading `bench` so writes appended during the benchmark match the loaded data.
 

--- a/validation/README.md
+++ b/validation/README.md
@@ -104,7 +104,7 @@ Generated load and benchmark keys open with a byte derived from the logical inde
     "batch_size": 100,
     "keyspace_layout_version": 2,
     "value_generator_version": 1,
-    "workload_generator_version": 5,
+    "workload_generator_version": 6,
     "read_retry_attempts": 3,
     "request_compression": "zstd"
   },

--- a/validation/README.md
+++ b/validation/README.md
@@ -79,7 +79,7 @@ Generated load and benchmark keys open with a byte derived from the logical inde
 
 ## Benchmark Manifests
 
-`validation bench --manifest <path>` accepts the normalized `config` and `seed` fields from a benchmark JSON report, so a run can be replayed without reconstructing CLI flags. The config includes request compression because it materially affects measured throughput. For a fixed manifest, each worker repeats its logical operation stream and its appended-key allocation independent of task scheduling. A manifest whose key, value, or workload-generator version differs from the current binary is rejected rather than silently replayed with different data. A minimal manifest has this shape:
+`validation bench --manifest <path>` accepts the normalized `config` and `seed` fields from a benchmark JSON report, so a run can be replayed without reconstructing CLI flags. The config includes request compression because it materially affects measured throughput. For a fixed manifest and the same acknowledged write outcomes, each worker repeats its logical operation stream and its appended-key allocation independent of task scheduling. A manifest whose key, value, or workload-generator version differs from the current binary is rejected rather than silently replayed with different data. A minimal manifest has this shape:
 
 ```json
 {
@@ -104,7 +104,7 @@ Generated load and benchmark keys open with a byte derived from the logical inde
     "batch_size": 100,
     "keyspace_layout_version": 2,
     "value_generator_version": 1,
-    "workload_generator_version": 6,
+    "workload_generator_version": 7,
     "read_retry_attempts": 3,
     "request_compression": "zstd"
   },

--- a/validation/README.md
+++ b/validation/README.md
@@ -73,13 +73,13 @@ Benchmark JSON reports include the normalized config, seed, counters, and per-op
 
 Generated load and benchmark keys open with a byte derived from the logical index, so a run's keys spread across the entire physical key range instead of sharing a fixed prefix. Standard validation instead uses its own contiguous key layout, keeping its whole-keyspace range checks bounded to the rows it owns.
 
-`bench` scans seek forward from one sampled key and bound their work by the row limit (`--scan-length`); because keys spread across the physical range, a window between two sampled keys would span an arbitrarily large fraction of the store. `scan_rows` counts every physical row returned, including rows from other namespaces past the seek point. Compare scan latency and row counts only between runs against the same controlled fixture; the action's simulator reports are functionality artifacts, not cross-environment performance evidence.
+`bench` scans seek forward from one sampled key within the ordered range that shares its leading byte. `--scan-length` caps returned rows. A scan can return fewer rows when it reaches the end of that prefix range. This keeps the requested key range narrow even though generated keys spread across the full keyspace. `scan_rows` counts every physical row returned, including rows from other namespaces after the seek point. Compare scan latency and row counts only between runs against the same controlled fixture. The action's simulator reports are functionality artifacts rather than cross-environment performance evidence.
 
 `load`, `bench`, and `validate` accept `--value-size` (bytes, default 160) to control generated value size. Pass the same `--value-size` to `load` and a reading `bench` so writes appended during the benchmark match the loaded data.
 
 ## Benchmark Manifests
 
-`validation bench --manifest <path>` accepts the normalized `config` and `seed` fields from a benchmark JSON report, so a run can be replayed without reconstructing CLI flags. For a fixed manifest, each worker repeats its logical operation stream and its appended-key allocation independent of task scheduling. A manifest whose key, value, or workload-generator version differs from the current binary is rejected rather than silently replayed with different data. A minimal manifest has this shape:
+`validation bench --manifest <path>` accepts the normalized `config` and `seed` fields from a benchmark JSON report, so a run can be replayed without reconstructing CLI flags. The config includes request compression because it materially affects measured throughput. For a fixed manifest, each worker repeats its logical operation stream and its appended-key allocation independent of task scheduling. A manifest whose key, value, or workload-generator version differs from the current binary is rejected rather than silently replayed with different data. A minimal manifest has this shape:
 
 ```json
 {
@@ -104,8 +104,9 @@ Generated load and benchmark keys open with a byte derived from the logical inde
     "batch_size": 100,
     "keyspace_layout_version": 2,
     "value_generator_version": 1,
-    "workload_generator_version": 3,
-    "read_retry_attempts": 3
+    "workload_generator_version": 5,
+    "read_retry_attempts": 3,
+    "request_compression": "zstd"
   },
   "seed": 1592639710
 }

--- a/validation/src/bench.rs
+++ b/validation/src/bench.rs
@@ -374,18 +374,12 @@ async fn run_workload(config: Config) -> anyhow::Result<()> {
                             }
                         }
                     }
-                    Operation::Scan { start, end, limit } => {
-                        // Index-hashed key placement leaves the two endpoint keys in
-                        // arbitrary lexicographic order, so sort them into a valid window.
-                        let (start_key, end_key) = {
-                            let a = keyspace.inserted_key(start);
-                            let b = keyspace.inserted_key(end);
-                            if a <= b {
-                                (a, b)
-                            } else {
-                                (b, a)
-                            }
-                        };
+                    Operation::Scan { start, limit } => {
+                        // Seek from one inserted key and let the row limit bound the
+                        // scan (see the Operation::Scan doc for why no second hashed
+                        // endpoint is used).
+                        let start_key = keyspace.inserted_key(start);
+                        let end_key = keyspace.scan_upper_bound();
                         let request_start = Instant::now();
                         let result = client.query().range(&start_key, &end_key, limit).await;
                         latencies.record_scan(request_start.elapsed());
@@ -520,6 +514,7 @@ mod tests {
     use std::sync::{Arc, Mutex};
 
     use super::*;
+    use crate::client::RequestCompression;
     use crate::keyspace::DEFAULT_KEY_LEN;
     use axum::Router;
     use connectrpc::{ConnectRpcService, RequestContext};
@@ -610,6 +605,7 @@ mod tests {
             client: ClientArgs {
                 url: "http://localhost:10000/".to_string(),
                 read_retry_attempts: 3,
+                request_compression: RequestCompression::default(),
             },
             manifest: None,
             keys: 10_000,

--- a/validation/src/bench.rs
+++ b/validation/src/bench.rs
@@ -351,6 +351,7 @@ async fn run_workload(config: Config) -> anyhow::Result<()> {
                 worker as u64,
                 worker_workload,
                 zipf_sampler,
+                concurrency,
             );
             let mut write_number = 0u64;
 

--- a/validation/src/bench.rs
+++ b/validation/src/bench.rs
@@ -208,6 +208,10 @@ impl Config {
             manifest.config.workload_generator_version,
             WORKLOAD_GENERATOR_VERSION
         );
+        let request_compression = manifest
+            .config
+            .request_compression
+            .context("current manifest requires request_compression")?;
         ensure!(
             manifest.config.key_space > 0,
             "manifest key_space must be > 0"
@@ -231,7 +235,7 @@ impl Config {
                 manifest.config.endpoint,
                 manifest.config.read_retry_attempts,
             )?
-            .with_request_compression(manifest.config.request_compression),
+            .with_request_compression(request_compression),
             namespace: manifest.config.namespace,
             keyspace: Keyspace::from_u64_namespace(
                 manifest.config.namespace,
@@ -252,10 +256,11 @@ impl Config {
 }
 
 pub async fn run(args: Args) -> anyhow::Result<()> {
-    run_workload(Config::try_from(args)?).await
+    run_workload(Config::try_from(args)?).await?;
+    Ok(())
 }
 
-async fn run_workload(config: Config) -> anyhow::Result<()> {
+async fn run_workload(config: Config) -> anyhow::Result<BenchReport> {
     let Config {
         client: client_config,
         namespace,
@@ -288,7 +293,7 @@ async fn run_workload(config: Config) -> anyhow::Result<()> {
         value_generator_version: VALUE_GENERATOR_VERSION,
         workload_generator_version: WORKLOAD_GENERATOR_VERSION,
         read_retry_attempts: client_config.read_retry_attempts(),
-        request_compression: client_config.request_compression(),
+        request_compression: Some(client_config.request_compression()),
     };
     let ops_done = Arc::new(AtomicU64::new(0));
     let reads_ok = Arc::new(AtomicU64::new(0));
@@ -302,8 +307,8 @@ async fn run_workload(config: Config) -> anyhow::Result<()> {
     // calls, so error-heavy runs still explain where time was spent.
     let latencies = Arc::new(LatencyHistogramsRecorder::default());
 
-    // Uniform and Zipfian reads sample the prepared fixture. Latest reads use
-    // a deterministic estimate of the appended frontier.
+    // Uniform and Zipfian reads sample the prepared fixture. Latest reads also
+    // sample prior writes from the current worker's deterministic lane.
     let readable_key_count = initial_keys;
     let zipf_sampler = (workload.key_dist == KeyDistribution::Zipfian)
         .then(|| Arc::new(ZipfSampler::new(readable_key_count, workload.zipf_theta)));
@@ -476,19 +481,24 @@ async fn run_workload(config: Config) -> anyhow::Result<()> {
     };
     print_bench_report(&report);
     if report.read_misses > 0 {
-        // A raw benchmark may deliberately measure absent-key reads, but a preloaded-fixture
-        // benchmark should treat them as a signal that its results are not representative.
-        tracing::warn!(
-            read_misses = report.read_misses,
-            reads = report.reads,
-            "benchmark observed missing reads; verify the intended fixture before using these results"
-        );
+        match report.config.workload.key_dist {
+            KeyDistribution::Latest => tracing::warn!(
+                read_misses = report.read_misses,
+                reads = report.reads,
+                "benchmark observed missing latest reads. Inspect post-write visibility before using these results"
+            ),
+            KeyDistribution::Uniform | KeyDistribution::Zipfian => tracing::warn!(
+                read_misses = report.read_misses,
+                reads = report.reads,
+                "benchmark observed missing fixture reads. Verify the intended fixture before using these results"
+            ),
+        }
     }
     if let Some(path) = output {
         write_bench_report_json(&path, &report, started_at, finished_at)?;
     }
 
-    Ok(())
+    Ok(report)
 }
 
 fn worker_batch_write_index(
@@ -519,11 +529,18 @@ mod tests {
     use crate::keyspace::DEFAULT_KEY_LEN;
     use axum::Router;
     use clap::Parser;
-    use connectrpc::{ConnectRpcService, RequestContext};
+    use connectrpc::{Chain, ConnectError, ConnectRpcService, RequestContext};
+    use exoware_sdk::common::kv::v1::Entry;
     use exoware_sdk::ingest::{
         OwnedPutRequestView, PutResponse, Service as IngestService,
         ServiceServer as IngestServiceServer,
     };
+    use exoware_sdk::query::{
+        GetManyFrame, GetResponse, OwnedGetManyRequestView, OwnedGetRequestView,
+        OwnedRangeRequestView, OwnedReduceRequestView, RangeFrame, ReduceResponse,
+        Service as QueryService, ServiceServer as QueryServiceServer,
+    };
+    use futures::stream;
 
     #[derive(Parser)]
     struct BenchCli {
@@ -534,6 +551,30 @@ mod tests {
     #[derive(Clone)]
     struct BenchIngestHarness {
         batch_sizes: Arc<Mutex<Vec<usize>>>,
+    }
+
+    #[derive(Clone, Debug, Eq, PartialEq)]
+    struct CapturedRange {
+        start: Vec<u8>,
+        end: Vec<u8>,
+        limit: Option<u32>,
+    }
+
+    #[derive(Clone)]
+    struct BenchQueryHarness {
+        ranges: Arc<Mutex<Vec<CapturedRange>>>,
+    }
+
+    #[derive(Default)]
+    struct BenchStoreState {
+        available_keys: HashSet<Vec<u8>>,
+        written_keys: HashSet<Vec<u8>>,
+        written_read_hits: usize,
+    }
+
+    #[derive(Clone)]
+    struct BenchStoreHarness {
+        state: Arc<Mutex<BenchStoreState>>,
     }
 
     #[allow(refining_impl_trait)]
@@ -551,6 +592,125 @@ mod tests {
                 sequence_number: 1,
                 ..Default::default()
             })
+        }
+    }
+
+    #[allow(refining_impl_trait)]
+    impl QueryService for BenchQueryHarness {
+        async fn get(
+            &self,
+            _ctx: RequestContext,
+            _request: OwnedGetRequestView,
+        ) -> connectrpc::ServiceResult<GetResponse> {
+            Err(ConnectError::unimplemented("test harness"))
+        }
+
+        async fn get_many(
+            &self,
+            _ctx: RequestContext,
+            _request: OwnedGetManyRequestView,
+        ) -> connectrpc::ServiceResult<connectrpc::ServiceStream<GetManyFrame>> {
+            Err(ConnectError::unimplemented("test harness"))
+        }
+
+        async fn range(
+            &self,
+            _ctx: RequestContext,
+            request: OwnedRangeRequestView,
+        ) -> connectrpc::ServiceResult<connectrpc::ServiceStream<RangeFrame>> {
+            self.ranges
+                .lock()
+                .expect("range request lock")
+                .push(CapturedRange {
+                    start: request.start.to_vec(),
+                    end: request.end.to_vec(),
+                    limit: request.limit,
+                });
+            let entry = Entry {
+                key: request.start.to_vec(),
+                value: vec![1].into(),
+                ..Default::default()
+            };
+            Ok(connectrpc::Response::stream(stream::iter([Ok(
+                RangeFrame {
+                    results: vec![entry.clone(), entry],
+                    ..Default::default()
+                },
+            )])))
+        }
+
+        async fn reduce(
+            &self,
+            _ctx: RequestContext,
+            _request: OwnedReduceRequestView,
+        ) -> connectrpc::ServiceResult<ReduceResponse> {
+            Err(ConnectError::unimplemented("test harness"))
+        }
+    }
+
+    #[allow(refining_impl_trait)]
+    impl IngestService for BenchStoreHarness {
+        async fn put(
+            &self,
+            _ctx: RequestContext,
+            request: OwnedPutRequestView,
+        ) -> connectrpc::ServiceResult<PutResponse> {
+            let mut state = self.state.lock().expect("store state lock");
+            for entry in request.kvs.iter() {
+                let key = entry.key.to_vec();
+                state.available_keys.insert(key.clone());
+                state.written_keys.insert(key);
+            }
+            connectrpc::Response::ok(PutResponse {
+                sequence_number: 1,
+                ..Default::default()
+            })
+        }
+    }
+
+    #[allow(refining_impl_trait)]
+    impl QueryService for BenchStoreHarness {
+        async fn get(
+            &self,
+            _ctx: RequestContext,
+            request: OwnedGetRequestView,
+        ) -> connectrpc::ServiceResult<GetResponse> {
+            let mut state = self.state.lock().expect("store state lock");
+            let value = state
+                .available_keys
+                .contains(request.key)
+                .then(|| vec![1].into());
+            if state.written_keys.contains(request.key) {
+                state.written_read_hits += 1;
+            }
+            connectrpc::Response::ok(GetResponse {
+                value,
+                ..Default::default()
+            })
+        }
+
+        async fn get_many(
+            &self,
+            _ctx: RequestContext,
+            _request: OwnedGetManyRequestView,
+        ) -> connectrpc::ServiceResult<connectrpc::ServiceStream<GetManyFrame>> {
+            Err(ConnectError::unimplemented("test harness"))
+        }
+
+        async fn range(
+            &self,
+            _ctx: RequestContext,
+            _request: OwnedRangeRequestView,
+        ) -> connectrpc::ServiceResult<connectrpc::ServiceStream<RangeFrame>> {
+            Err(ConnectError::unimplemented("test harness"))
+        }
+
+        async fn reduce(
+            &self,
+            _ctx: RequestContext,
+            _request: OwnedReduceRequestView,
+        ) -> connectrpc::ServiceResult<ReduceResponse> {
+            Err(ConnectError::unimplemented("test harness"))
         }
     }
 
@@ -572,6 +732,49 @@ mod tests {
             axum::serve(listener, app).await.expect("serve test app");
         });
         (url, batch_sizes)
+    }
+
+    async fn spawn_query_harness() -> (String, Arc<Mutex<Vec<CapturedRange>>>) {
+        let ranges = Arc::new(Mutex::new(Vec::new()));
+        let harness = BenchQueryHarness {
+            ranges: ranges.clone(),
+        };
+        let connect = ConnectRpcService::new(QueryServiceServer::new(harness));
+        let app = Router::new().fallback_service(connect);
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind test listener");
+        let url = format!(
+            "http://{}",
+            listener.local_addr().expect("listener address")
+        );
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.expect("serve test app");
+        });
+        (url, ranges)
+    }
+
+    async fn spawn_store_harness() -> (String, Arc<Mutex<BenchStoreState>>) {
+        let state = Arc::new(Mutex::new(BenchStoreState::default()));
+        let harness = BenchStoreHarness {
+            state: state.clone(),
+        };
+        let connect = ConnectRpcService::new(Chain(
+            IngestServiceServer::new(harness.clone()),
+            QueryServiceServer::new(harness),
+        ));
+        let app = Router::new().fallback_service(connect);
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind test listener");
+        let url = format!(
+            "http://{}",
+            listener.local_addr().expect("listener address")
+        );
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.expect("serve test app");
+        });
+        (url, state)
     }
 
     fn sample_manifest() -> BenchManifest {
@@ -603,7 +806,7 @@ mod tests {
                 value_generator_version: VALUE_GENERATOR_VERSION,
                 workload_generator_version: WORKLOAD_GENERATOR_VERSION,
                 read_retry_attempts: 5,
-                request_compression: RequestCompression::Gzip,
+                request_compression: Some(RequestCompression::Gzip),
             },
             123,
         )
@@ -769,6 +972,133 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn latest_reads_hit_keys_appended_by_earlier_puts() {
+        let initial_keys = 1u64;
+        let batch_size = 3usize;
+        let seed = 42u64;
+        let mix = crate::workload::WorkloadMix {
+            read_ratio: 0.5,
+            write_ratio: 0.5,
+            scan_ratio: 0.0,
+        };
+        let workload = WorkloadSpec::new(mix, 1, KeyDistribution::Latest, 10, 1.0, 0.99)
+            .expect("latest workload should validate");
+        let mut replay = WorkerPlan::new(seed, 0, workload, 1, batch_size);
+        let mut total_ops = 0u64;
+        loop {
+            total_ops += 1;
+            if matches!(
+                replay.next_operation(initial_keys),
+                Operation::Read { index } if index >= initial_keys
+            ) {
+                break;
+            }
+            assert!(total_ops < 256, "replay should reach an appended-key read");
+        }
+
+        let (url, state) = spawn_store_harness().await;
+        let keyspace = Keyspace::from_u64_namespace(42, DEFAULT_KEY_LEN)
+            .expect("test keyspace should validate");
+        state
+            .lock()
+            .expect("store state lock")
+            .available_keys
+            .insert(keyspace.inserted_key(0).to_vec());
+
+        let mut args = sample_args();
+        args.client.url = url;
+        args.keys = initial_keys;
+        args.ops = total_ops;
+        args.batch_size = batch_size;
+        args.concurrency = 1;
+        args.key_dist = KeyDistribution::Latest;
+        args.latest_window = 10;
+        args.latest_prob = 1.0;
+        args.read_ratio = Some(mix.read_ratio);
+        args.write_ratio = Some(mix.write_ratio);
+        args.scan_ratio = Some(mix.scan_ratio);
+        args.rng_seed = seed;
+        args.progress_interval_secs = 0;
+
+        let config = Config::try_from(args).expect("latest config should validate");
+        let report = run_workload(config)
+            .await
+            .expect("latest benchmark should succeed");
+
+        assert_eq!(report.errors, 0);
+        assert_eq!(report.read_misses, 0);
+        assert!(report.reads > 0);
+        assert!(report.writes > 0);
+        assert!(
+            state.lock().expect("store state lock").written_read_hits > 0,
+            "latest replay should read a key from an earlier put"
+        );
+    }
+
+    #[tokio::test]
+    async fn scan_operations_send_prefix_bound_and_limit_and_count_rows() {
+        let (url, ranges) = spawn_query_harness().await;
+        let initial_keys = 100;
+        let scan_length = 7;
+        let batch_size = 3;
+        let mix = crate::workload::WorkloadMix {
+            read_ratio: 0.0,
+            write_ratio: 0.0,
+            scan_ratio: 1.0,
+        };
+        let workload = WorkloadSpec::new(
+            mix,
+            scan_length,
+            KeyDistribution::Uniform,
+            5_000,
+            0.90,
+            0.99,
+        )
+        .expect("scan workload should validate");
+        let mut plan =
+            WorkerPlan::with_zipf_sampler(DEFAULT_BENCH_RNG_SEED, 0, workload, None, 1, batch_size);
+        let expected_start_index = match plan.next_operation(initial_keys) {
+            Operation::Scan { start, .. } => start,
+            operation => panic!("expected scan operation, got {operation:?}"),
+        };
+        let keyspace = Keyspace::from_u64_namespace(42, DEFAULT_KEY_LEN)
+            .expect("test keyspace should validate");
+        let expected_start = keyspace.inserted_key(expected_start_index);
+        let expected_end = keyspace.scan_upper_bound(&expected_start);
+
+        let mut args = sample_args();
+        args.client.url = url;
+        args.keys = initial_keys;
+        args.ops = 1;
+        args.batch_size = batch_size;
+        args.concurrency = 1;
+        args.scan_length = scan_length;
+        args.key_dist = KeyDistribution::Uniform;
+        args.read_ratio = Some(mix.read_ratio);
+        args.write_ratio = Some(mix.write_ratio);
+        args.scan_ratio = Some(mix.scan_ratio);
+        args.progress_interval_secs = 0;
+
+        let config = Config::try_from(args).expect("scan config should validate");
+        let report = run_workload(config)
+            .await
+            .expect("scan-only benchmark should succeed");
+
+        assert_eq!(
+            ranges.lock().expect("range request lock").as_slice(),
+            [CapturedRange {
+                start: expected_start.to_vec(),
+                end: expected_end.to_vec(),
+                limit: Some(scan_length as u32),
+            }]
+        );
+        assert_eq!(report.operations, 1);
+        assert_eq!(report.scans, 1);
+        assert_eq!(report.scan_rows, 2);
+        assert_eq!(report.errors, 0);
+    }
+
     #[test]
     fn config_rejects_invalid_latest_probability() {
         let mut args = sample_args();
@@ -824,6 +1154,23 @@ mod tests {
         let err = Config::try_from_manifest(manifest, None, 10)
             .expect_err("workload generator version mismatch should be rejected");
         assert!(err.to_string().contains("workload_generator_version"));
+    }
+
+    #[test]
+    fn config_from_current_manifest_requires_request_compression() {
+        let manifest = sample_manifest();
+        let mut value = serde_json::to_value(manifest).expect("manifest should serialize");
+        value["config"]
+            .as_object_mut()
+            .expect("config should be an object")
+            .remove("request_compression");
+
+        let config = serde_json::from_value::<BenchManifest>(value)
+            .map_err(anyhow::Error::from)
+            .and_then(|manifest| Config::try_from_manifest(manifest, None, 10));
+        let err = config.expect_err("current manifest should require request_compression");
+
+        assert!(err.to_string().contains("request_compression"));
     }
 
     #[test]

--- a/validation/src/bench.rs
+++ b/validation/src/bench.rs
@@ -52,6 +52,7 @@ pub struct Args {
             "scan_ratio",
             "rng_seed",
             "read_retry_attempts",
+            "request_compression",
             "key_len",
             "namespace",
             "value_size"
@@ -229,7 +230,8 @@ impl Config {
             client: ClientConfig::new(
                 manifest.config.endpoint,
                 manifest.config.read_retry_attempts,
-            )?,
+            )?
+            .with_request_compression(manifest.config.request_compression),
             namespace: manifest.config.namespace,
             keyspace: Keyspace::from_u64_namespace(
                 manifest.config.namespace,
@@ -286,6 +288,7 @@ async fn run_workload(config: Config) -> anyhow::Result<()> {
         value_generator_version: VALUE_GENERATOR_VERSION,
         workload_generator_version: WORKLOAD_GENERATOR_VERSION,
         read_retry_attempts: client_config.read_retry_attempts(),
+        request_compression: client_config.request_compression(),
     };
     let ops_done = Arc::new(AtomicU64::new(0));
     let reads_ok = Arc::new(AtomicU64::new(0));
@@ -299,9 +302,8 @@ async fn run_workload(config: Config) -> anyhow::Result<()> {
     // calls, so error-heavy runs still explain where time was spent.
     let latencies = Arc::new(LatencyHistogramsRecorder::default());
 
-    // Reads and scans sample only the keyspace prepared before the benchmark. Including
-    // concurrently appended keys would make a worker's seeded operation stream depend on task
-    // scheduling, while reads could race the write that first creates the key.
+    // Uniform and Zipfian reads sample the prepared fixture. Latest reads use
+    // a deterministic estimate of the appended frontier.
     let readable_key_count = initial_keys;
     let zipf_sampler = (workload.key_dist == KeyDistribution::Zipfian)
         .then(|| Arc::new(ZipfSampler::new(readable_key_count, workload.zipf_theta)));
@@ -352,6 +354,7 @@ async fn run_workload(config: Config) -> anyhow::Result<()> {
                 worker_workload,
                 zipf_sampler,
                 concurrency,
+                batch_size,
             );
             let mut write_number = 0u64;
 
@@ -376,11 +379,8 @@ async fn run_workload(config: Config) -> anyhow::Result<()> {
                         }
                     }
                     Operation::Scan { start, limit } => {
-                        // Seek from one inserted key and let the row limit bound the
-                        // scan (see the Operation::Scan doc for why no second hashed
-                        // endpoint is used).
                         let start_key = keyspace.inserted_key(start);
-                        let end_key = keyspace.scan_upper_bound();
+                        let end_key = keyspace.scan_upper_bound(&start_key);
                         let request_start = Instant::now();
                         let result = client.query().range(&start_key, &end_key, limit).await;
                         latencies.record_scan(request_start.elapsed());
@@ -518,11 +518,18 @@ mod tests {
     use crate::client::RequestCompression;
     use crate::keyspace::DEFAULT_KEY_LEN;
     use axum::Router;
+    use clap::Parser;
     use connectrpc::{ConnectRpcService, RequestContext};
     use exoware_sdk::ingest::{
         OwnedPutRequestView, PutResponse, Service as IngestService,
         ServiceServer as IngestServiceServer,
     };
+
+    #[derive(Parser)]
+    struct BenchCli {
+        #[command(flatten)]
+        args: Args,
+    }
 
     #[derive(Clone)]
     struct BenchIngestHarness {
@@ -596,6 +603,7 @@ mod tests {
                 value_generator_version: VALUE_GENERATOR_VERSION,
                 workload_generator_version: WORKLOAD_GENERATOR_VERSION,
                 read_retry_attempts: 5,
+                request_compression: RequestCompression::Gzip,
             },
             123,
         )
@@ -637,6 +645,22 @@ mod tests {
     fn config_normalizes_url() {
         let config = Config::try_from(sample_args()).expect("bench args should be valid");
         assert_eq!(config.client.endpoint(), "http://localhost:10000");
+    }
+
+    #[test]
+    fn manifest_rejects_request_compression_override() {
+        assert!(BenchCli::try_parse_from([
+            "validation",
+            "--manifest",
+            "report.json",
+            "--request-compression",
+            "none",
+        ])
+        .is_err());
+
+        let parsed = BenchCli::try_parse_from(["validation", "--manifest", "report.json"])
+            .expect("manifest without overrides should parse");
+        assert_eq!(parsed.args.manifest, Some(PathBuf::from("report.json")));
     }
 
     #[test]
@@ -771,6 +795,10 @@ mod tests {
         assert_eq!(config.total_ops, 10_000);
         assert_eq!(config.concurrency, 4);
         assert_eq!(config.batch_size, DEFAULT_INGEST_BATCH_SIZE);
+        assert_eq!(
+            config.client.request_compression(),
+            RequestCompression::Gzip
+        );
         assert_eq!(config.scenario, Scenario::ScanHeavy);
         assert_eq!(config.workload.key_dist, KeyDistribution::Latest);
         assert_eq!(config.rng_seed, 123);

--- a/validation/src/bench.rs
+++ b/validation/src/bench.rs
@@ -401,13 +401,14 @@ async fn run_workload(config: Config) -> anyhow::Result<BenchReport> {
                         }
                     }
                     Operation::Write => {
+                        let batch_number = write_number;
                         let mut records = Vec::with_capacity(batch_size);
                         for batch_offset in 0..batch_size {
                             let write_idx = worker_batch_write_index(
                                 initial_keys,
                                 concurrency,
                                 worker,
-                                write_number,
+                                batch_number,
                                 batch_offset,
                                 batch_size,
                             )?;
@@ -422,6 +423,7 @@ async fn run_workload(config: Config) -> anyhow::Result<BenchReport> {
                         let request_start = Instant::now();
                         let result = client.ingest().put(&refs).await;
                         latencies.record_write(request_start.elapsed());
+                        plan.record_write_result(batch_number, result.is_ok())?;
                         match result {
                             Ok(_) => {
                                 writes_ok.fetch_add(1, Ordering::Relaxed);
@@ -570,6 +572,7 @@ mod tests {
         available_keys: HashSet<Vec<u8>>,
         written_keys: HashSet<Vec<u8>>,
         written_read_hits: usize,
+        reject_writes: bool,
     }
 
     #[derive(Clone)]
@@ -656,6 +659,9 @@ mod tests {
             request: OwnedPutRequestView,
         ) -> connectrpc::ServiceResult<PutResponse> {
             let mut state = self.state.lock().expect("store state lock");
+            if state.reject_writes {
+                return Err(ConnectError::invalid_argument("put rejected"));
+            }
             for entry in request.kvs.iter() {
                 let key = entry.key.to_vec();
                 state.available_keys.insert(key.clone());
@@ -986,12 +992,15 @@ mod tests {
             .expect("latest workload should validate");
         let mut replay = WorkerPlan::new(seed, 0, workload, 1, batch_size);
         let mut total_ops = 0u64;
+        let mut write_batch = 0u64;
         loop {
             total_ops += 1;
-            if matches!(
-                replay.next_operation(initial_keys),
-                Operation::Read { index } if index >= initial_keys
-            ) {
+            let operation = replay.next_operation(initial_keys);
+            if matches!(operation, Operation::Write) {
+                replay.record_write_result(write_batch, true).unwrap();
+                write_batch += 1;
+            }
+            if matches!(operation, Operation::Read { index } if index >= initial_keys) {
                 break;
             }
             assert!(total_ops < 256, "replay should reach an appended-key read");
@@ -1033,6 +1042,49 @@ mod tests {
         assert!(
             state.lock().expect("store state lock").written_read_hits > 0,
             "latest replay should read a key from an earlier put"
+        );
+    }
+
+    #[tokio::test]
+    async fn latest_reads_do_not_target_failed_puts() {
+        let initial_keys = 1u64;
+        let (url, state) = spawn_store_harness().await;
+        let keyspace = Keyspace::from_u64_namespace(42, DEFAULT_KEY_LEN)
+            .expect("test keyspace should validate");
+        {
+            let mut state = state.lock().expect("store state lock");
+            state
+                .available_keys
+                .insert(keyspace.inserted_key(0).to_vec());
+            state.reject_writes = true;
+        }
+
+        let mut args = sample_args();
+        args.client.url = url;
+        args.keys = initial_keys;
+        args.ops = 256;
+        args.batch_size = 3;
+        args.concurrency = 1;
+        args.key_dist = KeyDistribution::Latest;
+        args.latest_window = 10;
+        args.latest_prob = 1.0;
+        args.read_ratio = Some(0.5);
+        args.write_ratio = Some(0.5);
+        args.scan_ratio = Some(0.0);
+        args.rng_seed = 42;
+        args.progress_interval_secs = 0;
+
+        let config = Config::try_from(args).expect("latest config should validate");
+        let report = run_workload(config)
+            .await
+            .expect("benchmark should record failed puts");
+
+        assert!(report.errors > 0, "failed puts should be reported");
+        assert!(report.reads > 0, "benchmark should issue reads");
+        assert_eq!(report.writes, 0, "rejected puts must not be counted");
+        assert_eq!(
+            report.read_misses, 0,
+            "latest reads must not target rejected write batches"
         );
     }
 

--- a/validation/src/client.rs
+++ b/validation/src/client.rs
@@ -2,10 +2,39 @@ use std::time::Duration;
 
 use anyhow::{ensure, Context};
 use connectrpc::ErrorCode;
-use exoware_sdk::{ClientError, PrefixedStoreClient, RetryConfig, StoreClient};
+use exoware_sdk::{
+    ClientError, ConnectRequestCompression, PrefixedStoreClient, RetryConfig, StoreClient,
+};
 
 const DEFAULT_INITIAL_BACKOFF_MS: u64 = 50;
 const DEFAULT_MAX_BACKOFF_MS: u64 = 1_000;
+
+/// Request-body compression for the SDK client.
+///
+/// Generated workload payloads are mostly zero bytes (big-endian encodings of
+/// small integers), so uncompressed batches are an order of magnitude larger
+/// on the wire and shift their cost onto the edge proxy and object-store
+/// emulator; measured in kv-mk1 CI, flipping the SDK default to uncompressed
+/// cut batched-load throughput ~4x. Zstd stays this tool's default even
+/// though the SDK now defaults to none.
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq, clap::ValueEnum)]
+#[value(rename_all = "kebab-case")]
+pub enum RequestCompression {
+    #[default]
+    Zstd,
+    Gzip,
+    None,
+}
+
+impl From<RequestCompression> for ConnectRequestCompression {
+    fn from(value: RequestCompression) -> Self {
+        match value {
+            RequestCompression::Zstd => Self::Zstd,
+            RequestCompression::Gzip => Self::Gzip,
+            RequestCompression::None => Self::None,
+        }
+    }
+}
 
 /// Shared SDK client CLI flags for validation commands.
 #[derive(clap::Args, Clone, Debug)]
@@ -15,11 +44,15 @@ pub struct ClientArgs {
     /// Max client read retry attempts for lookup/range calls.
     #[arg(long, default_value_t = 3)]
     pub read_retry_attempts: usize,
+    /// Request-body compression for outgoing RPCs.
+    #[arg(long, value_enum, default_value_t = RequestCompression::Zstd)]
+    pub request_compression: RequestCompression,
 }
 
 impl ClientArgs {
     pub fn into_config(self) -> anyhow::Result<ClientConfig> {
-        ClientConfig::new(self.url, self.read_retry_attempts)
+        Ok(ClientConfig::new(self.url, self.read_retry_attempts)?
+            .with_request_compression(self.request_compression))
     }
 }
 
@@ -28,6 +61,7 @@ impl ClientArgs {
 pub struct ClientConfig {
     endpoint: String,
     read_retry_attempts: usize,
+    request_compression: RequestCompression,
 }
 
 impl ClientConfig {
@@ -36,9 +70,16 @@ impl ClientConfig {
         let config = Self {
             endpoint: normalize_endpoint(&endpoint.into()),
             read_retry_attempts,
+            request_compression: RequestCompression::default(),
         };
         validate_config(&config)?;
         Ok(config)
+    }
+
+    /// Overrides the request-body compression (see [`RequestCompression`]).
+    pub fn with_request_compression(mut self, compression: RequestCompression) -> Self {
+        self.request_compression = compression;
+        self
     }
 
     /// Returns the normalized endpoint passed to the SDK client.
@@ -56,6 +97,7 @@ impl ClientConfig {
 pub fn build_client(config: &ClientConfig) -> anyhow::Result<PrefixedStoreClient> {
     let client = StoreClient::builder()
         .url(config.endpoint())
+        .connect_request_compression(config.request_compression.into())
         .retry_config(
             RetryConfig::standard()
                 .with_max_attempts(config.read_retry_attempts())
@@ -166,6 +208,7 @@ mod tests {
         let config = ClientConfig {
             endpoint: "http://[::1".to_string(),
             read_retry_attempts: 3,
+            request_compression: RequestCompression::default(),
         };
         build_client(&config).expect_err("malformed endpoint should be rejected");
     }

--- a/validation/src/client.rs
+++ b/validation/src/client.rs
@@ -5,19 +5,17 @@ use connectrpc::ErrorCode;
 use exoware_sdk::{
     ClientError, ConnectRequestCompression, PrefixedStoreClient, RetryConfig, StoreClient,
 };
+use serde::{Deserialize, Serialize};
 
 const DEFAULT_INITIAL_BACKOFF_MS: u64 = 50;
 const DEFAULT_MAX_BACKOFF_MS: u64 = 1_000;
 
-/// Request-body compression for the SDK client.
-///
-/// Generated workload payloads are mostly zero bytes (big-endian encodings of
-/// small integers), so uncompressed batches are an order of magnitude larger
-/// on the wire and shift their cost onto the edge proxy and object-store
-/// emulator; measured in kv-mk1 CI, flipping the SDK default to uncompressed
-/// cut batched-load throughput ~4x. Zstd stays this tool's default even
-/// though the SDK now defaults to none.
-#[derive(Copy, Clone, Debug, Default, Eq, PartialEq, clap::ValueEnum)]
+// Deterministic validation values contain long zero-filled regions. Zstd keeps
+// generated write batches small without changing the SDK default for callers
+// with less compressible payloads.
+/// Request-body compression for outgoing RPCs.
+#[derive(Copy, Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize, clap::ValueEnum)]
+#[serde(rename_all = "kebab-case")]
 #[value(rename_all = "kebab-case")]
 pub enum RequestCompression {
     #[default]
@@ -90,6 +88,11 @@ impl ClientConfig {
     /// Returns the maximum number of attempts for SDK reads.
     pub fn read_retry_attempts(&self) -> usize {
         self.read_retry_attempts
+    }
+
+    /// Returns the request-body compression used by the SDK client.
+    pub fn request_compression(&self) -> RequestCompression {
+        self.request_compression
     }
 }
 

--- a/validation/src/keyspace.rs
+++ b/validation/src/keyspace.rs
@@ -135,6 +135,16 @@ impl Keyspace {
         self.key(index, MISSING_KEY_DOMAIN)
     }
 
+    /// Returns the maximal key of this keyspace's physical key length.
+    ///
+    /// Forward scans seek from one inserted key and bound their work by row
+    /// limit, not by a second endpoint (leading entropy scatters inserted
+    /// keys across the byte keyspace, so no narrow endpoint exists). This is
+    /// the end bound such scans pass to the range API.
+    pub fn scan_upper_bound(&self) -> Key {
+        vec![u8::MAX; self.key_len].into()
+    }
+
     /// Returns the logical index that produced `key`, or `None` when `key` is
     /// not exactly one of this keyspace's inserted keys.
     ///

--- a/validation/src/keyspace.rs
+++ b/validation/src/keyspace.rs
@@ -135,14 +135,14 @@ impl Keyspace {
         self.key(index, MISSING_KEY_DOMAIN)
     }
 
-    /// Returns the maximal key of this keyspace's physical key length.
-    ///
-    /// Forward scans seek from one inserted key and bound their work by row
-    /// limit, not by a second endpoint (leading entropy scatters inserted
-    /// keys across the byte keyspace, so no narrow endpoint exists). This is
-    /// the end bound such scans pass to the range API.
-    pub fn scan_upper_bound(&self) -> Key {
-        vec![u8::MAX; self.key_len].into()
+    // Generated keys use their leading byte for entropy. Keeping both bounds
+    // under the same leading byte narrows the ordered key range the backend
+    // must plan while the row limit still caps returned data.
+    pub(crate) fn scan_upper_bound(&self, start: &Key) -> Key {
+        debug_assert_eq!(start.len(), self.key_len);
+        let mut end = vec![u8::MAX; self.key_len];
+        end[0] = start[0];
+        end.into()
     }
 
     /// Returns the logical index that produced `key`, or `None` when `key` is
@@ -295,6 +295,18 @@ mod tests {
     fn keys_use_configured_length() {
         let keyspace = Keyspace::unnamespaced(24).unwrap();
         assert_eq!(keyspace.inserted_key(0).len(), 24);
+    }
+
+    #[test]
+    fn scan_upper_bound_keeps_the_starting_leading_byte() {
+        let keyspace = Keyspace::from_u64_namespace(7, DEFAULT_KEY_LEN).unwrap();
+        let start = keyspace.inserted_key(42);
+        let end = keyspace.scan_upper_bound(&start);
+
+        assert_eq!(end.len(), start.len());
+        assert_eq!(end[0], start[0]);
+        assert!(end[1..].iter().all(|byte| *byte == u8::MAX));
+        assert!(end > start);
     }
 
     #[test]

--- a/validation/src/keyspace.rs
+++ b/validation/src/keyspace.rs
@@ -136,8 +136,8 @@ impl Keyspace {
     }
 
     // Generated keys use their leading byte for entropy. Keeping both bounds
-    // under the same leading byte narrows the ordered key range the backend
-    // must plan while the row limit still caps returned data.
+    // under the same leading byte narrows the requested range. Any planning
+    // or storage-read reduction depends on the backend implementation.
     pub(crate) fn scan_upper_bound(&self, start: &Key) -> Key {
         debug_assert_eq!(start.len(), self.key_len);
         let mut end = vec![u8::MAX; self.key_len];

--- a/validation/src/load.rs
+++ b/validation/src/load.rs
@@ -232,6 +232,7 @@ mod tests {
     use std::sync::Arc;
 
     use super::*;
+    use crate::client::RequestCompression;
     use crate::keyspace::DEFAULT_KEY_LEN;
     use axum::Router;
     use connectrpc::{ConnectError, ConnectRpcService, RequestContext};
@@ -303,6 +304,7 @@ mod tests {
             client: ClientArgs {
                 url: "http://localhost:10000/".to_string(),
                 read_retry_attempts: 3,
+                request_compression: RequestCompression::default(),
             },
             keys: 100,
             batch_size: 25,

--- a/validation/src/report.rs
+++ b/validation/src/report.rs
@@ -60,8 +60,8 @@ pub struct BenchConfig {
     #[serde(default = "default_workload_generator_version")]
     pub workload_generator_version: u16,
     pub read_retry_attempts: usize,
-    #[serde(default)]
-    pub request_compression: RequestCompression,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub request_compression: Option<RequestCompression>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -291,7 +291,9 @@ impl fmt::Display for BenchReport {
         writeln!(
             f,
             "  request_compression: {:?}",
-            self.config.request_compression
+            self.config
+                .request_compression
+                .unwrap_or(RequestCompression::None)
         )?;
         writeln!(f, "  elapsed_ms: {}", self.elapsed_ms)?;
         writeln!(f, "  ops_per_sec: {:.2}", self.ops_per_sec())?;
@@ -488,7 +490,7 @@ mod tests {
                 value_generator_version: crate::value::VALUE_GENERATOR_VERSION,
                 workload_generator_version: crate::workload::WORKLOAD_GENERATOR_VERSION,
                 read_retry_attempts: 3,
-                request_compression: RequestCompression::Gzip,
+                request_compression: Some(RequestCompression::Gzip),
             },
             seed: 42,
             elapsed_ms: 2_000,
@@ -725,7 +727,7 @@ mod tests {
     }
 
     #[test]
-    fn manifest_without_request_compression_defaults_to_zstd() {
+    fn manifest_without_request_compression_preserves_absence() {
         let report = sample_report();
         let manifest = BenchManifest::new(report.config, report.seed);
         let mut value = serde_json::to_value(&manifest).expect("manifest should serialize");
@@ -734,15 +736,9 @@ mod tests {
             .expect("config should be a JSON object")
             .remove("request_compression");
 
-        let path = std::env::temp_dir().join(format!(
-            "exoware-validation-manifest-no-request-compression-{}-{}.json",
-            std::process::id(),
-            Utc::now().timestamp_nanos_opt().unwrap_or_default()
-        ));
-        std::fs::write(&path, value.to_string()).expect("manifest fixture should write");
-        let parsed = read_bench_manifest_json(&path).expect("legacy manifest should parse");
-        std::fs::remove_file(&path).ok();
+        let parsed = serde_json::from_value::<BenchManifest>(value)
+            .expect("manifest without compression should deserialize");
 
-        assert_eq!(parsed.config.request_compression, RequestCompression::Zstd);
+        assert_eq!(parsed.config.request_compression, None);
     }
 }

--- a/validation/src/report.rs
+++ b/validation/src/report.rs
@@ -8,6 +8,7 @@ use anyhow::{ensure, Context};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
+use crate::client::RequestCompression;
 use crate::workload::{Scenario, WorkloadSpec};
 
 const BENCH_MANIFEST_SCHEMA_VERSION: u16 = 1;
@@ -59,6 +60,8 @@ pub struct BenchConfig {
     #[serde(default = "default_workload_generator_version")]
     pub workload_generator_version: u16,
     pub read_retry_attempts: usize,
+    #[serde(default)]
+    pub request_compression: RequestCompression,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -285,6 +288,11 @@ impl fmt::Display for BenchReport {
             "  read_retry_attempts: {}",
             self.config.read_retry_attempts
         )?;
+        writeln!(
+            f,
+            "  request_compression: {:?}",
+            self.config.request_compression
+        )?;
         writeln!(f, "  elapsed_ms: {}", self.elapsed_ms)?;
         writeln!(f, "  ops_per_sec: {:.2}", self.ops_per_sec())?;
         writeln!(f, "  operations: {}", self.operations)?;
@@ -480,6 +488,7 @@ mod tests {
                 value_generator_version: crate::value::VALUE_GENERATOR_VERSION,
                 workload_generator_version: crate::workload::WORKLOAD_GENERATOR_VERSION,
                 read_retry_attempts: 3,
+                request_compression: RequestCompression::Gzip,
             },
             seed: 42,
             elapsed_ms: 2_000,
@@ -713,5 +722,27 @@ mod tests {
         std::fs::remove_file(&path).ok();
 
         assert_eq!(parsed.config.workload_generator_version, 1);
+    }
+
+    #[test]
+    fn manifest_without_request_compression_defaults_to_zstd() {
+        let report = sample_report();
+        let manifest = BenchManifest::new(report.config, report.seed);
+        let mut value = serde_json::to_value(&manifest).expect("manifest should serialize");
+        value["config"]
+            .as_object_mut()
+            .expect("config should be a JSON object")
+            .remove("request_compression");
+
+        let path = std::env::temp_dir().join(format!(
+            "exoware-validation-manifest-no-request-compression-{}-{}.json",
+            std::process::id(),
+            Utc::now().timestamp_nanos_opt().unwrap_or_default()
+        ));
+        std::fs::write(&path, value.to_string()).expect("manifest fixture should write");
+        let parsed = read_bench_manifest_json(&path).expect("legacy manifest should parse");
+        std::fs::remove_file(&path).ok();
+
+        assert_eq!(parsed.config.request_compression, RequestCompression::Zstd);
     }
 }

--- a/validation/src/workload.rs
+++ b/validation/src/workload.rs
@@ -89,6 +89,10 @@ pub struct WorkerPlan {
     rng: rand::rngs::StdRng,
     spec: WorkloadSpec,
     zipf_sampler: Option<Arc<ZipfSampler>>,
+    /// Total bench workers, for the deterministic write-frontier estimate.
+    worker_count: u64,
+    /// Operations this plan has emitted (the stream position).
+    ops_emitted: u64,
 }
 
 pub(crate) struct ZipfSampler {
@@ -192,7 +196,7 @@ impl WorkloadSpec {
 impl WorkerPlan {
     /// Creates a replayable worker stream from the run seed and worker id.
     pub fn new(seed: u64, worker_id: u64, spec: WorkloadSpec) -> Self {
-        Self::with_zipf_sampler(seed, worker_id, spec, None)
+        Self::with_zipf_sampler(seed, worker_id, spec, None, 1)
     }
 
     pub(crate) fn with_zipf_sampler(
@@ -200,16 +204,20 @@ impl WorkerPlan {
         worker_id: u64,
         spec: WorkloadSpec,
         zipf_sampler: Option<Arc<ZipfSampler>>,
+        worker_count: usize,
     ) -> Self {
         Self {
             rng: worker_rng(seed, worker_id),
             spec,
             zipf_sampler,
+            worker_count: (worker_count as u64).max(1),
+            ops_emitted: 0,
         }
     }
 
     /// Emits the next logical operation for the current visible key range.
     pub fn next_operation(&mut self, max_key_exclusive: u64) -> Operation {
+        self.ops_emitted += 1;
         let p = self.rng.random::<f64>();
         if p < self.spec.mix.read_ratio {
             return Operation::Read {
@@ -230,6 +238,21 @@ impl WorkerPlan {
         Operation::Write
     }
 
+    // "Latest" must chase the write frontier or it degenerates into a fixed
+    // dead zone: writes append past the fixture, so a window anchored to the
+    // static fixture top reads keys nothing ever writes. A shared live counter
+    // would make seeded streams depend on task scheduling, so the frontier is
+    // instead *estimated* from this worker's own stream position (a pure
+    // function of the seed): all workers progress through identical op mixes,
+    // so expected appended keys after k ops is k * write_ratio per worker.
+    // Reads near the estimate may race the writes they target; those misses
+    // are the intended "latest" measurement, mirroring visibility lag.
+    fn estimated_write_frontier(&self, initial_keys: u64) -> u64 {
+        let appended =
+            (self.ops_emitted as f64 * self.spec.mix.write_ratio) as u64 * self.worker_count;
+        initial_keys.saturating_add(appended)
+    }
+
     // Each arm draws the same amount of randomness on every call for a given
     // distribution; the stream is versioned by `WORKLOAD_GENERATOR_VERSION`.
     fn sample_key_index(&mut self, max_key_exclusive: u64) -> u64 {
@@ -241,15 +264,19 @@ impl WorkerPlan {
                 self.rng.random_range(0..max_key_exclusive)
             }
             KeyDistribution::Latest => {
-                if max_key_exclusive <= 1 {
+                // Sampling range = fixture plus the estimated frontier (see
+                // estimated_write_frontier); the window hugs the frontier so
+                // "latest" reads chase recent writes rather than a fixed top.
+                let frontier = self.estimated_write_frontier(max_key_exclusive);
+                if frontier <= 1 {
                     return 0;
                 }
                 if self.rng.random::<f64>() < self.spec.latest_prob {
-                    let window = self.spec.latest_window.max(1).min(max_key_exclusive);
-                    let start = max_key_exclusive - window;
-                    self.rng.random_range(start..max_key_exclusive)
+                    let window = self.spec.latest_window.max(1).min(frontier);
+                    let start = frontier - window;
+                    self.rng.random_range(start..frontier)
                 } else {
-                    self.rng.random_range(0..max_key_exclusive)
+                    self.rng.random_range(0..frontier)
                 }
             }
             KeyDistribution::Zipfian => {
@@ -594,8 +621,8 @@ mod tests {
             ..sample_spec()
         };
         let sampler = Arc::new(ZipfSampler::new(100, spec.zipf_theta));
-        let first = WorkerPlan::with_zipf_sampler(1, 0, spec, Some(sampler.clone()));
-        let second = WorkerPlan::with_zipf_sampler(1, 1, spec, Some(sampler));
+        let first = WorkerPlan::with_zipf_sampler(1, 0, spec, Some(sampler.clone()), 2);
+        let second = WorkerPlan::with_zipf_sampler(1, 1, spec, Some(sampler), 2);
 
         assert!(Arc::ptr_eq(
             first.zipf_sampler.as_ref().expect("sampler is set"),
@@ -734,5 +761,48 @@ mod tests {
         let ops_a: Vec<Operation> = (0..32).map(|_| a.next_operation(1_000)).collect();
         let ops_b: Vec<Operation> = (0..32).map(|_| b.next_operation(1_000)).collect();
         assert_ne!(ops_a, ops_b);
+    }
+
+    #[test]
+    fn latest_window_chases_the_estimated_write_frontier() {
+        let spec = WorkloadSpec::new(
+            WorkloadMix {
+                read_ratio: 0.5,
+                write_ratio: 0.5,
+                scan_ratio: 0.0,
+            },
+            25,
+            KeyDistribution::Latest,
+            10,
+            1.0,
+            0.99,
+        )
+        .expect("spec should validate");
+        let initial = 1_000u64;
+        let workers = 4usize;
+
+        // Late in the stream, every latest read must target the moving
+        // frontier region, not the static fixture top: after k ops the
+        // estimate is initial + k*write_ratio*workers, far above `initial`.
+        let mut plan = WorkerPlan::with_zipf_sampler(7, 0, spec, None, workers);
+        let mut read_indexes = Vec::new();
+        for _ in 0..2_000 {
+            if let Operation::Read { index } = plan.next_operation(initial) {
+                read_indexes.push(index);
+            }
+        }
+        let late_reads = &read_indexes[read_indexes.len() - 20..];
+        assert!(
+            late_reads.iter().all(|&idx| idx > initial),
+            "late latest reads should chase appended keys, got {late_reads:?}"
+        );
+
+        // The estimate is a pure function of the seeded stream position, so
+        // two identically-seeded plans emit identical operations.
+        let mut x = WorkerPlan::with_zipf_sampler(7, 0, spec, None, workers);
+        let mut y = WorkerPlan::with_zipf_sampler(7, 0, spec, None, workers);
+        let ops_x: Vec<Operation> = (0..256).map(|_| x.next_operation(initial)).collect();
+        let ops_y: Vec<Operation> = (0..256).map(|_| y.next_operation(initial)).collect();
+        assert_eq!(ops_x, ops_y);
     }
 }

--- a/validation/src/workload.rs
+++ b/validation/src/workload.rs
@@ -12,8 +12,10 @@ pub const DEFAULT_BENCH_RNG_SEED: u64 = 0x5eed_c0de;
 
 /// Version of the deterministic operation-stream generator used in manifests.
 ///
-/// Bump this when changing its seeded random stream, including an RNG update.
-pub const WORKLOAD_GENERATOR_VERSION: u16 = 3;
+/// Bump this when changing its seeded random stream, including an RNG update,
+/// or when changing what an emitted operation means (v4: scans became
+/// seek-forward-with-limit instead of two-hashed-endpoint windows).
+pub const WORKLOAD_GENERATOR_VERSION: u16 = 4;
 
 /// Named workload mixes for benchmark operation selection.
 #[derive(Copy, Clone, Debug, Deserialize, Eq, PartialEq, Serialize, ValueEnum)]
@@ -70,9 +72,14 @@ pub struct WorkloadSpec {
 pub enum Operation {
     /// Point read of an inserted logical key index.
     Read { index: u64 },
-    /// Inclusive range scan between the keys of two inserted logical indexes;
-    /// the executor orders the endpoint keys lexicographically.
-    Scan { start: u64, end: u64, limit: usize },
+    /// Forward range scan of up to `limit` physical rows starting at an
+    /// inserted logical index's key. Index-hashed key placement scatters
+    /// logical indexes across the byte keyspace, so a window between two
+    /// hashed endpoints would span an arbitrarily large fraction of the store
+    /// (the server plans every overlapping run for it); seeking from one key
+    /// and bounding by row count keeps each scan's work proportional to
+    /// `limit` regardless of placement.
+    Scan { start: u64, limit: usize },
     /// Ingest write; the executor assigns the next concrete write index.
     Write,
 }
@@ -213,14 +220,9 @@ impl WorkerPlan {
         if p < self.spec.mix.read_ratio + self.spec.mix.scan_ratio {
             let max_key_exclusive = max_key_exclusive.max(1);
             let start = self.sample_key_index(max_key_exclusive);
-            let mut end = start.saturating_add(self.spec.scan_length.saturating_sub(1) as u64);
-            if end >= max_key_exclusive {
-                end = max_key_exclusive - 1;
-            }
 
             return Operation::Scan {
                 start,
-                end,
                 limit: self.spec.scan_length,
             };
         }

--- a/validation/src/workload.rs
+++ b/validation/src/workload.rs
@@ -13,9 +13,9 @@ pub const DEFAULT_BENCH_RNG_SEED: u64 = 0x5eed_c0de;
 /// Version of the deterministic operation-stream generator used in manifests.
 ///
 /// Bump this when changing its seeded random stream or operation semantics.
-/// Version 6 samples latest keys from the fixture and prior writes in the
-/// current worker's lane.
-pub const WORKLOAD_GENERATOR_VERSION: u16 = 6;
+/// Version 7 samples latest keys from the fixture and acknowledged writes in
+/// the current worker's lane.
+pub const WORKLOAD_GENERATOR_VERSION: u16 = 7;
 
 /// Named workload mixes for benchmark operation selection.
 #[derive(Copy, Clone, Debug, Deserialize, Eq, PartialEq, Serialize, ValueEnum)]
@@ -75,7 +75,7 @@ pub enum Operation {
     /// Forward range scan of up to `limit` physical rows starting at an
     /// inserted logical index's key.
     Scan { start: u64, limit: usize },
-    /// Ingest write. The executor assigns the next concrete write index.
+    /// Ingest write. The executor assigns its concrete index and reports the outcome.
     Write,
 }
 
@@ -90,15 +90,20 @@ pub struct WorkerPlan {
     worker_count: u64,
     write_batch_size: u64,
 
-    // The executor awaits each operation before requesting the next one.
-    // This promotes only earlier write batches into latest-key candidates.
-    write_batches_completed: u64,
-    previous_operation_was_write: bool,
+    // Failed batches leave holes in the worker's allocated write sequence.
+    successful_write_batches: Vec<u64>,
+    next_write_batch: u64,
 }
 
 pub(crate) struct ZipfSampler {
     max_key_exclusive: u64,
     cdf: Vec<f64>,
+}
+
+struct SuccessfulWriteWindow {
+    batch_indices: Range<usize>,
+    first_write_number: u64,
+    last_write_number: u64,
 }
 
 impl Scenario {
@@ -195,7 +200,7 @@ impl WorkloadSpec {
 }
 
 impl WorkerPlan {
-    /// Creates a replayable worker stream from the run seed and worker id.
+    /// Creates a seeded worker stream from the run seed and worker id.
     pub fn new(
         seed: u64,
         worker_id: u64,
@@ -221,18 +226,46 @@ impl WorkerPlan {
             worker_id,
             worker_count: u64::try_from(worker_count).unwrap_or(u64::MAX).max(1),
             write_batch_size: u64::try_from(write_batch_size).unwrap_or(u64::MAX).max(1),
-            write_batches_completed: 0,
-            previous_operation_was_write: false,
+            successful_write_batches: Vec::new(),
+            next_write_batch: 0,
         }
     }
 
-    /// Emits the next logical operation for the current visible key range.
-    pub fn next_operation(&mut self, max_key_exclusive: u64) -> Operation {
-        if self.previous_operation_was_write {
-            self.write_batches_completed = self.write_batches_completed.saturating_add(1);
-            self.previous_operation_was_write = false;
+    /// Records whether the backend acknowledged a generated write batch.
+    ///
+    /// Results must be reported in batch order.
+    pub fn record_write_result(
+        &mut self,
+        batch_number: u64,
+        succeeded: bool,
+    ) -> anyhow::Result<()> {
+        ensure!(
+            batch_number == self.next_write_batch,
+            "write batches must be reported in order"
+        );
+        self.next_write_batch = self
+            .next_write_batch
+            .checked_add(1)
+            .context("write batch number overflow")?;
+
+        if !succeeded {
+            return Ok(());
         }
 
+        let first_write_number = batch_number
+            .checked_mul(self.write_batch_size)
+            .context("write batch number overflow")?;
+        first_write_number
+            .checked_add(self.write_batch_size - 1)
+            .context("write batch number overflow")?;
+        self.successful_write_batches.push(batch_number);
+        Ok(())
+    }
+
+    /// Emits the next logical operation for the current visible key range.
+    ///
+    /// Report each emitted write outcome before requesting another operation.
+    pub fn next_operation(&mut self, max_key_exclusive: u64) -> Operation {
         let p = self.rng.random::<f64>();
         if p < self.spec.mix.read_ratio {
             return Operation::Read {
@@ -250,19 +283,7 @@ impl WorkerPlan {
             };
         }
 
-        self.previous_operation_was_write = true;
         Operation::Write
-    }
-
-    fn prior_written_key_count(&self, initial_keys: u64) -> u64 {
-        let requested = self
-            .write_batches_completed
-            .saturating_mul(self.write_batch_size);
-        let Some(first) = initial_keys.checked_add(self.worker_id) else {
-            return 0;
-        };
-        let representable = ((u64::MAX - first) / self.worker_count).saturating_add(1);
-        requested.min(representable)
     }
 
     fn prior_written_key_index(&self, initial_keys: u64, write_number: u64) -> Option<u64> {
@@ -272,31 +293,137 @@ impl WorkerPlan {
             .and_then(|offset| initial_keys.checked_add(offset))
     }
 
-    fn first_prior_write_at_or_after(
-        &self,
-        initial_keys: u64,
-        lower_bound: u64,
-        written_keys: u64,
-    ) -> u64 {
-        let Some(first) = initial_keys.checked_add(self.worker_id) else {
-            return written_keys;
-        };
+    fn write_batch_first_write_number(&self, batch_number: u64) -> u64 {
+        batch_number
+            .checked_mul(self.write_batch_size)
+            .expect("acknowledged write batch should be representable")
+    }
+
+    fn write_batch_last_write_number(&self, batch_number: u64) -> u64 {
+        self.write_batch_first_write_number(batch_number)
+            .checked_add(self.write_batch_size - 1)
+            .expect("acknowledged write batch should be representable")
+    }
+
+    fn first_prior_write_at_or_after(&self, initial_keys: u64, lower_bound: u64) -> Option<u64> {
+        let first = initial_keys.checked_add(self.worker_id)?;
         if lower_bound <= first {
-            return 0;
+            return Some(0);
         }
 
         let delta = lower_bound - first;
-        delta.div_ceil(self.worker_count).min(written_keys)
+        Some(delta.div_ceil(self.worker_count))
+    }
+
+    fn last_representable_write_number(&self, initial_keys: u64) -> Option<u64> {
+        let first = initial_keys.checked_add(self.worker_id)?;
+        Some((u64::MAX - first) / self.worker_count)
+    }
+
+    fn successful_write_window(
+        &self,
+        initial_keys: u64,
+        lower_bound: u64,
+    ) -> Option<SuccessfulWriteWindow> {
+        let first_write_number = self.first_prior_write_at_or_after(initial_keys, lower_bound)?;
+        let last_write_number = self.last_representable_write_number(initial_keys)?;
+        let first_batch = self
+            .successful_write_batches
+            .partition_point(|&batch_number| {
+                self.write_batch_last_write_number(batch_number) < first_write_number
+            });
+        let end_batch = self
+            .successful_write_batches
+            .partition_point(|&batch_number| {
+                self.write_batch_first_write_number(batch_number) <= last_write_number
+            });
+        if first_batch >= end_batch {
+            return None;
+        }
+
+        let first_write_number = first_write_number
+            .max(self.write_batch_first_write_number(self.successful_write_batches[first_batch]));
+        let last_write_number = last_write_number
+            .min(self.write_batch_last_write_number(self.successful_write_batches[end_batch - 1]));
+        if first_write_number > last_write_number {
+            return None;
+        }
+
+        Some(SuccessfulWriteWindow {
+            batch_indices: first_batch..end_batch,
+            first_write_number,
+            last_write_number,
+        })
+    }
+
+    fn successful_write_count(&self, window: &SuccessfulWriteWindow) -> u64 {
+        let first_batch = window.batch_indices.start;
+        let last_batch = window.batch_indices.end - 1;
+        if first_batch == last_batch {
+            return window
+                .last_write_number
+                .saturating_sub(window.first_write_number)
+                .saturating_add(1);
+        }
+
+        let first_count = self
+            .write_batch_last_write_number(self.successful_write_batches[first_batch])
+            - window.first_write_number
+            + 1;
+        let middle_batches = window.batch_indices.end - first_batch - 2;
+        let middle_count = u64::try_from(middle_batches)
+            .unwrap_or(u64::MAX)
+            .saturating_mul(self.write_batch_size);
+        let last_count = window.last_write_number
+            - self.write_batch_first_write_number(self.successful_write_batches[last_batch])
+            + 1;
+
+        first_count
+            .saturating_add(middle_count)
+            .saturating_add(last_count)
+    }
+
+    fn successful_write_number_at(&self, window: &SuccessfulWriteWindow, choice: u64) -> u64 {
+        let first_batch = window.batch_indices.start;
+        let last_batch = window.batch_indices.end - 1;
+        if first_batch == last_batch {
+            return window.first_write_number + choice;
+        }
+
+        let first_count = self
+            .write_batch_last_write_number(self.successful_write_batches[first_batch])
+            - window.first_write_number
+            + 1;
+        if choice < first_count {
+            return window.first_write_number + choice;
+        }
+
+        let choice = choice - first_count;
+        let middle_batches = window.batch_indices.end - first_batch - 2;
+        let middle_count = u64::try_from(middle_batches)
+            .unwrap_or(u64::MAX)
+            .saturating_mul(self.write_batch_size);
+        if choice < middle_count {
+            let batch_index = first_batch
+                + 1
+                + usize::try_from(choice / self.write_batch_size)
+                    .expect("successful write batch index should fit");
+            return self.write_batch_first_write_number(self.successful_write_batches[batch_index])
+                + choice % self.write_batch_size;
+        }
+
+        self.write_batch_first_write_number(self.successful_write_batches[last_batch]) + choice
+            - middle_count
     }
 
     fn sample_known_key_index(&mut self, initial_keys: u64, lower_bound: u64) -> u64 {
-        let written_keys = self.prior_written_key_count(initial_keys);
         let fixture_start = lower_bound.min(initial_keys);
         let fixture_keys = initial_keys - fixture_start;
-        let first_write =
-            self.first_prior_write_at_or_after(initial_keys, lower_bound, written_keys);
-        let eligible_writes = written_keys - first_write;
-        let candidates = fixture_keys.saturating_add(eligible_writes);
+        let successful_writes = self.successful_write_window(initial_keys, lower_bound);
+        let successful_write_count = successful_writes
+            .as_ref()
+            .map_or(0, |window| self.successful_write_count(window));
+        let candidates = fixture_keys.saturating_add(successful_write_count);
         if candidates == 0 {
             return 0;
         }
@@ -306,17 +433,23 @@ impl WorkerPlan {
             return fixture_start + choice;
         }
 
-        let write_number = first_write + choice - fixture_keys;
+        let write_number = self.successful_write_number_at(
+            successful_writes
+                .as_ref()
+                .expect("write candidate requires an acknowledged write batch"),
+            choice - fixture_keys,
+        );
         self.prior_written_key_index(initial_keys, write_number)
-            .expect("prior written key index should fit")
+            .expect("acknowledged write index should fit")
     }
 
     fn sample_latest_key_index(&mut self, initial_keys: u64) -> u64 {
         let lower_bound = if self.rng.random::<f64>() < self.spec.latest_prob {
-            let written_keys = self.prior_written_key_count(initial_keys);
-            let latest_key = written_keys
-                .checked_sub(1)
-                .and_then(|write_number| self.prior_written_key_index(initial_keys, write_number))
+            let latest_key = self
+                .successful_write_window(initial_keys, 0)
+                .and_then(|window| {
+                    self.prior_written_key_index(initial_keys, window.last_write_number)
+                })
                 .unwrap_or_else(|| initial_keys.saturating_sub(1));
             latest_key.saturating_sub(self.spec.latest_window.saturating_sub(1))
         } else {
@@ -511,8 +644,16 @@ mod tests {
                 let worker_ops = worker_operation_count(total_ops, concurrency, worker).unwrap();
                 let mut plan =
                     WorkerPlan::new(seed, worker as u64, spec, concurrency, write_batch_size);
+                let mut write_batch = 0;
                 (0..worker_ops)
-                    .map(|_| plan.next_operation(max_key_exclusive))
+                    .map(|_| {
+                        let operation = plan.next_operation(max_key_exclusive);
+                        if matches!(operation, Operation::Write) {
+                            plan.record_write_result(write_batch, true).unwrap();
+                            write_batch += 1;
+                        }
+                        operation
+                    })
                     .collect()
             })
             .collect()
@@ -755,9 +896,13 @@ mod tests {
                 let operation = plans[worker].next_operation(100);
                 let write_index = match operation {
                     Operation::Write => {
-                        let write_number = writes[worker] * write_batch_size as u64;
+                        let write_batch = writes[worker];
+                        let write_number = write_batch * write_batch_size as u64;
                         let index =
                             worker_write_index(100, worker_count, worker, write_number).unwrap();
+                        plans[worker]
+                            .record_write_result(write_batch, true)
+                            .unwrap();
                         writes[worker] += 1;
                         index
                     }
@@ -854,9 +999,15 @@ mod tests {
         // static fixture boundary.
         let mut plan = WorkerPlan::with_zipf_sampler(7, 0, spec, None, workers, 1);
         let mut read_indexes = Vec::new();
+        let mut write_batch = 0;
         for _ in 0..2_000 {
-            if let Operation::Read { index } = plan.next_operation(initial) {
-                read_indexes.push(index);
+            match plan.next_operation(initial) {
+                Operation::Read { index } => read_indexes.push(index),
+                Operation::Write => {
+                    plan.record_write_result(write_batch, true).unwrap();
+                    write_batch += 1;
+                }
+                Operation::Scan { .. } => unreachable!("scan ratio is zero"),
             }
         }
         let late_reads = &read_indexes[read_indexes.len() - 20..];
@@ -928,6 +1079,7 @@ mod tests {
                                 .expect("write index should be valid");
                             written.insert(index);
                         }
+                        plan.record_write_result(write_batch, true).unwrap();
                         write_batch += 1;
                     }
                     Operation::Scan { .. } => unreachable!("scan ratio is zero"),
@@ -940,5 +1092,102 @@ mod tests {
             appended_read_count > 0,
             "stream should exercise reads from prior writes"
         );
+    }
+
+    #[test]
+    fn latest_reads_do_not_target_failed_write_attempts() {
+        let spec = WorkloadSpec::new(
+            WorkloadMix {
+                read_ratio: 0.5,
+                write_ratio: 0.5,
+                scan_ratio: 0.0,
+            },
+            25,
+            KeyDistribution::Latest,
+            10,
+            1.0,
+            0.99,
+        )
+        .expect("spec should validate");
+        let initial = 1u64;
+        let mut plan = WorkerPlan::new(42, 0, spec, 1, 3);
+        let mut failed_write_attempts = 0;
+
+        for _ in 0..256 {
+            match plan.next_operation(initial) {
+                Operation::Read { index } => assert!(
+                    index < initial,
+                    "latest read targeted key {index} after {failed_write_attempts} failed write attempts"
+                ),
+                Operation::Write => failed_write_attempts += 1,
+                Operation::Scan { .. } => unreachable!("scan ratio is zero"),
+            }
+        }
+
+        assert!(failed_write_attempts > 0, "stream should contain writes");
+    }
+
+    #[test]
+    fn latest_scans_do_not_target_failed_write_attempts() {
+        let spec = WorkloadSpec::new(
+            WorkloadMix {
+                read_ratio: 0.0,
+                write_ratio: 0.5,
+                scan_ratio: 0.5,
+            },
+            25,
+            KeyDistribution::Latest,
+            10,
+            1.0,
+            0.99,
+        )
+        .expect("spec should validate");
+        let initial = 1u64;
+        let mut plan = WorkerPlan::new(42, 0, spec, 1, 3);
+        let mut failed_write_attempts = 0;
+
+        for _ in 0..256 {
+            match plan.next_operation(initial) {
+                Operation::Read { .. } => unreachable!("read ratio is zero"),
+                Operation::Scan { start, .. } => assert!(
+                    start < initial,
+                    "latest scan targeted key {start} after {failed_write_attempts} failed write attempts"
+                ),
+                Operation::Write => failed_write_attempts += 1,
+            }
+        }
+
+        assert!(failed_write_attempts > 0, "stream should contain writes");
+    }
+
+    #[test]
+    fn acknowledged_write_batches_keep_failed_gaps() {
+        let spec = WorkloadSpec::new(
+            WorkloadMix {
+                read_ratio: 0.5,
+                write_ratio: 0.5,
+                scan_ratio: 0.0,
+            },
+            25,
+            KeyDistribution::Latest,
+            10,
+            1.0,
+            0.99,
+        )
+        .expect("spec should validate");
+        let mut plan = WorkerPlan::new(42, 0, spec, 1, 3);
+
+        plan.record_write_result(0, true).unwrap();
+        plan.record_write_result(1, false).unwrap();
+        plan.record_write_result(2, true).unwrap();
+
+        let window = plan
+            .successful_write_window(1, 0)
+            .expect("successful writes should be available");
+        let writes: Vec<u64> = (0..plan.successful_write_count(&window))
+            .map(|choice| plan.successful_write_number_at(&window, choice))
+            .collect();
+
+        assert_eq!(writes, [0, 1, 2, 6, 7, 8]);
     }
 }

--- a/validation/src/workload.rs
+++ b/validation/src/workload.rs
@@ -13,9 +13,9 @@ pub const DEFAULT_BENCH_RNG_SEED: u64 = 0x5eed_c0de;
 /// Version of the deterministic operation-stream generator used in manifests.
 ///
 /// Bump this when changing its seeded random stream or operation semantics.
-/// Version 5 makes the latest frontier batch-aware and bounds scans to one
-/// leading-byte prefix.
-pub const WORKLOAD_GENERATOR_VERSION: u16 = 5;
+/// Version 6 samples latest keys from the fixture and prior writes in the
+/// current worker's lane.
+pub const WORKLOAD_GENERATOR_VERSION: u16 = 6;
 
 /// Named workload mixes for benchmark operation selection.
 #[derive(Copy, Clone, Debug, Deserialize, Eq, PartialEq, Serialize, ValueEnum)]
@@ -84,12 +84,16 @@ pub struct WorkerPlan {
     rng: rand::rngs::StdRng,
     spec: WorkloadSpec,
     zipf_sampler: Option<Arc<ZipfSampler>>,
-    // Execution shape used by the deterministic write-frontier estimate.
+
+    // The execution shape maps prior write batches to their concrete keys.
+    worker_id: u64,
     worker_count: u64,
     write_batch_size: u64,
 
-    // Position in this worker's operation stream.
-    ops_emitted: u64,
+    // The executor awaits each operation before requesting the next one.
+    // This promotes only earlier write batches into latest-key candidates.
+    write_batches_completed: u64,
+    previous_operation_was_write: bool,
 }
 
 pub(crate) struct ZipfSampler {
@@ -192,8 +196,14 @@ impl WorkloadSpec {
 
 impl WorkerPlan {
     /// Creates a replayable worker stream from the run seed and worker id.
-    pub fn new(seed: u64, worker_id: u64, spec: WorkloadSpec) -> Self {
-        Self::with_zipf_sampler(seed, worker_id, spec, None, 1, 1)
+    pub fn new(
+        seed: u64,
+        worker_id: u64,
+        spec: WorkloadSpec,
+        worker_count: usize,
+        write_batch_size: usize,
+    ) -> Self {
+        Self::with_zipf_sampler(seed, worker_id, spec, None, worker_count, write_batch_size)
     }
 
     pub(crate) fn with_zipf_sampler(
@@ -208,15 +218,21 @@ impl WorkerPlan {
             rng: worker_rng(seed, worker_id),
             spec,
             zipf_sampler,
+            worker_id,
             worker_count: u64::try_from(worker_count).unwrap_or(u64::MAX).max(1),
             write_batch_size: u64::try_from(write_batch_size).unwrap_or(u64::MAX).max(1),
-            ops_emitted: 0,
+            write_batches_completed: 0,
+            previous_operation_was_write: false,
         }
     }
 
     /// Emits the next logical operation for the current visible key range.
     pub fn next_operation(&mut self, max_key_exclusive: u64) -> Operation {
-        self.ops_emitted += 1;
+        if self.previous_operation_was_write {
+            self.write_batches_completed = self.write_batches_completed.saturating_add(1);
+            self.previous_operation_was_write = false;
+        }
+
         let p = self.rng.random::<f64>();
         if p < self.spec.mix.read_ratio {
             return Operation::Read {
@@ -234,20 +250,80 @@ impl WorkerPlan {
             };
         }
 
+        self.previous_operation_was_write = true;
         Operation::Write
     }
 
-    // A shared live counter would make seeded streams depend on task
-    // scheduling. Estimate the latest frontier from this worker's stream
-    // position and the configured execution shape instead. Reads near the
-    // estimate may race the writes they target. Those misses measure
-    // visibility lag at the latest frontier.
-    fn estimated_write_frontier(&self, initial_keys: u64) -> u64 {
-        let writes_per_worker = (self.ops_emitted as f64 * self.spec.mix.write_ratio) as u64;
-        let appended = writes_per_worker
-            .saturating_mul(self.worker_count)
+    fn prior_written_key_count(&self, initial_keys: u64) -> u64 {
+        let requested = self
+            .write_batches_completed
             .saturating_mul(self.write_batch_size);
-        initial_keys.saturating_add(appended)
+        let Some(first) = initial_keys.checked_add(self.worker_id) else {
+            return 0;
+        };
+        let representable = ((u64::MAX - first) / self.worker_count).saturating_add(1);
+        requested.min(representable)
+    }
+
+    fn prior_written_key_index(&self, initial_keys: u64, write_number: u64) -> Option<u64> {
+        write_number
+            .checked_mul(self.worker_count)
+            .and_then(|offset| offset.checked_add(self.worker_id))
+            .and_then(|offset| initial_keys.checked_add(offset))
+    }
+
+    fn first_prior_write_at_or_after(
+        &self,
+        initial_keys: u64,
+        lower_bound: u64,
+        written_keys: u64,
+    ) -> u64 {
+        let Some(first) = initial_keys.checked_add(self.worker_id) else {
+            return written_keys;
+        };
+        if lower_bound <= first {
+            return 0;
+        }
+
+        let delta = lower_bound - first;
+        delta.div_ceil(self.worker_count).min(written_keys)
+    }
+
+    fn sample_known_key_index(&mut self, initial_keys: u64, lower_bound: u64) -> u64 {
+        let written_keys = self.prior_written_key_count(initial_keys);
+        let fixture_start = lower_bound.min(initial_keys);
+        let fixture_keys = initial_keys - fixture_start;
+        let first_write =
+            self.first_prior_write_at_or_after(initial_keys, lower_bound, written_keys);
+        let eligible_writes = written_keys - first_write;
+        let candidates = fixture_keys.saturating_add(eligible_writes);
+        if candidates == 0 {
+            return 0;
+        }
+
+        let choice = self.rng.random_range(0..candidates);
+        if choice < fixture_keys {
+            return fixture_start + choice;
+        }
+
+        let write_number = first_write + choice - fixture_keys;
+        self.prior_written_key_index(initial_keys, write_number)
+            .expect("prior written key index should fit")
+    }
+
+    fn sample_latest_key_index(&mut self, initial_keys: u64) -> u64 {
+        let lower_bound = if self.rng.random::<f64>() < self.spec.latest_prob {
+            let written_keys = self.prior_written_key_count(initial_keys);
+            let latest_key = written_keys
+                .checked_sub(1)
+                .and_then(|write_number| self.prior_written_key_index(initial_keys, write_number))
+                .unwrap_or_else(|| initial_keys.saturating_sub(1));
+            latest_key.saturating_sub(self.spec.latest_window.saturating_sub(1))
+        } else {
+            0
+        };
+
+        self.sample_known_key_index(initial_keys, lower_bound)
     }
 
     // Each arm draws the same amount of randomness on every call for a given
@@ -260,21 +336,7 @@ impl WorkerPlan {
                 }
                 self.rng.random_range(0..max_key_exclusive)
             }
-            KeyDistribution::Latest => {
-                // Keep the recency window against the estimated append
-                // frontier instead of the static fixture boundary.
-                let frontier = self.estimated_write_frontier(max_key_exclusive);
-                if frontier <= 1 {
-                    return 0;
-                }
-                if self.rng.random::<f64>() < self.spec.latest_prob {
-                    let window = self.spec.latest_window.max(1).min(frontier);
-                    let start = frontier - window;
-                    self.rng.random_range(start..frontier)
-                } else {
-                    self.rng.random_range(0..frontier)
-                }
-            }
+            KeyDistribution::Latest => self.sample_latest_key_index(max_key_exclusive),
             KeyDistribution::Zipfian => {
                 let replace_sampler = self
                     .zipf_sampler
@@ -415,6 +477,8 @@ fn approx_eq(a: f64, b: f64, eps: f64) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
+
     use super::*;
     use rand::{RngExt, SeedableRng};
 
@@ -439,12 +503,14 @@ mod tests {
         spec: WorkloadSpec,
         total_ops: u64,
         concurrency: usize,
+        write_batch_size: usize,
         max_key_exclusive: u64,
     ) -> Vec<Vec<Operation>> {
         (0..concurrency)
             .map(|worker| {
                 let worker_ops = worker_operation_count(total_ops, concurrency, worker).unwrap();
-                let mut plan = WorkerPlan::new(seed, worker as u64, spec);
+                let mut plan =
+                    WorkerPlan::new(seed, worker as u64, spec, concurrency, write_batch_size);
                 (0..worker_ops)
                     .map(|_| plan.next_operation(max_key_exclusive))
                     .collect()
@@ -523,7 +589,7 @@ mod tests {
             latest_prob: 1.0,
             ..sample_spec()
         };
-        let mut plan = WorkerPlan::new(7, 0, spec);
+        let mut plan = WorkerPlan::new(7, 0, spec, 1, 1);
 
         for _ in 0..1_000 {
             let idx = plan.sample_key_index(max);
@@ -543,7 +609,7 @@ mod tests {
                 key_dist,
                 ..sample_spec()
             };
-            let mut plan = WorkerPlan::new(11, 0, spec);
+            let mut plan = WorkerPlan::new(11, 0, spec, 1, 1);
 
             for _ in 0..1_000 {
                 let idx = plan.sample_key_index(500);
@@ -576,7 +642,7 @@ mod tests {
             key_dist: KeyDistribution::Zipfian,
             ..sample_spec()
         };
-        let mut plan = WorkerPlan::new(11, 0, spec);
+        let mut plan = WorkerPlan::new(11, 0, spec, 1, 1);
 
         assert!((0..10_000).any(|_| plan.sample_key_index(2) == 1));
     }
@@ -634,7 +700,7 @@ mod tests {
                 zipf_theta: theta,
                 ..sample_spec()
             };
-            let mut plan = WorkerPlan::new(11, 0, spec);
+            let mut plan = WorkerPlan::new(11, 0, spec, 1, 1);
             assert!(
                 (0..10_000).any(|_| plan.sample_key_index(4) == 3),
                 "last key was not sampled for theta={theta}"
@@ -676,7 +742,12 @@ mod tests {
     #[test]
     fn worker_schedules_preserve_operation_streams_and_write_indexes() {
         fn run_schedule(schedule: &[usize], spec: WorkloadSpec) -> Vec<Vec<(Operation, u64)>> {
-            let mut plans = [WorkerPlan::new(42, 0, spec), WorkerPlan::new(42, 1, spec)];
+            let worker_count = 2;
+            let write_batch_size = 3;
+            let mut plans = [
+                WorkerPlan::new(42, 0, spec, worker_count, write_batch_size),
+                WorkerPlan::new(42, 1, spec, worker_count, write_batch_size),
+            ];
             let mut writes = [0u64; 2];
             let mut operations = vec![Vec::new(), Vec::new()];
 
@@ -684,7 +755,9 @@ mod tests {
                 let operation = plans[worker].next_operation(100);
                 let write_index = match operation {
                     Operation::Write => {
-                        let index = worker_write_index(100, 2, worker, writes[worker]).unwrap();
+                        let write_number = writes[worker] * write_batch_size as u64;
+                        let index =
+                            worker_write_index(100, worker_count, worker, write_number).unwrap();
                         writes[worker] += 1;
                         index
                     }
@@ -723,8 +796,8 @@ mod tests {
     #[test]
     fn worker_plan_is_replayable_for_same_seed_and_worker() {
         let spec = sample_spec();
-        let mut a = WorkerPlan::new(42, 0, spec);
-        let mut b = WorkerPlan::new(42, 0, spec);
+        let mut a = WorkerPlan::new(42, 0, spec, 4, 100);
+        let mut b = WorkerPlan::new(42, 0, spec, 4, 100);
         let ops_a: Vec<Operation> = (0..32).map(|_| a.next_operation(1_000)).collect();
         let ops_b: Vec<Operation> = (0..32).map(|_| b.next_operation(1_000)).collect();
         assert_eq!(ops_a, ops_b);
@@ -741,9 +814,9 @@ mod tests {
             0.99,
         )
         .unwrap();
-        let first = worker_streams(42, spec, 257, 8, 10_000);
-        let second = worker_streams(42, spec, 257, 8, 10_000);
-        let different_seed = worker_streams(43, spec, 257, 8, 10_000);
+        let first = worker_streams(42, spec, 257, 8, 100, 10_000);
+        let second = worker_streams(42, spec, 257, 8, 100, 10_000);
+        let different_seed = worker_streams(43, spec, 257, 8, 100, 10_000);
 
         assert_eq!(first, second);
         assert_ne!(first, different_seed);
@@ -752,15 +825,15 @@ mod tests {
     #[test]
     fn worker_plan_differs_across_workers() {
         let spec = sample_spec();
-        let mut a = WorkerPlan::new(42, 0, spec);
-        let mut b = WorkerPlan::new(42, 1, spec);
+        let mut a = WorkerPlan::new(42, 0, spec, 4, 100);
+        let mut b = WorkerPlan::new(42, 1, spec, 4, 100);
         let ops_a: Vec<Operation> = (0..32).map(|_| a.next_operation(1_000)).collect();
         let ops_b: Vec<Operation> = (0..32).map(|_| b.next_operation(1_000)).collect();
         assert_ne!(ops_a, ops_b);
     }
 
     #[test]
-    fn latest_window_chases_the_estimated_write_frontier() {
+    fn latest_window_chases_prior_writes() {
         let spec = WorkloadSpec::new(
             WorkloadMix {
                 read_ratio: 0.5,
@@ -777,8 +850,8 @@ mod tests {
         let initial = 1_000u64;
         let workers = 4usize;
 
-        // Late reads must target the moving frontier instead of the static
-        // fixture boundary.
+        // Late reads must target prior appended keys instead of staying at the
+        // static fixture boundary.
         let mut plan = WorkerPlan::with_zipf_sampler(7, 0, spec, None, workers, 1);
         let mut read_indexes = Vec::new();
         for _ in 0..2_000 {
@@ -801,7 +874,7 @@ mod tests {
     }
 
     #[test]
-    fn latest_frontier_accounts_for_write_batch_size() {
+    fn latest_reads_target_keys_written_by_the_replayed_stream() {
         let spec = WorkloadSpec::new(
             WorkloadMix {
                 read_ratio: 0.5,
@@ -815,10 +888,57 @@ mod tests {
             0.99,
         )
         .expect("spec should validate");
-        let initial = 1_000u64;
-        let mut plan = WorkerPlan::with_zipf_sampler(7, 0, spec, None, 4, 100);
-        plan.ops_emitted = 2_000;
+        let initial = 1u64;
+        let workers = 4usize;
+        let batch_size = 3u64;
+        let total_ops = 256u64;
+        let mut read_count = 0;
+        let mut appended_read_count = 0;
 
-        assert_eq!(plan.estimated_write_frontier(initial), 401_000);
+        for worker in 0..workers {
+            let worker_ops = worker_operation_count(total_ops, workers, worker)
+                .expect("worker operation count should be valid");
+            let mut plan = WorkerPlan::with_zipf_sampler(
+                42,
+                worker as u64,
+                spec,
+                None,
+                workers,
+                batch_size as usize,
+            );
+            let mut write_batch = 0u64;
+            let mut written = HashSet::new();
+
+            for _ in 0..worker_ops {
+                match plan.next_operation(initial) {
+                    Operation::Read { index } => {
+                        read_count += 1;
+                        if index >= initial {
+                            appended_read_count += 1;
+                            assert!(
+                                written.contains(&index),
+                                "latest read targeted key {index} before its write"
+                            );
+                        }
+                    }
+                    Operation::Write => {
+                        for offset in 0..batch_size {
+                            let write_number = write_batch * batch_size + offset;
+                            let index = worker_write_index(initial, workers, worker, write_number)
+                                .expect("write index should be valid");
+                            written.insert(index);
+                        }
+                        write_batch += 1;
+                    }
+                    Operation::Scan { .. } => unreachable!("scan ratio is zero"),
+                }
+            }
+        }
+
+        assert!(read_count > 0, "stream should contain reads");
+        assert!(
+            appended_read_count > 0,
+            "stream should exercise reads from prior writes"
+        );
     }
 }

--- a/validation/src/workload.rs
+++ b/validation/src/workload.rs
@@ -12,10 +12,10 @@ pub const DEFAULT_BENCH_RNG_SEED: u64 = 0x5eed_c0de;
 
 /// Version of the deterministic operation-stream generator used in manifests.
 ///
-/// Bump this when changing its seeded random stream, including an RNG update,
-/// or when changing what an emitted operation means (v4: scans became
-/// seek-forward-with-limit instead of two-hashed-endpoint windows).
-pub const WORKLOAD_GENERATOR_VERSION: u16 = 4;
+/// Bump this when changing its seeded random stream or operation semantics.
+/// Version 5 makes the latest frontier batch-aware and bounds scans to one
+/// leading-byte prefix.
+pub const WORKLOAD_GENERATOR_VERSION: u16 = 5;
 
 /// Named workload mixes for benchmark operation selection.
 #[derive(Copy, Clone, Debug, Deserialize, Eq, PartialEq, Serialize, ValueEnum)]
@@ -55,7 +55,7 @@ pub struct WorkloadMix {
 pub struct WorkloadSpec {
     /// Operation mix used by every worker.
     pub mix: WorkloadMix,
-    /// Requested row limit and maximum logical span for generated scans.
+    /// Maximum number of physical rows returned by a generated scan.
     pub scan_length: usize,
     /// Distribution used when selecting existing-key indexes.
     pub key_dist: KeyDistribution,
@@ -73,14 +73,9 @@ pub enum Operation {
     /// Point read of an inserted logical key index.
     Read { index: u64 },
     /// Forward range scan of up to `limit` physical rows starting at an
-    /// inserted logical index's key. Index-hashed key placement scatters
-    /// logical indexes across the byte keyspace, so a window between two
-    /// hashed endpoints would span an arbitrarily large fraction of the store
-    /// (the server plans every overlapping run for it); seeking from one key
-    /// and bounding by row count keeps each scan's work proportional to
-    /// `limit` regardless of placement.
+    /// inserted logical index's key.
     Scan { start: u64, limit: usize },
-    /// Ingest write; the executor assigns the next concrete write index.
+    /// Ingest write. The executor assigns the next concrete write index.
     Write,
 }
 
@@ -89,9 +84,11 @@ pub struct WorkerPlan {
     rng: rand::rngs::StdRng,
     spec: WorkloadSpec,
     zipf_sampler: Option<Arc<ZipfSampler>>,
-    /// Total bench workers, for the deterministic write-frontier estimate.
+    // Execution shape used by the deterministic write-frontier estimate.
     worker_count: u64,
-    /// Operations this plan has emitted (the stream position).
+    write_batch_size: u64,
+
+    // Position in this worker's operation stream.
     ops_emitted: u64,
 }
 
@@ -196,7 +193,7 @@ impl WorkloadSpec {
 impl WorkerPlan {
     /// Creates a replayable worker stream from the run seed and worker id.
     pub fn new(seed: u64, worker_id: u64, spec: WorkloadSpec) -> Self {
-        Self::with_zipf_sampler(seed, worker_id, spec, None, 1)
+        Self::with_zipf_sampler(seed, worker_id, spec, None, 1, 1)
     }
 
     pub(crate) fn with_zipf_sampler(
@@ -205,12 +202,14 @@ impl WorkerPlan {
         spec: WorkloadSpec,
         zipf_sampler: Option<Arc<ZipfSampler>>,
         worker_count: usize,
+        write_batch_size: usize,
     ) -> Self {
         Self {
             rng: worker_rng(seed, worker_id),
             spec,
             zipf_sampler,
-            worker_count: (worker_count as u64).max(1),
+            worker_count: u64::try_from(worker_count).unwrap_or(u64::MAX).max(1),
+            write_batch_size: u64::try_from(write_batch_size).unwrap_or(u64::MAX).max(1),
             ops_emitted: 0,
         }
     }
@@ -238,18 +237,16 @@ impl WorkerPlan {
         Operation::Write
     }
 
-    // "Latest" must chase the write frontier or it degenerates into a fixed
-    // dead zone: writes append past the fixture, so a window anchored to the
-    // static fixture top reads keys nothing ever writes. A shared live counter
-    // would make seeded streams depend on task scheduling, so the frontier is
-    // instead *estimated* from this worker's own stream position (a pure
-    // function of the seed): all workers progress through identical op mixes,
-    // so expected appended keys after k ops is k * write_ratio per worker.
-    // Reads near the estimate may race the writes they target; those misses
-    // are the intended "latest" measurement, mirroring visibility lag.
+    // A shared live counter would make seeded streams depend on task
+    // scheduling. Estimate the latest frontier from this worker's stream
+    // position and the configured execution shape instead. Reads near the
+    // estimate may race the writes they target. Those misses measure
+    // visibility lag at the latest frontier.
     fn estimated_write_frontier(&self, initial_keys: u64) -> u64 {
-        let appended =
-            (self.ops_emitted as f64 * self.spec.mix.write_ratio) as u64 * self.worker_count;
+        let writes_per_worker = (self.ops_emitted as f64 * self.spec.mix.write_ratio) as u64;
+        let appended = writes_per_worker
+            .saturating_mul(self.worker_count)
+            .saturating_mul(self.write_batch_size);
         initial_keys.saturating_add(appended)
     }
 
@@ -264,9 +261,8 @@ impl WorkerPlan {
                 self.rng.random_range(0..max_key_exclusive)
             }
             KeyDistribution::Latest => {
-                // Sampling range = fixture plus the estimated frontier (see
-                // estimated_write_frontier); the window hugs the frontier so
-                // "latest" reads chase recent writes rather than a fixed top.
+                // Keep the recency window against the estimated append
+                // frontier instead of the static fixture boundary.
                 let frontier = self.estimated_write_frontier(max_key_exclusive);
                 if frontier <= 1 {
                     return 0;
@@ -621,8 +617,8 @@ mod tests {
             ..sample_spec()
         };
         let sampler = Arc::new(ZipfSampler::new(100, spec.zipf_theta));
-        let first = WorkerPlan::with_zipf_sampler(1, 0, spec, Some(sampler.clone()), 2);
-        let second = WorkerPlan::with_zipf_sampler(1, 1, spec, Some(sampler), 2);
+        let first = WorkerPlan::with_zipf_sampler(1, 0, spec, Some(sampler.clone()), 2, 1);
+        let second = WorkerPlan::with_zipf_sampler(1, 1, spec, Some(sampler), 2, 1);
 
         assert!(Arc::ptr_eq(
             first.zipf_sampler.as_ref().expect("sampler is set"),
@@ -781,10 +777,9 @@ mod tests {
         let initial = 1_000u64;
         let workers = 4usize;
 
-        // Late in the stream, every latest read must target the moving
-        // frontier region, not the static fixture top: after k ops the
-        // estimate is initial + k*write_ratio*workers, far above `initial`.
-        let mut plan = WorkerPlan::with_zipf_sampler(7, 0, spec, None, workers);
+        // Late reads must target the moving frontier instead of the static
+        // fixture boundary.
+        let mut plan = WorkerPlan::with_zipf_sampler(7, 0, spec, None, workers, 1);
         let mut read_indexes = Vec::new();
         for _ in 0..2_000 {
             if let Operation::Read { index } = plan.next_operation(initial) {
@@ -797,12 +792,33 @@ mod tests {
             "late latest reads should chase appended keys, got {late_reads:?}"
         );
 
-        // The estimate is a pure function of the seeded stream position, so
-        // two identically-seeded plans emit identical operations.
-        let mut x = WorkerPlan::with_zipf_sampler(7, 0, spec, None, workers);
-        let mut y = WorkerPlan::with_zipf_sampler(7, 0, spec, None, workers);
+        // Identical execution shapes and seeds must remain replayable.
+        let mut x = WorkerPlan::with_zipf_sampler(7, 0, spec, None, workers, 1);
+        let mut y = WorkerPlan::with_zipf_sampler(7, 0, spec, None, workers, 1);
         let ops_x: Vec<Operation> = (0..256).map(|_| x.next_operation(initial)).collect();
         let ops_y: Vec<Operation> = (0..256).map(|_| y.next_operation(initial)).collect();
         assert_eq!(ops_x, ops_y);
+    }
+
+    #[test]
+    fn latest_frontier_accounts_for_write_batch_size() {
+        let spec = WorkloadSpec::new(
+            WorkloadMix {
+                read_ratio: 0.5,
+                write_ratio: 0.5,
+                scan_ratio: 0.0,
+            },
+            25,
+            KeyDistribution::Latest,
+            10,
+            1.0,
+            0.99,
+        )
+        .expect("spec should validate");
+        let initial = 1_000u64;
+        let mut plan = WorkerPlan::with_zipf_sampler(7, 0, spec, None, 4, 100);
+        plan.ops_emitted = 2_000;
+
+        assert_eq!(plan.estimated_write_frontier(initial), 401_000);
     }
 }


### PR DESCRIPTION
Improves validation benchmark performance by enabling `zstd` request compression by default and recording the setting in reports and replay-able manifests. Range scans now seek forward within a single leading-byte prefix, avoiding expensive planning across the full keyspace caused by hashing key indices previously.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Bumps workload_generator_version to 7 (breaking old manifest replay) and changes scan and latest-read semantics, which alters benchmark comparability; request compression also changes measured throughput vs prior defaults.
> 
> **Overview**
> Improves **validation bench** throughput and replay fidelity by defaulting outgoing RPC bodies to **zstd** compression (`--request-compression` also supports gzip/none), wiring it through the SDK client, and persisting **`request_compression`** in JSON reports, GitHub summaries, and manifests (replay requires the field; CLI overrides conflict with `--manifest`).
> 
> **Range scans** no longer build a two-key window from sampled indexes. Each scan seeks from one key forward with an upper bound that shares the start key’s **leading byte** (`scan_upper_bound`) and applies `--scan-length` as the row limit.
> 
> **Workload generator v7** changes operation semantics: `WorkerPlan` tracks **successful write batches** per worker (`record_write_result`), so **latest** reads/scans sample the loaded fixture plus keys from **acknowledged** puts in that worker’s lane and skip failed batches. `Operation::Scan` drops the `end` index. Read-miss warnings are split by key distribution. Docs and integration tests cover compression manifests, prefix scans, and latest-read behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 159d867814f5ff389a204ddc9bb30926440da573. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->