### PR TITLE
server: bounded get_batch lookahead

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2768,6 +2768,7 @@ dependencies = [
  "connectrpc",
  "exoware-sdk",
  "exoware-server",
+ "futures",
  "http",
  "mimalloc",
  "parking_lot",

--- a/examples/simulator/Cargo.toml
+++ b/examples/simulator/Cargo.toml
@@ -31,6 +31,7 @@ tower-http = { workspace = true }
 
 [dev-dependencies]
 connectrpc = { workspace = true }
+futures = { workspace = true }
 http = { workspace = true }
 
 [[bin]]

--- a/examples/simulator/src/rocks.rs
+++ b/examples/simulator/src/rocks.rs
@@ -1420,13 +1420,22 @@ impl Log for RocksStore {
         if sequence_number > self.frontiers.published.load(Ordering::Acquire) {
             return Ok(None);
         }
-        let value = match self
-            .db
-            .get_cf(self.log_cf(), sequence_log_key(sequence_number))
-            .map_err(|e| e.to_string())?
-        {
-            Some(value) => value,
-            None => return Ok(None),
+
+        // The read runs on the blocking pool so this future yields. An inline read
+        // holds a Tokio worker for the whole RocksDB lookup, which serializes the
+        // subscribe lookahead and stalls unrelated tasks on cold reads.
+        let store = self.clone();
+        let value = tokio::task::spawn_blocking(move || {
+            store
+                .db
+                .get_cf(store.log_cf(), sequence_log_key(sequence_number))
+                .map_err(|e| e.to_string())
+        })
+        .await
+        .map_err(|e| format!("log read task failed: {e}"))??;
+
+        let Some(value) = value else {
+            return Ok(None);
         };
         Ok(Some(LogBatch::from_response_bytes(sequence_number, value)))
     }
@@ -2098,6 +2107,52 @@ mod tests {
             .expect("get batch")
             .expect("batch retained");
         assert_eq!(batch_entries(batch), vec![(key, value)]);
+    }
+
+    // The subscribe lookahead can only overlap log reads if `get_batch` yields.
+    // An inline read completes within a single poll, so the in-flight gauge
+    // would never exceed one and this test would fail.
+    #[tokio::test]
+    async fn get_batch_reads_overlap_under_buffered_lookahead() {
+        use futures::StreamExt;
+
+        let dir = tempdir().expect("tempdir");
+        let store = Arc::new(RocksStore::open(dir.path(), None).expect("open db"));
+        let batches = 8u64;
+        for i in 0..batches {
+            store
+                .put_batch(vec![(
+                    Bytes::from(format!("key-{i}")),
+                    Bytes::from_static(b"value"),
+                )])
+                .await
+                .expect("put");
+        }
+
+        let in_flight = Arc::new(AtomicU64::new(0));
+        let max_in_flight = Arc::new(AtomicU64::new(0));
+        let mut reads = futures::stream::iter(1..=batches)
+            .map(|sequence| {
+                let store = store.clone();
+                let in_flight = in_flight.clone();
+                let max_in_flight = max_in_flight.clone();
+                async move {
+                    let level = in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+                    max_in_flight.fetch_max(level, Ordering::SeqCst);
+                    let result = store.get_batch(sequence).await;
+                    in_flight.fetch_sub(1, Ordering::SeqCst);
+                    result
+                }
+            })
+            .buffered(batches as usize);
+        while let Some(batch) = reads.next().await {
+            batch.expect("get batch").expect("batch retained");
+        }
+
+        assert!(
+            max_in_flight.load(Ordering::SeqCst) >= 2,
+            "buffered get_batch reads never overlapped",
+        );
     }
 
     #[tokio::test]

--- a/qmdb/rs/src/connect.rs
+++ b/qmdb/rs/src/connect.rs
@@ -586,6 +586,20 @@ struct BatchSubscribeStream<D: commonware_cryptography::Digest, F: Graftable> {
     watermarks: BTreeMap<Location<F>, u64>,
     ready: VecDeque<ReadyBatch<F>>,
     building: Option<BoxFuture<'static, Result<PreEncoded<SubscribeResponse>, ConnectError>>>,
+    // Terminal upstream event observed while a proof was still building. It is
+    // delivered after the staged batches drain.
+    staged_terminal: Option<StagedTerminal>,
+}
+
+// Bound on batches staged (pending plus ready) while a proof builds. Staging
+// keeps demand flowing to the store subscription so the server-side lookahead
+// stays occupied during proof construction, and the bound keeps the staged
+// queues finite when the subscriber outruns proof throughput.
+const SUBSCRIBE_STAGED_BATCHES: usize = 8;
+
+enum StagedTerminal {
+    End,
+    Error(ConnectError),
 }
 
 impl<D: commonware_cryptography::Digest, F: Graftable> Unpin for BatchSubscribeStream<D, F> {}
@@ -625,7 +639,23 @@ impl<D: commonware_cryptography::Digest, F: Graftable> BatchSubscribeStream<D, F
             watermarks: BTreeMap::new(),
             ready: VecDeque::new(),
             building: None,
+            staged_terminal: None,
         }
+    }
+
+    fn poll_frame(
+        &mut self,
+        cx: &mut TaskContext<'_>,
+    ) -> Poll<Result<Option<exoware_sdk::StreamSubscriptionFrame>, ConnectError>> {
+        let next_fut = self.sub.next();
+        tokio::pin!(next_fut);
+        next_fut.as_mut().poll(cx).map_err(|err| {
+            if let Some(rpc) = err.rpc_error() {
+                ConnectError::new(rpc.code, rpc.message.clone().unwrap_or_default())
+            } else {
+                ConnectError::new(ErrorCode::Internal, err.to_string())
+            }
+        })
     }
 
     fn ingest_frame(
@@ -730,7 +760,30 @@ impl<D: commonware_cryptography::Digest, F: Graftable> Stream for BatchSubscribe
                         this.building = None;
                         return Poll::Ready(Some(result));
                     }
-                    Poll::Pending => return Poll::Pending,
+                    Poll::Pending => {
+                        // Keep pulling upstream frames while the proof builds
+                        // so demand reaches the store subscription, up to the
+                        // staged-batch bound.
+                        while this.staged_terminal.is_none()
+                            && this.pending.len() + this.ready.len() < SUBSCRIBE_STAGED_BATCHES
+                        {
+                            match this.poll_frame(cx) {
+                                Poll::Ready(Ok(Some(frame))) => {
+                                    if let Err(err) = this.ingest_frame(&frame) {
+                                        this.staged_terminal = Some(StagedTerminal::Error(*err));
+                                    }
+                                }
+                                Poll::Ready(Ok(None)) => {
+                                    this.staged_terminal = Some(StagedTerminal::End);
+                                }
+                                Poll::Ready(Err(err)) => {
+                                    this.staged_terminal = Some(StagedTerminal::Error(err));
+                                }
+                                Poll::Pending => break,
+                            }
+                        }
+                        return Poll::Pending;
+                    }
                 }
             }
 
@@ -750,26 +803,22 @@ impl<D: commonware_cryptography::Digest, F: Graftable> Stream for BatchSubscribe
                 continue;
             }
 
-            let frame = {
-                let next_fut = this.sub.next();
-                tokio::pin!(next_fut);
-                match next_fut.as_mut().poll(cx) {
-                    Poll::Ready(Ok(Some(frame))) => frame,
-                    Poll::Ready(Ok(None)) => return Poll::Ready(None),
-                    Poll::Ready(Err(err)) => {
-                        let connect = if let Some(rpc) = err.rpc_error() {
-                            ConnectError::new(rpc.code, rpc.message.clone().unwrap_or_default())
-                        } else {
-                            ConnectError::new(ErrorCode::Internal, err.to_string())
-                        };
-                        return Poll::Ready(Some(Err(connect)));
-                    }
-                    Poll::Pending => return Poll::Pending,
-                }
-            };
+            if let Some(terminal) = this.staged_terminal.take() {
+                return Poll::Ready(match terminal {
+                    StagedTerminal::End => None,
+                    StagedTerminal::Error(err) => Some(Err(err)),
+                });
+            }
 
-            if let Err(err) = this.ingest_frame(&frame) {
-                return Poll::Ready(Some(Err(*err)));
+            match this.poll_frame(cx) {
+                Poll::Ready(Ok(Some(frame))) => {
+                    if let Err(err) = this.ingest_frame(&frame) {
+                        return Poll::Ready(Some(Err(*err)));
+                    }
+                }
+                Poll::Ready(Ok(None)) => return Poll::Ready(None),
+                Poll::Ready(Err(err)) => return Poll::Ready(Some(Err(err))),
+                Poll::Pending => return Poll::Pending,
             }
         }
     }

--- a/server/src/connect.rs
+++ b/server/src/connect.rs
@@ -56,6 +56,11 @@ use crate::{
 const MAX_CONNECTRPC_BODY_BYTES: usize = 256 * 1024 * 1024;
 const RANGE_STREAM_MAX_FRAME_ROWS: usize = 4096;
 const REDUCE_SCAN_BATCH_SIZE: usize = 4096;
+// Per-subscription bound on concurrent subscribe log reads. Each slot can pin
+// a fully materialized batch (in flight, or completed but held for in-order
+// delivery), so server-wide memory and engine read pressure scale with this
+// bound times the subscriber count. Engines stay responsible for protecting
+// their own read path (for example via caching or request collapsing).
 const SUBSCRIBE_GET_BATCH_LOOKAHEAD: usize = 8;
 
 fn query_detail(sequence_number: u64, extra: QueryExtra) -> Detail {
@@ -867,19 +872,22 @@ fn filtered_subscribe_response(
 
 type OrderedBatchStream = Pin<Box<dyn Stream<Item = Result<Option<LogBatch>, String>> + Send>>;
 
-fn ordered_batch_stream<B>(
+fn ordered_batch_stream<B, S>(
     log: Arc<B>,
-    range: std::ops::RangeInclusive<u64>,
-    first_batch: Option<LogBatch>,
+    sequences: S,
+    mut first_batch: Option<LogBatch>,
 ) -> OrderedBatchStream
 where
     B: Log,
+    S: Stream<Item = u64> + Send + 'static,
 {
-    let mut first_batch = first_batch;
     Box::pin(
-        stream_util::iter(range)
+        sequences
             .map(move |sequence_number| {
                 let log = log.clone();
+                // The sequence stream is consumed in order, so only the first
+                // closure invocation observes the eagerly fetched batch and it
+                // pairs with the first sequence.
                 let first_batch = first_batch.take();
                 async move {
                     match first_batch {
@@ -892,6 +900,35 @@ where
     )
 }
 
+// Live sequences are generated on demand and re-check the published frontier
+// on every pull. The lookahead therefore keeps extending through new commits
+// while earlier reads drain, instead of stopping at a frontier snapshot. When
+// the subscriber is caught up the next pull parks on a publish notification,
+// which keeps one live stream serving the whole subscription.
+fn live_sequence_stream(
+    notifier: Arc<dyn StreamNotifier>,
+    notify: Arc<Notify>,
+    start: Option<u64>,
+) -> impl Stream<Item = u64> + Send {
+    stream_util::unfold(start, move |next| {
+        let notifier = notifier.clone();
+        let notify = notify.clone();
+        async move {
+            let sequence_number = next?;
+            // Re-check the frontier after arming the notifier so a publish
+            // racing this pull is not lost.
+            while sequence_number > notifier.current_sequence() {
+                let notified = notify.clone().notified_owned();
+                if sequence_number <= notifier.current_sequence() {
+                    break;
+                }
+                notified.await;
+            }
+            Some((sequence_number, sequence_number.checked_add(1)))
+        }
+    })
+}
+
 struct ReplayState {
     batches: OrderedBatchStream,
 }
@@ -902,19 +939,13 @@ enum ReplayProgress {
     Done,
 }
 
-enum LiveProgress {
-    Frame(SubscribeResponse),
-    Advanced,
-    NeedWait,
-}
-
 struct SubscriptionState<B> {
     state: StreamState<B>,
     matchers: crate::stream::CompiledMatchers,
+    // Both streams are dropped at termination so buffered batches free at the
+    // failure boundary instead of when the client tears the stream down.
     replay: Option<ReplayState>,
     live: Option<OrderedBatchStream>,
-    next_live_sequence: Option<u64>,
-    live_notify: Arc<Notify>,
     terminated: bool,
 }
 
@@ -926,16 +957,13 @@ where
         state: StreamState<B>,
         matchers: crate::stream::CompiledMatchers,
         replay: Option<ReplayState>,
-        next_live_sequence: Option<u64>,
-        live_notify: Arc<Notify>,
+        live: OrderedBatchStream,
     ) -> Self {
         Self {
             state,
             matchers,
             replay,
-            live: None,
-            next_live_sequence,
-            live_notify,
+            live: Some(live),
             terminated: false,
         }
     }
@@ -954,26 +982,27 @@ where
                         Ok(ReplayProgress::Frame(frame)) => return Some((Ok(frame), state)),
                         Ok(ReplayProgress::Advanced) => continue,
                         Ok(ReplayProgress::Done) => {}
-                        Err(err) => {
-                            state.terminated = true;
-                            return Some((Err(err), state));
-                        }
+                        Err(err) => return Some((state.terminate(err), state)),
                     }
                 }
 
-                match state.next_live_frame().await {
-                    Ok(LiveProgress::Frame(frame)) => return Some((Ok(frame), state)),
-                    Ok(LiveProgress::Advanced) => continue,
-                    Ok(LiveProgress::NeedWait) => {
-                        state.wait_for_live().await;
-                    }
-                    Err(err) => {
-                        state.terminated = true;
-                        return Some((Err(err), state));
-                    }
+                // The live sequence source only ends past u64::MAX, so an
+                // exhausted live stream ends the subscription.
+                let batch = state.live.as_mut()?.next().await?;
+                match state.resolve_batch(batch).await {
+                    Ok(Some(frame)) => return Some((Ok(frame), state)),
+                    Ok(None) => continue,
+                    Err(err) => return Some((state.terminate(err), state)),
                 }
             }
         }))
+    }
+
+    fn terminate(&mut self, err: ConnectError) -> Result<SubscribeResponse, ConnectError> {
+        self.terminated = true;
+        self.replay = None;
+        self.live = None;
+        Err(err)
     }
 
     async fn next_replay_frame(&mut self) -> Result<ReplayProgress, ConnectError> {
@@ -987,33 +1016,6 @@ where
         Ok(match self.resolve_batch(batch).await? {
             Some(frame) => ReplayProgress::Frame(frame),
             None => ReplayProgress::Advanced,
-        })
-    }
-
-    async fn next_live_frame(&mut self) -> Result<LiveProgress, ConnectError> {
-        if self.live.is_none() {
-            let Some(next_sequence) = self.next_live_sequence else {
-                return Ok(LiveProgress::NeedWait);
-            };
-            let current = self.state.notifier.current_sequence();
-            if next_sequence > current {
-                return Ok(LiveProgress::NeedWait);
-            }
-            self.live = Some(ordered_batch_stream(
-                self.state.log.clone(),
-                next_sequence..=current,
-                None,
-            ));
-            self.next_live_sequence = current.checked_add(1);
-        }
-
-        let Some(batch) = self.live.as_mut().expect("live stream exists").next().await else {
-            self.live = None;
-            return Ok(LiveProgress::Advanced);
-        };
-        Ok(match self.resolve_batch(batch).await? {
-            Some(frame) => LiveProgress::Frame(frame),
-            None => LiveProgress::Advanced,
         })
     }
 
@@ -1032,22 +1034,6 @@ where
             return Err(StreamConnect::<B>::batch_evicted_connect_error(oldest));
         };
         filtered_subscribe_response(&batch, &self.matchers)
-    }
-
-    fn live_available(&self) -> bool {
-        self.next_live_sequence
-            .is_some_and(|next| next <= self.state.notifier.current_sequence())
-    }
-
-    async fn wait_for_live(&mut self) {
-        if self.live_available() {
-            return;
-        }
-        let notified = self.live_notify.clone().notified_owned();
-        if self.live_available() {
-            return;
-        }
-        notified.await;
     }
 }
 
@@ -1096,8 +1082,8 @@ where
         let filter = domain_filter_from_subscribe_view(&request)?;
         let since = request.since_sequence_number;
 
-        // Snapshot the current published frontier and subscribe for future
-        // wakeups. Bounded lookahead overlaps log reads while retaining
+        // Snapshot the published frontier to bound replay and subscribe for
+        // live wakeups. Bounded lookahead overlaps log reads while retaining
         // client-driven backpressure.
         let matchers = crate::stream::compile_matchers(&filter)?;
         let subscription = self.state.notifier.subscribe();
@@ -1128,24 +1114,25 @@ where
                 Some(ReplayState {
                     batches: ordered_batch_stream(
                         self.state.log.clone(),
-                        s..=replay_bound,
+                        stream_util::iter(s..=replay_bound),
                         Some(first_batch),
                     ),
                 })
             }
             _ => None,
         };
-        let next_live_sequence = replay_bound.checked_add(1);
+        let live = ordered_batch_stream(
+            self.state.log.clone(),
+            live_sequence_stream(
+                self.state.notifier.clone(),
+                live_notify,
+                replay_bound.checked_add(1),
+            ),
+            None,
+        );
 
         Ok(connectrpc::Response::stream(
-            SubscriptionState::new(
-                self.state.clone(),
-                matchers,
-                replay,
-                next_live_sequence,
-                live_notify,
-            )
-            .into_stream(),
+            SubscriptionState::new(self.state.clone(), matchers, replay, live).into_stream(),
         ))
     }
 
@@ -2687,6 +2674,46 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn dropping_subscription_cancels_in_flight_lookahead() {
+        let last_sequence = SUBSCRIBE_GET_BATCH_LOOKAHEAD as u64 + 1;
+        let engine = Arc::new(GatedLog::default());
+        for sequence_number in 1..=last_sequence {
+            engine.set_batch(
+                sequence_number,
+                vec![matching_kv(b"replay", &[sequence_number as u8])],
+            );
+        }
+        for sequence_number in 2..=last_sequence {
+            engine.gate(sequence_number);
+        }
+
+        let notifier = Arc::new(ManualNotifier::new(last_sequence));
+        let connect = StreamConnect::new(StreamState::new(engine.clone(), notifier));
+        let mut stream = subscribe_stream(&connect, Some(1))
+            .await
+            .expect("subscribe");
+
+        let first = tokio::time::timeout(Duration::from_secs(1), stream.next())
+            .await
+            .expect("first frame")
+            .expect("frame exists")
+            .expect("frame ok");
+        assert_eq!(first.sequence_number, 1);
+
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), stream.next())
+                .await
+                .is_err(),
+            "gated batches must hold the stream pending",
+        );
+        engine.wait_for_started(last_sequence as usize).await;
+        assert_eq!(engine.in_flight(), SUBSCRIBE_GET_BATCH_LOOKAHEAD);
+
+        drop(stream);
+        assert_eq!(engine.in_flight(), 0);
+    }
+
+    #[tokio::test]
     async fn replay_lookahead_is_bounded_and_emits_in_order() {
         let last_sequence = SUBSCRIBE_GET_BATCH_LOOKAHEAD as u64 + 1;
         let engine = Arc::new(GatedLog::default());
@@ -2812,7 +2839,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn replay_to_live_catch_up_uses_repeated_bounded_lookahead() {
+    async fn replay_to_live_catch_up_extends_bounded_lookahead() {
         const REPLAY_BOUND: u64 = 4;
 
         let first_live_bound = REPLAY_BOUND + SUBSCRIBE_GET_BATCH_LOOKAHEAD as u64;
@@ -2874,7 +2901,7 @@ mod tests {
             tokio::time::timeout(Duration::from_millis(50), frames.recv())
                 .await
                 .is_err(),
-            "live batches must remain ordered within a frontier snapshot",
+            "live batches must remain ordered within the lookahead",
         );
         assert_eq!(engine.started_sequences().len(), first_live_bound as usize);
 
@@ -2897,7 +2924,7 @@ mod tests {
             tokio::time::timeout(Duration::from_millis(50), frames.recv())
                 .await
                 .is_err(),
-            "a later frontier snapshot must preserve batch order",
+            "batches read past the old frontier must preserve batch order",
         );
 
         engine.release(first_live_bound + 1);
@@ -2907,6 +2934,59 @@ mod tests {
                 expected
             );
         }
+
+        reader.abort();
+        let _ = reader.await;
+    }
+
+    #[tokio::test]
+    async fn live_lookahead_extends_while_earlier_reads_are_in_flight() {
+        let last_sequence = 12u64;
+        let engine = Arc::new(GatedLog::default());
+        for sequence_number in 3..=last_sequence {
+            engine.set_batch(
+                sequence_number,
+                vec![matching_kv(b"live", &[sequence_number as u8])],
+            );
+            engine.gate(sequence_number);
+        }
+
+        let notifier = Arc::new(ManualNotifier::new(2));
+        let connect = StreamConnect::new(StreamState::new(engine.clone(), notifier.clone()));
+        let mut stream = subscribe_stream(&connect, None).await.expect("subscribe");
+        let (sender, mut frames) = tokio::sync::mpsc::unbounded_channel();
+        let reader = tokio::spawn(async move {
+            while let Some(frame) = stream.next().await {
+                if sender.send(frame).is_err() {
+                    return;
+                }
+            }
+        });
+
+        notifier.advance(4);
+        engine.wait_for_started(2).await;
+        assert_eq!(engine.in_flight(), 2);
+
+        // Reads past the old frontier must start while 3 and 4 are still in
+        // flight, rather than after the pre-advance window fully drains.
+        notifier.advance(last_sequence);
+        engine.wait_for_started(SUBSCRIBE_GET_BATCH_LOOKAHEAD).await;
+        assert_eq!(engine.in_flight(), SUBSCRIBE_GET_BATCH_LOOKAHEAD);
+        assert_eq!(
+            engine.started_sequences(),
+            (3..=2 + SUBSCRIBE_GET_BATCH_LOOKAHEAD as u64).collect::<Vec<_>>()
+        );
+
+        for sequence_number in 3..=last_sequence {
+            engine.release(sequence_number);
+        }
+        for expected in 3..=last_sequence {
+            assert_eq!(
+                next_subscribe_frame(&mut frames).await.sequence_number,
+                expected
+            );
+        }
+        assert_eq!(engine.max_in_flight(), SUBSCRIBE_GET_BATCH_LOOKAHEAD);
 
         reader.abort();
         let _ = reader.await;

--- a/server/src/connect.rs
+++ b/server/src/connect.rs
@@ -42,7 +42,7 @@ use exoware_sdk as exoware_proto;
 use exoware_sdk::common::kv::v1::filter::KindView as ProtoFilterKindView;
 use exoware_sdk::keys::Key;
 use exoware_sdk::selector::Selector;
-use futures::{stream as stream_util, Stream};
+use futures::{stream as stream_util, Stream, StreamExt};
 use tokio::sync::Notify;
 
 use crate::reduce::RangeReducer;
@@ -56,6 +56,7 @@ use crate::{
 const MAX_CONNECTRPC_BODY_BYTES: usize = 256 * 1024 * 1024;
 const RANGE_STREAM_MAX_FRAME_ROWS: usize = 4096;
 const REDUCE_SCAN_BATCH_SIZE: usize = 4096;
+const SUBSCRIBE_GET_BATCH_LOOKAHEAD: usize = 8;
 
 fn query_detail(sequence_number: u64, extra: QueryExtra) -> Detail {
     Detail {
@@ -864,10 +865,35 @@ fn filtered_subscribe_response(
     }))
 }
 
-struct ReplayState {
-    next_sequence: u64,
-    bound: u64,
+type OrderedBatchStream = Pin<Box<dyn Stream<Item = Result<Option<LogBatch>, String>> + Send>>;
+
+fn ordered_batch_stream<B>(
+    log: Arc<B>,
+    range: std::ops::RangeInclusive<u64>,
     first_batch: Option<LogBatch>,
+) -> OrderedBatchStream
+where
+    B: Log,
+{
+    let mut first_batch = first_batch;
+    Box::pin(
+        stream_util::iter(range)
+            .map(move |sequence_number| {
+                let log = log.clone();
+                let first_batch = first_batch.take();
+                async move {
+                    match first_batch {
+                        Some(batch) => Ok(Some(batch)),
+                        None => log.get_batch(sequence_number).await,
+                    }
+                }
+            })
+            .buffered(SUBSCRIBE_GET_BATCH_LOOKAHEAD),
+    )
+}
+
+struct ReplayState {
+    batches: OrderedBatchStream,
 }
 
 enum ReplayProgress {
@@ -886,7 +912,8 @@ struct SubscriptionState<B> {
     state: StreamState<B>,
     matchers: crate::stream::CompiledMatchers,
     replay: Option<ReplayState>,
-    next_live_sequence: u64,
+    live: Option<OrderedBatchStream>,
+    next_live_sequence: Option<u64>,
     live_notify: Arc<Notify>,
     terminated: bool,
 }
@@ -899,13 +926,14 @@ where
         state: StreamState<B>,
         matchers: crate::stream::CompiledMatchers,
         replay: Option<ReplayState>,
-        next_live_sequence: u64,
+        next_live_sequence: Option<u64>,
         live_notify: Arc<Notify>,
     ) -> Self {
         Self {
             state,
             matchers,
             replay,
+            live: None,
             next_live_sequence,
             live_notify,
             terminated: false,
@@ -952,48 +980,48 @@ where
         let Some(replay) = &mut self.replay else {
             return Ok(ReplayProgress::Done);
         };
-        let seq = replay.next_sequence;
-        let batch = if let Some(first_batch) = replay.first_batch.take() {
-            Some(first_batch)
-        } else {
-            self.state
-                .log
-                .get_batch(seq)
-                .await
-                .map_err(ConnectError::internal)?
-        };
-        replay.next_sequence += 1;
-        if replay.next_sequence > replay.bound {
+        let Some(batch) = replay.batches.next().await else {
             self.replay = None;
-        }
-        let Some(batch) = batch else {
-            let oldest = self
-                .state
-                .log
-                .oldest_retained_batch()
-                .await
-                .map_err(ConnectError::internal)?;
-            return Err(StreamConnect::<B>::batch_evicted_connect_error(oldest));
+            return Ok(ReplayProgress::Done);
         };
-        Ok(match filtered_subscribe_response(&batch, &self.matchers)? {
+        Ok(match self.resolve_batch(batch).await? {
             Some(frame) => ReplayProgress::Frame(frame),
             None => ReplayProgress::Advanced,
         })
     }
 
     async fn next_live_frame(&mut self) -> Result<LiveProgress, ConnectError> {
-        let current = self.state.notifier.current_sequence();
-        if self.next_live_sequence > current {
-            return Ok(LiveProgress::NeedWait);
+        if self.live.is_none() {
+            let Some(next_sequence) = self.next_live_sequence else {
+                return Ok(LiveProgress::NeedWait);
+            };
+            let current = self.state.notifier.current_sequence();
+            if next_sequence > current {
+                return Ok(LiveProgress::NeedWait);
+            }
+            self.live = Some(ordered_batch_stream(
+                self.state.log.clone(),
+                next_sequence..=current,
+                None,
+            ));
+            self.next_live_sequence = current.checked_add(1);
         }
-        let seq = self.next_live_sequence;
-        self.next_live_sequence += 1;
-        let batch = self
-            .state
-            .log
-            .get_batch(seq)
-            .await
-            .map_err(ConnectError::internal)?;
+
+        let Some(batch) = self.live.as_mut().expect("live stream exists").next().await else {
+            self.live = None;
+            return Ok(LiveProgress::Advanced);
+        };
+        Ok(match self.resolve_batch(batch).await? {
+            Some(frame) => LiveProgress::Frame(frame),
+            None => LiveProgress::Advanced,
+        })
+    }
+
+    async fn resolve_batch(
+        &mut self,
+        batch: Result<Option<LogBatch>, String>,
+    ) -> Result<Option<SubscribeResponse>, ConnectError> {
+        let batch = batch.map_err(ConnectError::internal)?;
         let Some(batch) = batch else {
             let oldest = self
                 .state
@@ -1003,18 +1031,20 @@ where
                 .map_err(ConnectError::internal)?;
             return Err(StreamConnect::<B>::batch_evicted_connect_error(oldest));
         };
-        Ok(match filtered_subscribe_response(&batch, &self.matchers)? {
-            Some(frame) => LiveProgress::Frame(frame),
-            None => LiveProgress::Advanced,
-        })
+        filtered_subscribe_response(&batch, &self.matchers)
     }
 
-    async fn wait_for_live(&self) {
-        if self.next_live_sequence <= self.state.notifier.current_sequence() {
+    fn live_available(&self) -> bool {
+        self.next_live_sequence
+            .is_some_and(|next| next <= self.state.notifier.current_sequence())
+    }
+
+    async fn wait_for_live(&mut self) {
+        if self.live_available() {
             return;
         }
         let notified = self.live_notify.clone().notified_owned();
-        if self.next_live_sequence <= self.state.notifier.current_sequence() {
+        if self.live_available() {
             return;
         }
         notified.await;
@@ -1067,9 +1097,8 @@ where
         let since = request.since_sequence_number;
 
         // Snapshot the current published frontier and subscribe for future
-        // wakeups. The stream then walks the log by sequence cursor, so
-        // live delivery is paced by client reads instead of server-side
-        // buffering.
+        // wakeups. Bounded lookahead overlaps log reads while retaining
+        // client-driven backpressure.
         let matchers = crate::stream::compile_matchers(&filter)?;
         let subscription = self.state.notifier.subscribe();
         let replay_bound = subscription.current_sequence;
@@ -1097,14 +1126,16 @@ where
                     return Err(self.batch_evicted_error(oldest));
                 };
                 Some(ReplayState {
-                    next_sequence: s,
-                    bound: replay_bound,
-                    first_batch: Some(first_batch),
+                    batches: ordered_batch_stream(
+                        self.state.log.clone(),
+                        s..=replay_bound,
+                        Some(first_batch),
+                    ),
                 })
             }
             _ => None,
         };
-        let next_live_sequence = replay_bound.saturating_add(1);
+        let next_live_sequence = replay_bound.checked_add(1);
 
         Ok(connectrpc::Response::stream(
             SubscriptionState::new(
@@ -1360,7 +1391,7 @@ where
 mod tests {
     use super::*;
     use std::collections::{BTreeMap, HashMap};
-    use std::sync::atomic::AtomicU64;
+    use std::sync::atomic::{AtomicU64, AtomicUsize};
     use std::sync::Mutex;
     use std::time::Duration;
 
@@ -1654,6 +1685,230 @@ mod tests {
         }
     }
 
+    #[derive(Default)]
+    struct BatchGate {
+        released: AtomicBool,
+        waits: AtomicUsize,
+        notify: Notify,
+    }
+
+    impl BatchGate {
+        async fn wait(&self) {
+            loop {
+                if self.released.load(Ordering::Acquire) {
+                    return;
+                }
+                let notified = self.notify.notified();
+                self.waits.fetch_add(1, Ordering::Release);
+                if self.released.load(Ordering::Acquire) {
+                    return;
+                }
+                notified.await;
+            }
+        }
+
+        fn release(&self) {
+            self.released.store(true, Ordering::Release);
+            self.notify.notify_waiters();
+        }
+
+        fn wake(&self) {
+            self.notify.notify_waiters();
+        }
+
+        fn wait_count(&self) -> usize {
+            self.waits.load(Ordering::Acquire)
+        }
+    }
+
+    #[derive(Default)]
+    struct GatedLogState {
+        batches: BTreeMap<u64, Vec<(Bytes, Bytes)>>,
+        errors: HashMap<u64, String>,
+        gates: HashMap<u64, Arc<BatchGate>>,
+        started_sequences: Vec<u64>,
+        get_counts: HashMap<u64, usize>,
+        in_flight: usize,
+        max_in_flight: usize,
+    }
+
+    #[derive(Default)]
+    struct GatedLog {
+        current_sequence: AtomicU64,
+        state: Arc<Mutex<GatedLogState>>,
+        started: Arc<Notify>,
+    }
+
+    impl GatedLog {
+        fn set_batch(&self, sequence_number: u64, kvs: Vec<(Bytes, Bytes)>) {
+            self.current_sequence
+                .fetch_max(sequence_number, Ordering::Release);
+            self.state
+                .lock()
+                .expect("lock")
+                .batches
+                .insert(sequence_number, kvs);
+        }
+
+        fn gate(&self, sequence_number: u64) {
+            self.state
+                .lock()
+                .expect("lock")
+                .gates
+                .insert(sequence_number, Arc::new(BatchGate::default()));
+        }
+
+        fn set_error(&self, sequence_number: u64, error: impl Into<String>) {
+            self.state
+                .lock()
+                .expect("lock")
+                .errors
+                .insert(sequence_number, error.into());
+        }
+
+        fn release(&self, sequence_number: u64) {
+            self.state
+                .lock()
+                .expect("lock")
+                .gates
+                .get(&sequence_number)
+                .expect("gate")
+                .release();
+        }
+
+        fn wake(&self, sequence_number: u64) {
+            self.state
+                .lock()
+                .expect("lock")
+                .gates
+                .get(&sequence_number)
+                .expect("gate")
+                .wake();
+        }
+
+        fn gate_wait_count(&self, sequence_number: u64) -> usize {
+            self.state
+                .lock()
+                .expect("lock")
+                .gates
+                .get(&sequence_number)
+                .expect("gate")
+                .wait_count()
+        }
+
+        fn started_sequences(&self) -> Vec<u64> {
+            self.state.lock().expect("lock").started_sequences.clone()
+        }
+
+        fn get_count(&self, sequence_number: u64) -> usize {
+            self.state
+                .lock()
+                .expect("lock")
+                .get_counts
+                .get(&sequence_number)
+                .copied()
+                .unwrap_or_default()
+        }
+
+        fn in_flight(&self) -> usize {
+            self.state.lock().expect("lock").in_flight
+        }
+
+        fn max_in_flight(&self) -> usize {
+            self.state.lock().expect("lock").max_in_flight
+        }
+
+        async fn wait_for_started(&self, count: usize) {
+            tokio::time::timeout(Duration::from_secs(1), async {
+                loop {
+                    if self.started_sequences().len() >= count {
+                        return;
+                    }
+                    let notified = self.started.notified();
+                    if self.started_sequences().len() >= count {
+                        return;
+                    }
+                    notified.await;
+                }
+            })
+            .await
+            .expect("batch reads should start");
+        }
+
+        async fn wait_for_gate_waits(&self, sequence_number: u64, count: usize) {
+            tokio::time::timeout(Duration::from_secs(1), async {
+                while self.gate_wait_count(sequence_number) < count {
+                    tokio::task::yield_now().await;
+                }
+            })
+            .await
+            .expect("batch gate should be polled");
+        }
+    }
+
+    struct InFlightGuard {
+        state: Arc<Mutex<GatedLogState>>,
+    }
+
+    impl Drop for InFlightGuard {
+        fn drop(&mut self) {
+            self.state.lock().expect("lock").in_flight -= 1;
+        }
+    }
+
+    impl Sequence for GatedLog {
+        fn current_sequence(&self) -> u64 {
+            self.current_sequence.load(Ordering::Acquire)
+        }
+    }
+
+    impl Log for GatedLog {
+        async fn get_batch(&self, sequence_number: u64) -> Result<Option<LogBatch>, String> {
+            let (gate, batch, error) = {
+                let mut state = self.state.lock().map_err(|err| err.to_string())?;
+                state.started_sequences.push(sequence_number);
+                *state.get_counts.entry(sequence_number).or_default() += 1;
+                state.in_flight += 1;
+                state.max_in_flight = state.max_in_flight.max(state.in_flight);
+                (
+                    state.gates.get(&sequence_number).cloned(),
+                    state.batches.get(&sequence_number).cloned(),
+                    state.errors.get(&sequence_number).cloned(),
+                )
+            };
+            self.started.notify_waiters();
+            let _guard = InFlightGuard {
+                state: self.state.clone(),
+            };
+            if let Some(gate) = gate {
+                gate.wait().await;
+            }
+            if let Some(error) = error {
+                return Err(error);
+            }
+            Ok(batch.map(|kvs| LogBatch::from_entries(sequence_number, kvs)))
+        }
+
+        async fn oldest_retained_batch(&self) -> Result<Option<u64>, String> {
+            Ok(self
+                .state
+                .lock()
+                .map_err(|err| err.to_string())?
+                .batches
+                .first_key_value()
+                .map(|(sequence_number, _)| *sequence_number))
+        }
+    }
+
+    impl Retention for GatedLog {
+        async fn set_retention(
+            &self,
+            _policy: Option<RetentionPolicy>,
+        ) -> Result<Option<u64>, String> {
+            self.oldest_retained_batch().await
+        }
+    }
+
     struct QueryOnlyEngine {
         sequence_number: u64,
         value: Option<Bytes>,
@@ -1767,6 +2022,13 @@ mod tests {
         (key, Bytes::copy_from_slice(value))
     }
 
+    fn nonmatching_kv(payload: &[u8], value: &[u8]) -> (Bytes, Bytes) {
+        let key = Prefix::from_byte(TEST_PREFIX + 1)
+            .encode(payload)
+            .expect("encode key");
+        (key, Bytes::copy_from_slice(value))
+    }
+
     fn numeric_query_extra(name: &str, value: f64) -> QueryExtra {
         HashMap::from([(
             name.to_string(),
@@ -1874,6 +2136,16 @@ mod tests {
         Ok(StreamApi::subscribe(connect, Context::default(), request)
             .await?
             .body)
+    }
+
+    async fn next_subscribe_frame(
+        frames: &mut tokio::sync::mpsc::UnboundedReceiver<Result<SubscribeResponse, ConnectError>>,
+    ) -> SubscribeResponse {
+        tokio::time::timeout(Duration::from_secs(1), frames.recv())
+            .await
+            .expect("stream should yield")
+            .expect("frame should exist")
+            .expect("frame should be ok")
     }
 
     async fn set_retention<R>(
@@ -2412,6 +2684,232 @@ mod tests {
         assert_eq!(frame.sequence_number, 1);
         assert_eq!(frame.entries.len(), 1);
         assert_eq!(frame.entries[0].value.as_ref(), b"v1");
+    }
+
+    #[tokio::test]
+    async fn replay_lookahead_is_bounded_and_emits_in_order() {
+        let last_sequence = SUBSCRIBE_GET_BATCH_LOOKAHEAD as u64 + 1;
+        let engine = Arc::new(GatedLog::default());
+        for sequence_number in 1..=last_sequence {
+            engine.set_batch(
+                sequence_number,
+                vec![matching_kv(b"replay", &[sequence_number as u8])],
+            );
+        }
+        for sequence_number in 2..=last_sequence {
+            engine.gate(sequence_number);
+        }
+
+        let notifier = Arc::new(ManualNotifier::new(last_sequence));
+        let connect = StreamConnect::new(StreamState::new(engine.clone(), notifier));
+        let mut stream = subscribe_stream(&connect, Some(1))
+            .await
+            .expect("subscribe");
+
+        assert_eq!(engine.started_sequences(), vec![1]);
+
+        let (sender, mut frames) = tokio::sync::mpsc::unbounded_channel();
+        let reader = tokio::spawn(async move {
+            while let Some(frame) = stream.next().await {
+                if sender.send(frame).is_err() {
+                    return;
+                }
+            }
+        });
+
+        assert_eq!(next_subscribe_frame(&mut frames).await.sequence_number, 1);
+        engine.wait_for_started(last_sequence as usize).await;
+
+        assert_eq!(engine.in_flight(), SUBSCRIBE_GET_BATCH_LOOKAHEAD);
+        assert_eq!(engine.max_in_flight(), SUBSCRIBE_GET_BATCH_LOOKAHEAD);
+        assert_eq!(
+            engine.started_sequences(),
+            (1..=last_sequence).collect::<Vec<_>>()
+        );
+
+        for sequence_number in (3..=last_sequence).rev() {
+            engine.release(sequence_number);
+        }
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), frames.recv())
+                .await
+                .is_err(),
+            "later batches must wait for the first pending batch",
+        );
+
+        engine.release(2);
+        for expected in 2..=last_sequence {
+            assert_eq!(
+                next_subscribe_frame(&mut frames).await.sequence_number,
+                expected
+            );
+        }
+        assert_eq!(engine.get_count(1), 1);
+
+        reader.abort();
+        let _ = reader.await;
+    }
+
+    #[tokio::test]
+    async fn replay_lookahead_refills_after_filtered_batches() {
+        let last_sequence = SUBSCRIBE_GET_BATCH_LOOKAHEAD as u64 + 2;
+        let engine = Arc::new(GatedLog::default());
+        for sequence_number in 1..=last_sequence {
+            let kv = if sequence_number == 1 || sequence_number == last_sequence {
+                matching_kv(b"match", &[sequence_number as u8])
+            } else {
+                nonmatching_kv(b"skip", &[sequence_number as u8])
+            };
+            engine.set_batch(sequence_number, vec![kv]);
+        }
+
+        let notifier = Arc::new(ManualNotifier::new(last_sequence));
+        let connect = StreamConnect::new(StreamState::new(engine.clone(), notifier));
+        let mut stream = subscribe_stream(&connect, Some(1))
+            .await
+            .expect("subscribe");
+
+        let first = stream.next().await.unwrap().unwrap();
+        assert_eq!(first.sequence_number, 1);
+        let last = stream.next().await.unwrap().unwrap();
+        assert_eq!(last.sequence_number, last_sequence);
+
+        for sequence_number in 1..=last_sequence {
+            assert_eq!(engine.get_count(sequence_number), 1);
+        }
+    }
+
+    #[tokio::test]
+    async fn replay_lookahead_emits_earliest_error_and_terminates() {
+        let engine = Arc::new(GatedLog::default());
+        engine.set_batch(1, vec![matching_kv(b"first", b"v1")]);
+        engine.set_batch(3, vec![matching_kv(b"later", b"v3")]);
+        engine.set_error(2, "batch read failed");
+        engine.gate(2);
+
+        let notifier = Arc::new(ManualNotifier::new(3));
+        let connect = StreamConnect::new(StreamState::new(engine.clone(), notifier));
+        let mut stream = subscribe_stream(&connect, Some(1))
+            .await
+            .expect("subscribe");
+
+        let first = stream.next().await.unwrap().unwrap();
+        assert_eq!(first.sequence_number, 1);
+        let mut next = Box::pin(stream.next());
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), &mut next)
+                .await
+                .is_err(),
+            "later successes must wait behind an earlier error",
+        );
+        engine.wait_for_started(3).await;
+        assert_eq!(engine.get_count(3), 1);
+
+        engine.release(2);
+        let error = next.await.unwrap().expect_err("stream error");
+        assert_eq!(error.code, connectrpc::ErrorCode::Internal);
+        assert!(stream.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn replay_to_live_catch_up_uses_repeated_bounded_lookahead() {
+        const REPLAY_BOUND: u64 = 4;
+
+        let first_live_bound = REPLAY_BOUND + SUBSCRIBE_GET_BATCH_LOOKAHEAD as u64;
+        let second_live_bound = first_live_bound + SUBSCRIBE_GET_BATCH_LOOKAHEAD as u64;
+        let engine = Arc::new(GatedLog::default());
+        for sequence_number in 1..=second_live_bound {
+            engine.set_batch(
+                sequence_number,
+                vec![matching_kv(b"batch", &[sequence_number as u8])],
+            );
+        }
+        engine.gate(2);
+        for sequence_number in (REPLAY_BOUND + 1)..=second_live_bound {
+            engine.gate(sequence_number);
+        }
+
+        let notifier = Arc::new(ManualNotifier::new(REPLAY_BOUND));
+        let connect = StreamConnect::new(StreamState::new(engine.clone(), notifier.clone()));
+        let mut stream = subscribe_stream(&connect, Some(1))
+            .await
+            .expect("subscribe");
+        let (sender, mut frames) = tokio::sync::mpsc::unbounded_channel();
+        let reader = tokio::spawn(async move {
+            while let Some(frame) = stream.next().await {
+                if sender.send(frame).is_err() {
+                    return;
+                }
+            }
+        });
+
+        assert_eq!(next_subscribe_frame(&mut frames).await.sequence_number, 1);
+        engine.wait_for_started(REPLAY_BOUND as usize).await;
+        engine.wait_for_gate_waits(2, 1).await;
+
+        notifier.advance(first_live_bound);
+        engine.wake(2);
+        engine.wait_for_gate_waits(2, 2).await;
+        assert_eq!(
+            engine.started_sequences(),
+            (1..=REPLAY_BOUND).collect::<Vec<_>>()
+        );
+
+        engine.release(2);
+        for expected in 2..=REPLAY_BOUND {
+            assert_eq!(
+                next_subscribe_frame(&mut frames).await.sequence_number,
+                expected
+            );
+        }
+
+        engine.wait_for_started(first_live_bound as usize).await;
+        assert_eq!(engine.in_flight(), SUBSCRIBE_GET_BATCH_LOOKAHEAD);
+
+        notifier.advance(second_live_bound);
+        for sequence_number in ((REPLAY_BOUND + 2)..=first_live_bound).rev() {
+            engine.release(sequence_number);
+        }
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), frames.recv())
+                .await
+                .is_err(),
+            "live batches must remain ordered within a frontier snapshot",
+        );
+        assert_eq!(engine.started_sequences().len(), first_live_bound as usize);
+
+        engine.release(REPLAY_BOUND + 1);
+        for expected in (REPLAY_BOUND + 1)..=first_live_bound {
+            assert_eq!(
+                next_subscribe_frame(&mut frames).await.sequence_number,
+                expected
+            );
+        }
+
+        engine.wait_for_started(second_live_bound as usize).await;
+        assert_eq!(engine.in_flight(), SUBSCRIBE_GET_BATCH_LOOKAHEAD);
+        assert_eq!(engine.max_in_flight(), SUBSCRIBE_GET_BATCH_LOOKAHEAD);
+
+        for sequence_number in ((first_live_bound + 2)..=second_live_bound).rev() {
+            engine.release(sequence_number);
+        }
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), frames.recv())
+                .await
+                .is_err(),
+            "a later frontier snapshot must preserve batch order",
+        );
+
+        engine.release(first_live_bound + 1);
+        for expected in (first_live_bound + 1)..=second_live_bound {
+            assert_eq!(
+                next_subscribe_frame(&mut frames).await.sequence_number,
+                expected
+            );
+        }
+
+        reader.abort();
+        let _ = reader.await;
     }
 
     #[tokio::test]

--- a/server/src/stream.rs
+++ b/server/src/stream.rs
@@ -1,9 +1,9 @@
 //! Live stream coordination for `log.stream.v1`.
 //!
 //! A [`StreamNotifier`] tracks the highest published batch sequence and wakes
-//! subscribers. Each subscriber then pulls batches from the log at its own
-//! pace, so live delivery is naturally paced by client reads instead of an
-//! internal per-subscriber backlog.
+//! subscribers. Each subscriber pulls batches from the log at its own pace.
+//! A small ordered lookahead overlaps log reads without allowing an unbounded
+//! per-subscriber backlog.
 //!
 //! `StreamNotifier` is an in-process coordination primitive. Split deployments
 //! need a separate remote notification path that advances a local notifier after

--- a/sql/rs/src/server.rs
+++ b/sql/rs/src/server.rs
@@ -341,6 +341,10 @@ type SubscriptionStream =
 
 enum StagedSubscriptionEvent {
     Frame(StreamSubscriptionFrame),
+    Terminal(TerminalSubscriptionEvent),
+}
+
+enum TerminalSubscriptionEvent {
     End,
     Error(ConnectError),
 }
@@ -400,22 +404,23 @@ impl BatchPredicateStream {
             std::task::Poll::Ready(Some(Ok(frame))) => {
                 std::task::Poll::Ready(StagedSubscriptionEvent::Frame(frame))
             }
-            std::task::Poll::Ready(Some(Err(err))) => {
-                std::task::Poll::Ready(StagedSubscriptionEvent::Error(err))
-            }
-            std::task::Poll::Ready(None) => std::task::Poll::Ready(StagedSubscriptionEvent::End),
+            std::task::Poll::Ready(Some(Err(err))) => std::task::Poll::Ready(
+                StagedSubscriptionEvent::Terminal(TerminalSubscriptionEvent::Error(err)),
+            ),
+            std::task::Poll::Ready(None) => std::task::Poll::Ready(
+                StagedSubscriptionEvent::Terminal(TerminalSubscriptionEvent::End),
+            ),
         }
     }
 
     fn finish_event(
         &mut self,
-        event: StagedSubscriptionEvent,
+        event: TerminalSubscriptionEvent,
     ) -> Option<Result<SubscribeResponse, ConnectError>> {
         self.done = true;
         match event {
-            StagedSubscriptionEvent::End => None,
-            StagedSubscriptionEvent::Error(err) => Some(Err(err)),
-            StagedSubscriptionEvent::Frame(_) => unreachable!(),
+            TerminalSubscriptionEvent::End => None,
+            TerminalSubscriptionEvent::Error(err) => Some(Err(err)),
         }
     }
 }
@@ -481,8 +486,16 @@ impl Stream for BatchPredicateStream {
             match event {
                 StagedSubscriptionEvent::Frame(frame) => {
                     this.building = Some((this.evaluator)(frame));
+                    // Register upstream demand before the evaluation is first
+                    // polled, so the next frame is fetched during evaluations
+                    // that complete on their first poll.
+                    if let std::task::Poll::Ready(event) = this.poll_upstream(cx) {
+                        this.staged = Some(event);
+                    }
                 }
-                terminal => return std::task::Poll::Ready(this.finish_event(terminal)),
+                StagedSubscriptionEvent::Terminal(terminal) => {
+                    return std::task::Poll::Ready(this.finish_event(terminal))
+                }
             }
         }
     }
@@ -923,6 +936,27 @@ mod tests {
             .next()
             .now_or_never()
             .expect("stream should be ready")
+    }
+
+    #[test]
+    fn prefetches_upstream_when_evaluation_completes_synchronously() {
+        let (input, polls) =
+            controlled_input([ControlledEvent::Frame(1), ControlledEvent::Frame(2)]);
+        // Mirrors evaluate_batch for the empty-WHERE path and for simple
+        // predicates over a single MemTable batch. Those futures have no
+        // yielding await points, so they are Ready on the first poll.
+        let evaluator = |frame: StreamSubscriptionFrame| {
+            let sequence_number = frame.sequence_number;
+            async move { Ok::<_, ConnectError>(Some(response(sequence_number))) }
+        };
+        let mut stream = BatchPredicateStream::with_evaluator(input, evaluator);
+
+        assert_eq!(next_ready(&mut stream).unwrap().unwrap().sequence_number, 1);
+        assert_eq!(
+            polls.load(Ordering::SeqCst),
+            2,
+            "frame 2 should be pulled from upstream while frame 1 evaluates",
+        );
     }
 
     #[test]

--- a/sql/rs/src/server.rs
+++ b/sql/rs/src/server.rs
@@ -44,9 +44,9 @@ use exoware_sdk::keys::Key;
 use exoware_sdk::kv_codec::{decode_stored_row, Utf8};
 use exoware_sdk::selector::Selector;
 use exoware_sdk::stream_filter::StreamFilter;
-use exoware_sdk::{PrefixedStoreClient, StreamSubscription};
+use exoware_sdk::{PrefixedStoreClient, StreamSubscription, StreamSubscriptionFrame};
 use futures::future::BoxFuture;
-use futures::stream::Stream;
+use futures::stream::{self, Stream};
 use futures::FutureExt;
 
 use crate::builder::{projected_column_indices, ProjectedBatchBuilder};
@@ -334,12 +334,23 @@ impl Service for SqlConnect {
     }
 }
 
+type BatchEvaluation = BoxFuture<'static, Result<Option<SubscribeResponse>, ConnectError>>;
+type BatchEvaluator = Box<dyn FnMut(StreamSubscriptionFrame) -> BatchEvaluation + Send>;
+type SubscriptionStream =
+    Pin<Box<dyn Stream<Item = Result<StreamSubscriptionFrame, ConnectError>> + Send>>;
+
+enum StagedSubscriptionEvent {
+    Frame(StreamSubscriptionFrame),
+    End,
+    Error(ConnectError),
+}
+
 struct BatchPredicateStream {
-    sub: StreamSubscription,
-    state: TableStream,
-    table_name: String,
-    where_sql: String,
-    building: Option<BoxFuture<'static, Result<Option<SubscribeResponse>, ConnectError>>>,
+    upstream: SubscriptionStream,
+    evaluator: BatchEvaluator,
+    building: Option<BatchEvaluation>,
+    staged: Option<StagedSubscriptionEvent>,
+    done: bool,
 }
 
 impl BatchPredicateStream {
@@ -349,14 +360,75 @@ impl BatchPredicateStream {
         table_name: String,
         where_sql: String,
     ) -> Self {
+        let upstream = subscription_stream(sub);
+        let evaluator = move |frame: StreamSubscriptionFrame| {
+            let sequence_number = frame.sequence_number;
+            let entries = frame
+                .entries
+                .into_iter()
+                .map(|entry| (entry.key, entry.value))
+                .collect();
+            let state = state.clone();
+            let table_name = table_name.clone();
+            let where_sql = where_sql.clone();
+            async move { evaluate_batch(state, table_name, where_sql, sequence_number, entries).await }
+        };
+        Self::with_evaluator(upstream, evaluator)
+    }
+
+    fn with_evaluator<S, E, F>(upstream: S, mut evaluator: E) -> Self
+    where
+        S: Stream<Item = Result<StreamSubscriptionFrame, ConnectError>> + Send + 'static,
+        E: FnMut(StreamSubscriptionFrame) -> F + Send + 'static,
+        F: Future<Output = Result<Option<SubscribeResponse>, ConnectError>> + Send + 'static,
+    {
         Self {
-            sub,
-            state,
-            table_name,
-            where_sql,
+            upstream: Box::pin(upstream),
+            evaluator: Box::new(move |frame| evaluator(frame).boxed()),
             building: None,
+            staged: None,
+            done: false,
         }
     }
+
+    fn poll_upstream(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<StagedSubscriptionEvent> {
+        match self.upstream.as_mut().poll_next(cx) {
+            std::task::Poll::Pending => std::task::Poll::Pending,
+            std::task::Poll::Ready(Some(Ok(frame))) => {
+                std::task::Poll::Ready(StagedSubscriptionEvent::Frame(frame))
+            }
+            std::task::Poll::Ready(Some(Err(err))) => {
+                std::task::Poll::Ready(StagedSubscriptionEvent::Error(err))
+            }
+            std::task::Poll::Ready(None) => std::task::Poll::Ready(StagedSubscriptionEvent::End),
+        }
+    }
+
+    fn finish_event(
+        &mut self,
+        event: StagedSubscriptionEvent,
+    ) -> Option<Result<SubscribeResponse, ConnectError>> {
+        self.done = true;
+        match event {
+            StagedSubscriptionEvent::End => None,
+            StagedSubscriptionEvent::Error(err) => Some(Err(err)),
+            StagedSubscriptionEvent::Frame(_) => unreachable!(),
+        }
+    }
+}
+
+fn subscription_stream(sub: StreamSubscription) -> SubscriptionStream {
+    Box::pin(stream::unfold(Some(sub), |sub| async move {
+        let mut sub = sub?;
+        match sub.next().await {
+            Ok(Some(frame)) => Some((Ok(frame), Some(sub))),
+            Ok(None) => None,
+            Err(err) => Some((Err(client_error_to_connect(err)), None)),
+        }
+    }))
 }
 
 impl Stream for BatchPredicateStream {
@@ -367,10 +439,21 @@ impl Stream for BatchPredicateStream {
         cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Option<Self::Item>> {
         let this = self.get_mut();
+        if this.done {
+            return std::task::Poll::Ready(None);
+        }
+
         loop {
             if let Some(fut) = this.building.as_mut() {
                 match fut.as_mut().poll(cx) {
-                    std::task::Poll::Pending => return std::task::Poll::Pending,
+                    std::task::Poll::Pending => {
+                        if this.staged.is_none() {
+                            if let std::task::Poll::Ready(event) = this.poll_upstream(cx) {
+                                this.staged = Some(event);
+                            }
+                        }
+                        return std::task::Poll::Pending;
+                    }
                     std::task::Poll::Ready(Ok(Some(resp))) => {
                         this.building = None;
                         return std::task::Poll::Ready(Some(Ok(resp)));
@@ -380,39 +463,27 @@ impl Stream for BatchPredicateStream {
                     }
                     std::task::Poll::Ready(Err(err)) => {
                         this.building = None;
+                        this.staged = None;
+                        this.done = true;
                         return std::task::Poll::Ready(Some(Err(err)));
                     }
                 }
             }
 
-            let frame = {
-                let next_fut = this.sub.next();
-                tokio::pin!(next_fut);
-                match next_fut.as_mut().poll(cx) {
-                    std::task::Poll::Ready(Ok(Some(frame))) => frame,
-                    std::task::Poll::Ready(Ok(None)) => return std::task::Poll::Ready(None),
-                    std::task::Poll::Ready(Err(err)) => {
-                        return std::task::Poll::Ready(Some(Err(client_error_to_connect(err))));
-                    }
+            let event = match this.staged.take() {
+                Some(event) => event,
+                None => match this.poll_upstream(cx) {
                     std::task::Poll::Pending => return std::task::Poll::Pending,
-                }
+                    std::task::Poll::Ready(event) => event,
+                },
             };
 
-            let sequence_number = frame.sequence_number;
-            let entries: Vec<(Key, Bytes)> = frame
-                .entries
-                .into_iter()
-                .map(|entry| (entry.key, entry.value))
-                .collect();
-            let state = this.state.clone();
-            let table_name = this.table_name.clone();
-            let where_sql = this.where_sql.clone();
-            this.building = Some(
-                async move {
-                    evaluate_batch(state, table_name, where_sql, sequence_number, entries).await
+            match event {
+                StagedSubscriptionEvent::Frame(frame) => {
+                    this.building = Some((this.evaluator)(frame));
                 }
-                .boxed(),
-            );
+                terminal => return std::task::Poll::Ready(this.finish_event(terminal)),
+            }
         }
     }
 }
@@ -727,6 +798,276 @@ fn _assert_projected_column_indices_visible() {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::VecDeque;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Mutex;
+
+    use futures::channel::oneshot;
+    use futures::StreamExt;
+
+    enum ControlledEvent {
+        Frame(u64),
+        End,
+        Error,
+    }
+
+    struct ControlledInput {
+        events: VecDeque<ControlledEvent>,
+        polls: Arc<AtomicUsize>,
+    }
+
+    impl Stream for ControlledInput {
+        type Item = Result<StreamSubscriptionFrame, ConnectError>;
+
+        fn poll_next(
+            mut self: Pin<&mut Self>,
+            _cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<Option<Self::Item>> {
+            self.polls.fetch_add(1, Ordering::SeqCst);
+            match self.events.pop_front() {
+                Some(ControlledEvent::Frame(sequence_number)) => {
+                    std::task::Poll::Ready(Some(Ok(StreamSubscriptionFrame {
+                        sequence_number,
+                        entries: Vec::new(),
+                    })))
+                }
+                Some(ControlledEvent::End) => std::task::Poll::Ready(None),
+                Some(ControlledEvent::Error) => {
+                    std::task::Poll::Ready(Some(Err(ConnectError::internal("upstream failed"))))
+                }
+                None => std::task::Poll::Pending,
+            }
+        }
+    }
+
+    struct ActiveEvaluation(Arc<AtomicUsize>);
+
+    impl Drop for ActiveEvaluation {
+        fn drop(&mut self) {
+            self.0.fetch_sub(1, Ordering::SeqCst);
+        }
+    }
+
+    type EvaluationResult = Result<Option<SubscribeResponse>, ConnectError>;
+
+    struct ControlledEvaluator {
+        evaluator: BatchEvaluator,
+        senders: HashMap<u64, oneshot::Sender<EvaluationResult>>,
+        started: Arc<Mutex<Vec<u64>>>,
+        max_active: Arc<AtomicUsize>,
+    }
+
+    fn controlled_input(
+        events: impl IntoIterator<Item = ControlledEvent>,
+    ) -> (ControlledInput, Arc<AtomicUsize>) {
+        let polls = Arc::new(AtomicUsize::new(0));
+        (
+            ControlledInput {
+                events: events.into_iter().collect(),
+                polls: polls.clone(),
+            },
+            polls,
+        )
+    }
+
+    fn controlled_evaluator(sequence_numbers: &[u64]) -> ControlledEvaluator {
+        let mut senders = HashMap::new();
+        let mut receivers = HashMap::new();
+        for &sequence_number in sequence_numbers {
+            let (sender, receiver) = oneshot::channel();
+            senders.insert(sequence_number, sender);
+            receivers.insert(sequence_number, receiver);
+        }
+
+        let started = Arc::new(Mutex::new(Vec::new()));
+        let evaluator_started = started.clone();
+        let active = Arc::new(AtomicUsize::new(0));
+        let max_active = Arc::new(AtomicUsize::new(0));
+        let evaluator_active = active.clone();
+        let evaluator_max_active = max_active.clone();
+        let evaluator: BatchEvaluator = Box::new(move |frame| {
+            let sequence_number = frame.sequence_number;
+            evaluator_started.lock().unwrap().push(sequence_number);
+            let receiver = receivers
+                .remove(&sequence_number)
+                .expect("evaluation receiver");
+            let active = evaluator_active.clone();
+            let max_active = evaluator_max_active.clone();
+            async move {
+                let active_count = active.fetch_add(1, Ordering::SeqCst) + 1;
+                max_active.fetch_max(active_count, Ordering::SeqCst);
+                let _active = ActiveEvaluation(active);
+                receiver.await.expect("evaluation result")
+            }
+            .boxed()
+        });
+        ControlledEvaluator {
+            evaluator,
+            senders,
+            started,
+            max_active,
+        }
+    }
+
+    fn response(sequence_number: u64) -> SubscribeResponse {
+        SubscribeResponse {
+            sequence_number,
+            ..Default::default()
+        }
+    }
+
+    fn next_ready(
+        stream: &mut BatchPredicateStream,
+    ) -> Option<Result<SubscribeResponse, ConnectError>> {
+        stream
+            .next()
+            .now_or_never()
+            .expect("stream should be ready")
+    }
+
+    #[test]
+    fn prefetches_one_frame_and_keeps_evaluation_ordered() {
+        let (input, polls) = controlled_input([
+            ControlledEvent::Frame(1),
+            ControlledEvent::Frame(2),
+            ControlledEvent::Frame(3),
+        ]);
+        let mut evaluator = controlled_evaluator(&[1, 2]);
+        let mut stream = BatchPredicateStream::with_evaluator(input, evaluator.evaluator);
+
+        assert!(stream.next().now_or_never().is_none());
+        assert_eq!(polls.load(Ordering::SeqCst), 2);
+        assert_eq!(*evaluator.started.lock().unwrap(), vec![1]);
+
+        assert!(stream.next().now_or_never().is_none());
+        assert_eq!(polls.load(Ordering::SeqCst), 2);
+        assert_eq!(*evaluator.started.lock().unwrap(), vec![1]);
+
+        evaluator
+            .senders
+            .remove(&1)
+            .unwrap()
+            .send(Ok(Some(response(1))))
+            .unwrap();
+        assert_eq!(next_ready(&mut stream).unwrap().unwrap().sequence_number, 1);
+        assert_eq!(polls.load(Ordering::SeqCst), 2);
+
+        assert!(stream.next().now_or_never().is_none());
+        assert_eq!(polls.load(Ordering::SeqCst), 3);
+        assert_eq!(*evaluator.started.lock().unwrap(), vec![1, 2]);
+
+        evaluator
+            .senders
+            .remove(&2)
+            .unwrap()
+            .send(Ok(Some(response(2))))
+            .unwrap();
+        assert_eq!(next_ready(&mut stream).unwrap().unwrap().sequence_number, 2);
+        assert_eq!(evaluator.max_active.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn filtered_frame_advances_to_staged_frame() {
+        let (input, polls) = controlled_input([
+            ControlledEvent::Frame(1),
+            ControlledEvent::Frame(2),
+            ControlledEvent::End,
+        ]);
+        let mut evaluator = controlled_evaluator(&[1, 2]);
+        let mut stream = BatchPredicateStream::with_evaluator(input, evaluator.evaluator);
+
+        assert!(stream.next().now_or_never().is_none());
+        evaluator
+            .senders
+            .remove(&1)
+            .unwrap()
+            .send(Ok(None))
+            .unwrap();
+        assert!(stream.next().now_or_never().is_none());
+        assert_eq!(*evaluator.started.lock().unwrap(), vec![1, 2]);
+        assert_eq!(polls.load(Ordering::SeqCst), 3);
+
+        evaluator
+            .senders
+            .remove(&2)
+            .unwrap()
+            .send(Ok(Some(response(2))))
+            .unwrap();
+        assert_eq!(next_ready(&mut stream).unwrap().unwrap().sequence_number, 2);
+        assert!(next_ready(&mut stream).is_none());
+        assert!(next_ready(&mut stream).is_none());
+        assert_eq!(evaluator.max_active.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn defers_upstream_end_until_pending_evaluation_finishes() {
+        let (input, polls) = controlled_input([ControlledEvent::Frame(1), ControlledEvent::End]);
+        let mut evaluator = controlled_evaluator(&[1]);
+        let mut stream = BatchPredicateStream::with_evaluator(input, evaluator.evaluator);
+
+        assert!(stream.next().now_or_never().is_none());
+        assert_eq!(polls.load(Ordering::SeqCst), 2);
+
+        evaluator
+            .senders
+            .remove(&1)
+            .unwrap()
+            .send(Ok(Some(response(1))))
+            .unwrap();
+        assert_eq!(next_ready(&mut stream).unwrap().unwrap().sequence_number, 1);
+        assert!(next_ready(&mut stream).is_none());
+        assert!(next_ready(&mut stream).is_none());
+    }
+
+    #[test]
+    fn defers_upstream_error_until_pending_evaluation_finishes() {
+        let (input, polls) = controlled_input([
+            ControlledEvent::Frame(1),
+            ControlledEvent::Error,
+            ControlledEvent::Frame(2),
+        ]);
+        let mut evaluator = controlled_evaluator(&[1]);
+        let mut stream = BatchPredicateStream::with_evaluator(input, evaluator.evaluator);
+
+        assert!(stream.next().now_or_never().is_none());
+        assert_eq!(polls.load(Ordering::SeqCst), 2);
+
+        evaluator
+            .senders
+            .remove(&1)
+            .unwrap()
+            .send(Ok(Some(response(1))))
+            .unwrap();
+        assert_eq!(next_ready(&mut stream).unwrap().unwrap().sequence_number, 1);
+        assert!(next_ready(&mut stream).unwrap().is_err());
+        assert!(next_ready(&mut stream).is_none());
+        assert_eq!(polls.load(Ordering::SeqCst), 2);
+        assert_eq!(*evaluator.started.lock().unwrap(), vec![1]);
+    }
+
+    #[test]
+    fn predicate_error_fuses_and_discards_staged_frame() {
+        let (input, polls) = controlled_input([
+            ControlledEvent::Frame(1),
+            ControlledEvent::Frame(2),
+            ControlledEvent::Frame(3),
+        ]);
+        let mut evaluator = controlled_evaluator(&[1]);
+        let mut stream = BatchPredicateStream::with_evaluator(input, evaluator.evaluator);
+
+        assert!(stream.next().now_or_never().is_none());
+        evaluator
+            .senders
+            .remove(&1)
+            .unwrap()
+            .send(Err(ConnectError::internal("predicate failed")))
+            .unwrap();
+
+        assert!(next_ready(&mut stream).unwrap().is_err());
+        assert!(next_ready(&mut stream).is_none());
+        assert_eq!(polls.load(Ordering::SeqCst), 2);
+        assert_eq!(*evaluator.started.lock().unwrap(), vec![1]);
+    }
 
     /// Result cells for Binary columns can arrive as any of the three arrow
     /// binary encodings; every one becomes a `binary_value` cell.


### PR DESCRIPTION
Adds bounded, ordered lookahead to stream subscriptions so replay and live catch-up can overlap up to eight `get_batch` reads.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes hot subscribe paths in the server, QMDB, and SQL with bounded but per-subscriber read staging; behavior is heavily tested but memory and engine read pressure scale with subscriber count.
> 
> **Overview**
> Stream subscriptions now **overlap up to eight ordered `get_batch` reads** during replay and live catch-up, while keeping client-driven backpressure and in-order delivery.
> 
> The store **subscribe path** is refactored around `ordered_batch_stream` (buffered sequence reads) and a **live sequence stream** that re-checks the published frontier and waits on publish notifications instead of snapshotting live progress once. Errors **drop replay/live batch streams** so buffered work is not held after failure. **Simulator RocksDB** runs log reads on the blocking pool so `get_batch` futures yield and lookahead can actually overlap.
> 
> **QMDB** and **SQL subscribe** layers keep pulling upstream while proofs or predicate evaluation are in flight, with a matching **staged-batch cap of eight** and deferred stream end/error until pending work drains. Docs and tests cover ordering, filtered batches, replay-to-live extension, and cancellation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 801589e4c26e0b707c40b8dbebb82c6b1b58d0e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->