### PR TITLE
server: get batch filtered

### DIFF
--- a/server/src/connect.rs
+++ b/server/src/connect.rs
@@ -858,7 +858,11 @@ where
     }
 }
 
-type OrderedBatchStream = Pin<Box<dyn Stream<Item = Result<Option<FilteredBatch>, String>> + Send>>;
+// Keep each result paired with its requested sequence number. Subscribe
+// frames use that number as the resume cursor instead of trusting sequence
+// metadata supplied by a custom filtered-read implementation.
+type OrderedBatchStream =
+    Pin<Box<dyn Stream<Item = (u64, Result<Option<FilteredBatch>, String>)> + Send>>;
 
 fn ordered_batch_stream<B, S>(
     log: Arc<B>,
@@ -880,13 +884,14 @@ where
                 let first_batch = first_batch.take();
                 let matchers = matchers.clone();
                 async move {
-                    match first_batch {
+                    let batch = match first_batch {
                         Some(batch) => Ok(Some(batch)),
                         None => {
                             log.get_batch_filtered(sequence_number, matchers.as_ref())
                                 .await
                         }
-                    }
+                    };
+                    (sequence_number, batch)
                 }
             })
             .buffered(SUBSCRIBE_GET_BATCH_LOOKAHEAD),
@@ -974,8 +979,8 @@ where
 
                 // The live sequence source only ends past u64::MAX, so an
                 // exhausted live stream ends the subscription.
-                let batch = state.live.as_mut()?.next().await?;
-                match state.resolve_batch(batch).await {
+                let (sequence_number, batch) = state.live.as_mut()?.next().await?;
+                match state.resolve_batch(sequence_number, batch).await {
                     Ok(Some(frame)) => return Some((Ok(frame), state)),
                     Ok(None) => continue,
                     Err(err) => return Some((state.terminate(err), state)),
@@ -995,11 +1000,11 @@ where
         let Some(replay) = &mut self.replay else {
             return Ok(ReplayProgress::Done);
         };
-        let Some(batch) = replay.batches.next().await else {
+        let Some((sequence_number, batch)) = replay.batches.next().await else {
             self.replay = None;
             return Ok(ReplayProgress::Done);
         };
-        Ok(match self.resolve_batch(batch).await? {
+        Ok(match self.resolve_batch(sequence_number, batch).await? {
             Some(frame) => ReplayProgress::Frame(frame),
             None => ReplayProgress::Advanced,
         })
@@ -1007,6 +1012,7 @@ where
 
     async fn resolve_batch(
         &mut self,
+        sequence_number: u64,
         batch: Result<Option<FilteredBatch>, String>,
     ) -> Result<Option<SubscribeResponse>, ConnectError> {
         let batch = batch.map_err(ConnectError::internal)?;
@@ -1019,7 +1025,6 @@ where
                 .map_err(ConnectError::internal)?;
             return Err(StreamConnect::<B>::batch_evicted_connect_error(oldest));
         };
-        let sequence_number = batch.sequence_number();
         let entries = batch.into_entries();
         if entries.is_empty() {
             return Ok(None);
@@ -1085,9 +1090,10 @@ where
         let replay_bound = subscription.current_sequence;
         let live_notify = subscription.notify;
 
-        // Optional replay. Validate the starting batch eagerly so an
-        // already-evicted cursor fails the RPC immediately; later replay holes
-        // are surfaced on the stream itself so callers reconnect from a safe
+        // Optional replay. The starting batch is read and filtered eagerly, so
+        // an already-evicted cursor and a first batch that fails to decode both
+        // fail the RPC at setup. Later replay holes and decode failures surface
+        // on the established stream itself so callers reconnect from a safe
         // point instead of silently continuing.
         let replay = match since {
             Some(s) if s <= replay_bound && s > 0 => {
@@ -1125,7 +1131,7 @@ where
                 replay_bound.checked_add(1),
             ),
             None,
-            matchers.clone(),
+            matchers,
         );
 
         Ok(connectrpc::Response::stream(
@@ -1943,7 +1949,7 @@ mod tests {
                     ..Default::default()
                 }]
             };
-            Ok(Some(FilteredBatch::from_entries(sequence_number, entries)))
+            Ok(Some(FilteredBatch::from_entries(entries)))
         }
 
         async fn oldest_retained_batch(&self) -> Result<Option<u64>, String> {
@@ -1956,6 +1962,39 @@ mod tests {
             &self,
             _policy: Option<RetentionPolicy>,
         ) -> Result<Option<u64>, String> {
+            Ok(Some(1))
+        }
+    }
+
+    struct MalformedLog {
+        current_sequence: u64,
+        malformed: u64,
+    }
+
+    impl Sequence for MalformedLog {
+        fn current_sequence(&self) -> u64 {
+            self.current_sequence
+        }
+    }
+
+    impl Log for MalformedLog {
+        async fn get_batch(&self, sequence_number: u64) -> Result<Option<LogBatch>, String> {
+            if sequence_number > self.current_sequence {
+                return Ok(None);
+            }
+            if sequence_number == self.malformed {
+                return Ok(Some(LogBatch::from_response_bytes(
+                    sequence_number,
+                    Bytes::from_static(&[0xff, 0xff, 0xff, 0xff]),
+                )));
+            }
+            Ok(Some(LogBatch::from_entries(
+                sequence_number,
+                vec![matching_kv(b"ok", &[sequence_number as u8])],
+            )))
+        }
+
+        async fn oldest_retained_batch(&self) -> Result<Option<u64>, String> {
             Ok(Some(1))
         }
     }
@@ -2815,6 +2854,98 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn subscribe_since_evicted_batch_fails_setup_with_batch_evicted_metadata() {
+        let engine = Arc::new(FakeEngine::default());
+        engine.set_current_sequence(3);
+        engine.set_oldest_retained(Some(2));
+        engine.set_batch(2, Some(vec![matching_kv(b"replay", b"v2")]));
+        engine.set_batch(3, Some(vec![matching_kv(b"replay", b"v3")]));
+
+        let connect = StreamConnect::new(AppState::new(engine));
+        let Err(err) = subscribe_stream(&connect, Some(1)).await else {
+            panic!("evicted cursor must fail subscription setup");
+        };
+
+        assert_eq!(err.code, connectrpc::ErrorCode::OutOfRange);
+        let decoded = decode_connect_error(&err).expect("decode connect error");
+        let info = decoded.error_info.expect("error info");
+        assert_eq!(info.reason, crate::stream::REASON_BATCH_EVICTED);
+        assert_eq!(
+            info.metadata
+                .get(crate::stream::METADATA_OLDEST_RETAINED)
+                .map(String::as_str),
+            Some("2"),
+        );
+    }
+
+    #[tokio::test]
+    async fn malformed_first_replay_batch_fails_subscription_setup() {
+        let engine = Arc::new(MalformedLog {
+            current_sequence: 2,
+            malformed: 1,
+        });
+        let notifier = Arc::new(ManualNotifier::new(2));
+        let connect = StreamConnect::new(StreamState::new(engine, notifier));
+
+        let Err(err) = subscribe_stream(&connect, Some(1)).await else {
+            panic!("malformed first replay batch must fail setup");
+        };
+        assert_eq!(err.code, connectrpc::ErrorCode::Internal);
+    }
+
+    #[tokio::test]
+    async fn malformed_later_replay_batch_terminates_established_stream() {
+        let engine = Arc::new(MalformedLog {
+            current_sequence: 2,
+            malformed: 2,
+        });
+        let notifier = Arc::new(ManualNotifier::new(2));
+        let connect = StreamConnect::new(StreamState::new(engine, notifier));
+        let mut stream = subscribe_stream(&connect, Some(1))
+            .await
+            .expect("subscribe");
+
+        let first = stream.next().await.unwrap().unwrap();
+        assert_eq!(first.sequence_number, 1);
+
+        let err = stream
+            .next()
+            .await
+            .unwrap()
+            .expect_err("malformed later batch must surface on the stream");
+        assert_eq!(err.code, connectrpc::ErrorCode::Internal);
+        assert!(
+            stream.next().await.is_none(),
+            "stream must terminate after the decode failure",
+        );
+    }
+
+    #[tokio::test]
+    async fn all_replay_batches_filtered_advance_silently_to_live() {
+        let engine = Arc::new(FakeEngine::default());
+        engine.set_current_sequence(3);
+        engine.set_oldest_retained(Some(1));
+        for seq in 1..=3 {
+            engine.set_batch(seq, Some(vec![nonmatching_kv(b"skip", &[seq as u8])]));
+        }
+
+        let state = AppState::new(engine.clone());
+        let connect = StreamConnect::new(state.clone());
+        let mut stream = subscribe_stream(&connect, Some(1))
+            .await
+            .expect("subscribe");
+
+        engine.publish_live(state.stream.clone(), 4, vec![matching_kv(b"live", b"v4")]);
+        let frame = tokio::time::timeout(Duration::from_secs(1), stream.next())
+            .await
+            .expect("stream should yield")
+            .expect("frame should exist")
+            .expect("frame should be ok");
+        assert_eq!(frame.sequence_number, 4);
+        assert_eq!(frame.entries[0].value.as_ref(), b"v4");
+    }
+
+    #[tokio::test]
     async fn replay_lookahead_is_bounded_and_emits_in_order() {
         let last_sequence = SUBSCRIBE_GET_BATCH_LOOKAHEAD as u64 + 1;
         let engine = Arc::new(GatedLog::default());
@@ -2903,6 +3034,93 @@ mod tests {
         for sequence_number in 1..=last_sequence {
             assert_eq!(engine.get_count(sequence_number), 1);
         }
+    }
+
+    #[derive(Default)]
+    struct GatedFilteredLog {
+        inner: GatedLog,
+    }
+
+    impl Sequence for GatedFilteredLog {
+        fn current_sequence(&self) -> u64 {
+            self.inner.current_sequence()
+        }
+    }
+
+    impl Log for GatedFilteredLog {
+        async fn get_batch(&self, _sequence_number: u64) -> Result<Option<LogBatch>, String> {
+            Err("subscribe must not use the unfiltered read".into())
+        }
+
+        async fn get_batch_filtered(
+            &self,
+            sequence_number: u64,
+            matchers: &crate::stream::CompiledMatchers,
+        ) -> Result<Option<FilteredBatch>, String> {
+            let Some(batch) = self.inner.get_batch(sequence_number).await? else {
+                return Ok(None);
+            };
+            let response = batch.decode_response()?;
+            let entries = crate::stream::apply_filter(matchers, response.entries);
+            Ok(Some(FilteredBatch::from_entries(entries)))
+        }
+
+        async fn oldest_retained_batch(&self) -> Result<Option<u64>, String> {
+            self.inner.oldest_retained_batch().await
+        }
+    }
+
+    #[tokio::test]
+    async fn custom_filtered_override_keeps_lookahead_bound_and_order() {
+        let last_sequence = SUBSCRIBE_GET_BATCH_LOOKAHEAD as u64 + 1;
+        let engine = Arc::new(GatedFilteredLog::default());
+        for sequence_number in 1..=last_sequence {
+            engine.inner.set_batch(
+                sequence_number,
+                vec![matching_kv(b"replay", &[sequence_number as u8])],
+            );
+        }
+        for sequence_number in 2..=last_sequence {
+            engine.inner.gate(sequence_number);
+        }
+
+        let notifier = Arc::new(ManualNotifier::new(last_sequence));
+        let connect = StreamConnect::new(StreamState::new(engine.clone(), notifier));
+        let mut stream = subscribe_stream(&connect, Some(1))
+            .await
+            .expect("subscribe");
+
+        let (sender, mut frames) = tokio::sync::mpsc::unbounded_channel();
+        let reader = tokio::spawn(async move {
+            while let Some(frame) = stream.next().await {
+                if sender.send(frame).is_err() {
+                    return;
+                }
+            }
+        });
+
+        assert_eq!(next_subscribe_frame(&mut frames).await.sequence_number, 1);
+        engine.inner.wait_for_started(last_sequence as usize).await;
+        assert_eq!(engine.inner.in_flight(), SUBSCRIBE_GET_BATCH_LOOKAHEAD);
+        assert_eq!(engine.inner.max_in_flight(), SUBSCRIBE_GET_BATCH_LOOKAHEAD);
+
+        // Completions land in reverse order to prove delivery stays sequence
+        // ordered and duplicate free through the override path.
+        for sequence_number in (2..=last_sequence).rev() {
+            engine.inner.release(sequence_number);
+        }
+        for expected in 2..=last_sequence {
+            assert_eq!(
+                next_subscribe_frame(&mut frames).await.sequence_number,
+                expected
+            );
+        }
+        for sequence_number in 1..=last_sequence {
+            assert_eq!(engine.inner.get_count(sequence_number), 1);
+        }
+
+        reader.abort();
+        let _ = reader.await;
     }
 
     #[tokio::test]

--- a/server/src/connect.rs
+++ b/server/src/connect.rs
@@ -49,7 +49,8 @@ use crate::reduce::RangeReducer;
 use crate::stream::{StreamHub, StreamNotifier};
 use crate::validate::{self, IngestLimits};
 use crate::{
-    Ingest, IngestError, Log, LogBatch, Prune, Query, QueryExtra, RangeScan, Retention, StoreEngine,
+    FilteredBatch, Ingest, IngestError, Log, Prune, Query, QueryExtra, RangeScan, Retention,
+    StoreEngine,
 };
 
 // TODO (#57): Make limits configurable.
@@ -857,25 +858,13 @@ where
     }
 }
 
-fn filtered_subscribe_response(
-    batch: &LogBatch,
-    matchers: &crate::stream::CompiledMatchers,
-) -> Result<Option<SubscribeResponse>, ConnectError> {
-    let response = batch.decode_response().map_err(ConnectError::internal)?;
-    let entries = crate::stream::apply_filter(matchers, &response.entries);
-    Ok((!entries.is_empty()).then_some(SubscribeResponse {
-        sequence_number: batch.sequence_number(),
-        entries,
-        ..Default::default()
-    }))
-}
-
-type OrderedBatchStream = Pin<Box<dyn Stream<Item = Result<Option<LogBatch>, String>> + Send>>;
+type OrderedBatchStream = Pin<Box<dyn Stream<Item = Result<Option<FilteredBatch>, String>> + Send>>;
 
 fn ordered_batch_stream<B, S>(
     log: Arc<B>,
     sequences: S,
-    mut first_batch: Option<LogBatch>,
+    mut first_batch: Option<FilteredBatch>,
+    matchers: Arc<crate::stream::CompiledMatchers>,
 ) -> OrderedBatchStream
 where
     B: Log,
@@ -889,10 +878,14 @@ where
                 // closure invocation observes the eagerly fetched batch and it
                 // pairs with the first sequence.
                 let first_batch = first_batch.take();
+                let matchers = matchers.clone();
                 async move {
                     match first_batch {
                         Some(batch) => Ok(Some(batch)),
-                        None => log.get_batch(sequence_number).await,
+                        None => {
+                            log.get_batch_filtered(sequence_number, matchers.as_ref())
+                                .await
+                        }
                     }
                 }
             })
@@ -941,7 +934,6 @@ enum ReplayProgress {
 
 struct SubscriptionState<B> {
     state: StreamState<B>,
-    matchers: crate::stream::CompiledMatchers,
     // Both streams are dropped at termination so buffered batches free at the
     // failure boundary instead of when the client tears the stream down.
     replay: Option<ReplayState>,
@@ -953,15 +945,9 @@ impl<B> SubscriptionState<B>
 where
     B: Log,
 {
-    fn new(
-        state: StreamState<B>,
-        matchers: crate::stream::CompiledMatchers,
-        replay: Option<ReplayState>,
-        live: OrderedBatchStream,
-    ) -> Self {
+    fn new(state: StreamState<B>, replay: Option<ReplayState>, live: OrderedBatchStream) -> Self {
         Self {
             state,
-            matchers,
             replay,
             live: Some(live),
             terminated: false,
@@ -1021,7 +1007,7 @@ where
 
     async fn resolve_batch(
         &mut self,
-        batch: Result<Option<LogBatch>, String>,
+        batch: Result<Option<FilteredBatch>, String>,
     ) -> Result<Option<SubscribeResponse>, ConnectError> {
         let batch = batch.map_err(ConnectError::internal)?;
         let Some(batch) = batch else {
@@ -1033,7 +1019,16 @@ where
                 .map_err(ConnectError::internal)?;
             return Err(StreamConnect::<B>::batch_evicted_connect_error(oldest));
         };
-        filtered_subscribe_response(&batch, &self.matchers)
+        let sequence_number = batch.sequence_number();
+        let entries = batch.into_entries();
+        if entries.is_empty() {
+            return Ok(None);
+        }
+        Ok(Some(SubscribeResponse {
+            sequence_number,
+            entries,
+            ..Default::default()
+        }))
     }
 }
 
@@ -1085,7 +1080,7 @@ where
         // Snapshot the published frontier to bound replay and subscribe for
         // live wakeups. Bounded lookahead overlaps log reads while retaining
         // client-driven backpressure.
-        let matchers = crate::stream::compile_matchers(&filter)?;
+        let matchers = Arc::new(crate::stream::compile_matchers(&filter)?);
         let subscription = self.state.notifier.subscribe();
         let replay_bound = subscription.current_sequence;
         let live_notify = subscription.notify;
@@ -1099,7 +1094,7 @@ where
                 let first_batch = self
                     .state
                     .log
-                    .get_batch(s)
+                    .get_batch_filtered(s, matchers.as_ref())
                     .await
                     .map_err(ConnectError::internal)?;
                 let Some(first_batch) = first_batch else {
@@ -1116,6 +1111,7 @@ where
                         self.state.log.clone(),
                         stream_util::iter(s..=replay_bound),
                         Some(first_batch),
+                        matchers.clone(),
                     ),
                 })
             }
@@ -1129,10 +1125,11 @@ where
                 replay_bound.checked_add(1),
             ),
             None,
+            matchers.clone(),
         );
 
         Ok(connectrpc::Response::stream(
-            SubscriptionState::new(self.state.clone(), matchers, replay, live).into_stream(),
+            SubscriptionState::new(self.state.clone(), replay, live).into_stream(),
         ))
     }
 
@@ -1385,7 +1382,9 @@ mod tests {
     use buffa::Message;
     use exoware_proto::common::kv::v1::Selector as ProtoSelector;
     use exoware_proto::log::retention::v1::SetRetentionRequest;
-    use exoware_proto::log::stream::v1::{SubscribeRequest, SubscribeRequestView};
+    use exoware_proto::log::stream::v1::{
+        GetRequest as StreamGetRequest, SubscribeRequest, SubscribeRequestView,
+    };
     use exoware_proto::store::prune::v1::{
         policy_retain, KeysScope, Policy as ProtoPolicy, PolicyRetain, PruneRequest,
         PruneRequestView, RetainKeepLatest,
@@ -1398,8 +1397,8 @@ mod tests {
     use futures::StreamExt;
 
     use crate::{
-        Ingest, IngestError, Log, Prune, Query, QueryExtra, RangeScan, RangeScanBatch, Retention,
-        Sequence, StreamNotification, StreamNotifier,
+        Ingest, IngestError, Log, LogBatch, Prune, Query, QueryExtra, RangeScan, RangeScanBatch,
+        Retention, Sequence, StreamNotification, StreamNotifier,
     };
 
     const TEST_PREFIX: u8 = 1;
@@ -1893,6 +1892,71 @@ mod tests {
             _policy: Option<RetentionPolicy>,
         ) -> Result<Option<u64>, String> {
             self.oldest_retained_batch().await
+        }
+    }
+
+    struct DispatchLog {
+        current_sequence: u64,
+        get_batch_calls: AtomicUsize,
+        get_batch_filtered_calls: AtomicUsize,
+    }
+
+    impl DispatchLog {
+        fn new(current_sequence: u64) -> Self {
+            Self {
+                current_sequence,
+                get_batch_calls: AtomicUsize::new(0),
+                get_batch_filtered_calls: AtomicUsize::new(0),
+            }
+        }
+    }
+
+    impl Sequence for DispatchLog {
+        fn current_sequence(&self) -> u64 {
+            self.current_sequence
+        }
+    }
+
+    impl Log for DispatchLog {
+        async fn get_batch(&self, sequence_number: u64) -> Result<Option<LogBatch>, String> {
+            self.get_batch_calls.fetch_add(1, Ordering::Relaxed);
+            Ok(Some(LogBatch::from_entries(
+                sequence_number,
+                vec![matching_kv(b"unfiltered", b"whole")],
+            )))
+        }
+
+        async fn get_batch_filtered(
+            &self,
+            sequence_number: u64,
+            _matchers: &crate::stream::CompiledMatchers,
+        ) -> Result<Option<FilteredBatch>, String> {
+            self.get_batch_filtered_calls
+                .fetch_add(1, Ordering::Relaxed);
+            let entries = if sequence_number == 1 {
+                Vec::new()
+            } else {
+                let (key, value) = matching_kv(b"filtered", b"selected");
+                vec![Entry {
+                    key: key.to_vec(),
+                    value,
+                    ..Default::default()
+                }]
+            };
+            Ok(Some(FilteredBatch::from_entries(sequence_number, entries)))
+        }
+
+        async fn oldest_retained_batch(&self) -> Result<Option<u64>, String> {
+            Ok(Some(1))
+        }
+    }
+
+    impl Retention for DispatchLog {
+        async fn set_retention(
+            &self,
+            _policy: Option<RetentionPolicy>,
+        ) -> Result<Option<u64>, String> {
+            Ok(Some(1))
         }
     }
 
@@ -2714,6 +2778,43 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn subscribe_uses_filtered_override_and_get_remains_unfiltered() {
+        let engine = Arc::new(DispatchLog::new(3));
+        let notifier = Arc::new(ManualNotifier::new(2));
+        let connect = StreamConnect::new(StreamState::new(engine.clone(), notifier.clone()));
+        let mut stream = subscribe_stream(&connect, Some(1))
+            .await
+            .expect("subscribe");
+
+        let replay = stream.next().await.unwrap().unwrap();
+        assert_eq!(replay.sequence_number, 2);
+        assert_eq!(replay.entries[0].value.as_ref(), b"selected");
+        assert_eq!(engine.get_batch_filtered_calls.load(Ordering::Relaxed), 2);
+        assert_eq!(engine.get_batch_calls.load(Ordering::Relaxed), 0);
+
+        notifier.advance(3);
+        let live = stream.next().await.unwrap().unwrap();
+        assert_eq!(live.sequence_number, 3);
+        assert_eq!(engine.get_batch_filtered_calls.load(Ordering::Relaxed), 3);
+
+        let request = buffa::view::OwnedView::<GetRequestView<'static>>::decode(
+            StreamGetRequest {
+                sequence_number: 3,
+                ..Default::default()
+            }
+            .encode_to_vec()
+            .into(),
+        )
+        .expect("decode get request");
+        StreamApi::get(&connect, Context::default(), request)
+            .await
+            .expect("get");
+
+        assert_eq!(engine.get_batch_calls.load(Ordering::Relaxed), 1);
+        assert_eq!(engine.get_batch_filtered_calls.load(Ordering::Relaxed), 3);
+    }
+
+    #[tokio::test]
     async fn replay_lookahead_is_bounded_and_emits_in_order() {
         let last_sequence = SUBSCRIBE_GET_BATCH_LOOKAHEAD as u64 + 1;
         let engine = Arc::new(GatedLog::default());
@@ -2782,7 +2883,7 @@ mod tests {
         let last_sequence = SUBSCRIBE_GET_BATCH_LOOKAHEAD as u64 + 2;
         let engine = Arc::new(GatedLog::default());
         for sequence_number in 1..=last_sequence {
-            let kv = if sequence_number == 1 || sequence_number == last_sequence {
+            let kv = if sequence_number == last_sequence {
                 matching_kv(b"match", &[sequence_number as u8])
             } else {
                 nonmatching_kv(b"skip", &[sequence_number as u8])
@@ -2796,8 +2897,6 @@ mod tests {
             .await
             .expect("subscribe");
 
-        let first = stream.next().await.unwrap().unwrap();
-        assert_eq!(first.sequence_number, 1);
         let last = stream.next().await.unwrap().unwrap();
         assert_eq!(last.sequence_number, last_sequence);
 

--- a/server/src/engine.rs
+++ b/server/src/engine.rs
@@ -172,10 +172,11 @@ impl LogBatch {
 
 /// Filtered and fully resolved entries from a retained sequence batch.
 ///
-/// An empty entry list represents a retained batch with no matches.
+/// An empty entry list represents a retained batch with no matches. Subscribe
+/// frames are stamped with the sequence number the read was requested under,
+/// so a filtered batch carries no sequence number a backend could misstamp.
 #[derive(Clone, Debug)]
 pub struct FilteredBatch {
-    sequence_number: u64,
     entries: Vec<Entry>,
 }
 
@@ -183,16 +184,22 @@ impl FilteredBatch {
     /// Build a filtered batch from owned caller-visible entries.
     ///
     /// Values must contain resolved payload bytes.
-    pub fn from_entries(sequence_number: u64, entries: Vec<Entry>) -> Self {
-        Self {
-            sequence_number,
-            entries,
-        }
+    pub fn from_entries(entries: Vec<Entry>) -> Self {
+        Self { entries }
     }
 
-    /// Sequence number under which this batch was loaded.
-    pub fn sequence_number(&self) -> u64 {
-        self.sequence_number
+    /// Build a filtered batch from resolved key-value pairs.
+    pub fn from_kvs(kvs: Vec<(Bytes, Bytes)>) -> Self {
+        Self {
+            entries: kvs
+                .into_iter()
+                .map(|(key, value)| Entry {
+                    key: key.to_vec(),
+                    value,
+                    ..Default::default()
+                })
+                .collect(),
+        }
     }
 
     /// Consume the batch into its entries.
@@ -219,13 +226,23 @@ pub trait Log: Sequence {
         sequence_number: u64,
     ) -> impl Future<Output = Result<Option<LogBatch>, String>> + Send;
 
-    /// Return fully resolved matching entries from a retained sequence batch.
+    /// Return fully resolved matching entries from the batch assigned
+    /// `sequence_number`.
     ///
     /// Return `Some` with no entries when the batch is retained but no entries
     /// match. Return `None` only when the batch is unavailable.
     ///
-    /// Optimized implementations only need to resolve entries whose keys match.
-    /// Failures confined to key-excluded values do not fail the filtered read.
+    /// An entry matches only when [`CompiledMatchers::matches_key`] accepts its
+    /// key and [`CompiledMatchers::matches_value`] accepts its resolved value.
+    /// Matching entries must keep their original batch order and multiplicity
+    /// without truncation, so subscribers observe the same frames the default
+    /// implementation would produce. Subscribe frames are stamped with the
+    /// requested `sequence_number`, so entries taken from any other batch would
+    /// be delivered under the wrong resume cursor.
+    ///
+    /// Optimized implementations must call `matches_key` before resolving a
+    /// value and `matches_value` afterward. Failures confined to key-excluded
+    /// values do not fail the filtered read.
     fn get_batch_filtered(
         &self,
         sequence_number: u64,
@@ -235,10 +252,9 @@ pub trait Log: Sequence {
             let Some(batch) = self.get_batch(sequence_number).await? else {
                 return Ok(None);
             };
-            let sequence_number = batch.sequence_number();
             let response = batch.decode_response()?;
             let entries = apply_filter(matchers, response.entries);
-            Ok(Some(FilteredBatch::from_entries(sequence_number, entries)))
+            Ok(Some(FilteredBatch::from_entries(entries)))
         }
     }
 
@@ -327,7 +343,6 @@ mod tests {
         let filtered = futures::executor::block_on(log.get_batch_filtered(1, &matchers()))
             .unwrap()
             .unwrap();
-        assert_eq!(filtered.sequence_number(), 1);
         let entries = filtered.into_entries();
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].value.as_ref(), b"one");

--- a/server/src/engine.rs
+++ b/server/src/engine.rs
@@ -14,6 +14,8 @@ use exoware_sdk::log::stream::v1::GetResponse as StreamGetResponse;
 use exoware_sdk::prune_policy::PrunePolicyDocument;
 use exoware_sdk::retention::RetentionPolicy;
 
+use crate::stream::{apply_filter, CompiledMatchers};
+
 /// Backend-defined query metadata.
 ///
 /// Keep this lightweight: streaming query RPCs may emit detail on every frame.
@@ -168,6 +170,37 @@ impl LogBatch {
     }
 }
 
+/// Filtered and fully resolved entries from a retained sequence batch.
+///
+/// An empty entry list represents a retained batch with no matches.
+#[derive(Clone, Debug)]
+pub struct FilteredBatch {
+    sequence_number: u64,
+    entries: Vec<Entry>,
+}
+
+impl FilteredBatch {
+    /// Build a filtered batch from owned caller-visible entries.
+    ///
+    /// Values must contain resolved payload bytes.
+    pub fn from_entries(sequence_number: u64, entries: Vec<Entry>) -> Self {
+        Self {
+            sequence_number,
+            entries,
+        }
+    }
+
+    /// Sequence number under which this batch was loaded.
+    pub fn sequence_number(&self) -> u64 {
+        self.sequence_number
+    }
+
+    /// Consume the batch into its entries.
+    pub fn into_entries(self) -> Vec<Entry> {
+        self.entries
+    }
+}
+
 /// Retained per-sequence batch-log access for stream replay and lookups.
 pub trait Log: Sequence {
     /// Return the pre-encoded `GetResponse` for the `put_batch` call that was
@@ -185,6 +218,29 @@ pub trait Log: Sequence {
         &self,
         sequence_number: u64,
     ) -> impl Future<Output = Result<Option<LogBatch>, String>> + Send;
+
+    /// Return fully resolved matching entries from a retained sequence batch.
+    ///
+    /// Return `Some` with no entries when the batch is retained but no entries
+    /// match. Return `None` only when the batch is unavailable.
+    ///
+    /// Optimized implementations only need to resolve entries whose keys match.
+    /// Failures confined to key-excluded values do not fail the filtered read.
+    fn get_batch_filtered(
+        &self,
+        sequence_number: u64,
+        matchers: &CompiledMatchers,
+    ) -> impl Future<Output = Result<Option<FilteredBatch>, String>> + Send {
+        async move {
+            let Some(batch) = self.get_batch(sequence_number).await? else {
+                return Ok(None);
+            };
+            let sequence_number = batch.sequence_number();
+            let response = batch.decode_response()?;
+            let entries = apply_filter(matchers, response.entries);
+            Ok(Some(FilteredBatch::from_entries(sequence_number, entries)))
+        }
+    }
 
     /// Lowest retained batch sequence number, or `None` when the log is
     /// empty. Surfaced in `BATCH_EVICTED` error details so clients know where
@@ -206,3 +262,92 @@ pub trait Retention: Send + Sync + 'static {
 pub trait StoreEngine: Ingest + Query + Prune + Log + Retention {}
 
 impl<T: Ingest + Query + Prune + Log + Retention> StoreEngine for T {}
+
+#[cfg(test)]
+mod tests {
+    use std::future::ready;
+
+    use super::*;
+    use exoware_sdk::kv_codec::Utf8;
+    use exoware_sdk::selector::Selector;
+    use exoware_sdk::stream_filter::StreamFilter;
+
+    #[derive(Clone)]
+    struct TestLog {
+        batch: Option<LogBatch>,
+    }
+
+    impl Sequence for TestLog {
+        fn current_sequence(&self) -> u64 {
+            u64::from(self.batch.is_some())
+        }
+    }
+
+    impl Log for TestLog {
+        fn get_batch(
+            &self,
+            sequence_number: u64,
+        ) -> impl Future<Output = Result<Option<LogBatch>, String>> + Send {
+            ready(Ok((sequence_number == 1)
+                .then(|| self.batch.clone())
+                .flatten()))
+        }
+
+        fn oldest_retained_batch(
+            &self,
+        ) -> impl Future<Output = Result<Option<u64>, String>> + Send {
+            ready(Ok(self.batch.as_ref().map(|_| 1)))
+        }
+    }
+
+    fn matchers() -> CompiledMatchers {
+        crate::stream::compile_matchers(&StreamFilter {
+            selectors: vec![Selector {
+                prefix: Bytes::from_static(&[1]),
+                payload_regex: Utf8::from("^keep$"),
+            }],
+            value_filters: vec![],
+        })
+        .unwrap()
+    }
+
+    #[test]
+    fn default_filtered_batch_preserves_retained_and_missing_states() {
+        let matching = (
+            Bytes::from_static(&[1, b'k', b'e', b'e', b'p']),
+            Bytes::from_static(b"one"),
+        );
+        let excluded = (
+            Bytes::from_static(&[2, b'k', b'e', b'e', b'p']),
+            Bytes::from_static(b"two"),
+        );
+        let log = TestLog {
+            batch: Some(LogBatch::from_entries(1, vec![matching, excluded])),
+        };
+        let filtered = futures::executor::block_on(log.get_batch_filtered(1, &matchers()))
+            .unwrap()
+            .unwrap();
+        assert_eq!(filtered.sequence_number(), 1);
+        let entries = filtered.into_entries();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].value.as_ref(), b"one");
+
+        let retained_without_matches = TestLog {
+            batch: Some(LogBatch::from_entries(
+                1,
+                vec![(Bytes::from_static(&[2]), Bytes::from_static(b"value"))],
+            )),
+        };
+        let filtered = futures::executor::block_on(
+            retained_without_matches.get_batch_filtered(1, &matchers()),
+        )
+        .unwrap()
+        .unwrap();
+        assert!(filtered.into_entries().is_empty());
+
+        let missing = TestLog { batch: None };
+        let filtered =
+            futures::executor::block_on(missing.get_batch_filtered(1, &matchers())).unwrap();
+        assert!(filtered.is_none());
+    }
+}

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -15,9 +15,9 @@ pub use connect::{
     stream_service, AppState, IngestState, PruneState, QueryState, RetentionState, StreamState,
 };
 pub use engine::{
-    Ingest, IngestError, Log, LogBatch, Prune, Query, QueryExtra, RangeScan, RangeScanBatch,
-    Retention, Sequence, StoreEngine,
+    FilteredBatch, Ingest, IngestError, Log, LogBatch, Prune, Query, QueryExtra, RangeScan,
+    RangeScanBatch, Retention, Sequence, StoreEngine,
 };
 pub use reduce::RangeError;
-pub use stream::{StreamHub, StreamNotification, StreamNotifier};
+pub use stream::{CompiledMatchers, StreamHub, StreamNotification, StreamNotifier};
 pub use validate::{IngestLimits, DEFAULT_MAX_VALUE_LEN};

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -19,5 +19,14 @@ pub use engine::{
     RangeScanBatch, Retention, Sequence, StoreEngine,
 };
 pub use reduce::RangeError;
-pub use stream::{CompiledMatchers, StreamHub, StreamNotification, StreamNotifier};
+pub use stream::{CompiledMatchers, InvalidFilter, StreamHub, StreamNotification, StreamNotifier};
 pub use validate::{IngestLimits, DEFAULT_MAX_VALUE_LEN};
+
+/// Types used by filtered-batch and matcher APIs, re-exported so backends can
+/// use the server API without a version-matched direct SDK dependency.
+pub use exoware_sdk::{
+    common::kv::v1::Entry,
+    kv_codec::Utf8,
+    selector::Selector,
+    stream_filter::{Filter, StreamFilter},
+};

--- a/server/src/stream.rs
+++ b/server/src/stream.rs
@@ -31,16 +31,40 @@ pub const REASON_BATCH_NOT_FOUND: &str = "BATCH_NOT_FOUND";
 /// Metadata key on `BATCH_EVICTED` errors carrying the lowest retained seq.
 pub const METADATA_OLDEST_RETAINED: &str = "oldest_retained";
 
-#[derive(Clone)]
-pub(crate) struct CompiledKeyMatcher {
+#[derive(Clone, Debug)]
+struct CompiledKeyMatcher {
     prefix: Prefix,
     regex: Regex,
 }
 
-#[derive(Clone)]
-pub(crate) struct CompiledMatchers {
-    pub keys: Vec<CompiledKeyMatcher>,
-    pub values: Option<CompiledFilters>,
+/// Validated stream matchers compiled for repeated evaluation.
+#[derive(Clone, Debug)]
+pub struct CompiledMatchers {
+    keys: Vec<CompiledKeyMatcher>,
+    values: Option<CompiledFilters>,
+}
+
+impl CompiledMatchers {
+    /// Return whether any selector matches the key.
+    ///
+    /// Selector regular expressions evaluate bytes after the matching prefix.
+    pub fn matches_key(&self, key: &[u8]) -> bool {
+        self.keys.iter().any(|matcher| {
+            matcher
+                .prefix
+                .strip_slice(key)
+                .is_some_and(|payload| matcher.regex.is_match(payload))
+        })
+    }
+
+    /// Return whether the configured value filters match the value.
+    ///
+    /// Values pass when no value filter is configured.
+    pub fn matches_value(&self, value: &[u8]) -> bool {
+        self.values
+            .as_ref()
+            .is_none_or(|matcher| matcher.matches(value))
+    }
 }
 
 /// Validate and compile a `StreamFilter`. Shared between replay and live
@@ -64,26 +88,13 @@ pub(crate) fn compile_matchers(filter: &StreamFilter) -> Result<CompiledMatchers
     Ok(CompiledMatchers { keys, values })
 }
 
-/// Apply a compiled filter to a batch. First-match-wins per entry.
-pub(crate) fn apply_filter(matchers: &CompiledMatchers, kvs: &[Entry]) -> Vec<Entry> {
-    let mut out = Vec::with_capacity(kvs.len());
-    'outer: for kv in kvs {
-        let v = kv.value.as_ref();
-        let value_ok = matchers.values.as_ref().is_none_or(|m| m.matches(v));
-        if !value_ok {
-            continue;
-        }
-        for matcher in &matchers.keys {
-            let Some(payload) = matcher.prefix.strip_slice(&kv.key) else {
-                continue;
-            };
-            if matcher.regex.is_match(payload) {
-                out.push(kv.clone());
-                continue 'outer;
-            }
-        }
-    }
-    out
+/// Apply compiled matchers while consuming the source entries.
+pub(crate) fn apply_filter(matchers: &CompiledMatchers, kvs: Vec<Entry>) -> Vec<Entry> {
+    kvs.into_iter()
+        .filter(|kv| {
+            matchers.matches_value(kv.value.as_ref()) && matchers.matches_key(kv.key.as_ref())
+        })
+        .collect()
 }
 
 #[derive(Clone)]
@@ -205,7 +216,7 @@ mod tests {
     fn apply_filter_still_selects_matching_entries() {
         let matchers = compile_matchers(&filter(1, "(?s).*")).unwrap();
         let kvs = vec![kv(1, b"hit", b"v1"), kv(2, b"miss", b"v2")];
-        let entries = apply_filter(&matchers, &kvs);
+        let entries = apply_filter(&matchers, kvs);
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].value.as_ref(), b"v1");
     }
@@ -228,7 +239,7 @@ mod tests {
         ))
         .unwrap();
         let kvs = vec![kv(1, b"a", b"keep"), kv(1, b"b", b"drop")];
-        let entries = apply_filter(&matchers, &kvs);
+        let entries = apply_filter(&matchers, kvs);
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].value.as_ref(), b"keep");
     }
@@ -242,7 +253,7 @@ mod tests {
         ))
         .unwrap();
         let kvs = vec![kv(1, b"a", b"target"), kv(1, b"b", b"other")];
-        let entries = apply_filter(&matchers, &kvs);
+        let entries = apply_filter(&matchers, kvs);
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].value.as_ref(), b"target");
     }
@@ -251,7 +262,32 @@ mod tests {
     fn value_filter_empty_accepts_all_matching_keys() {
         let matchers = compile_matchers(&filter(1, "(?s).*")).unwrap();
         let kvs = vec![kv(1, b"a", b"one"), kv(1, b"b", b"two")];
-        let entries = apply_filter(&matchers, &kvs);
+        let entries = apply_filter(&matchers, kvs);
         assert_eq!(entries.len(), 2);
+    }
+
+    #[test]
+    fn matcher_methods_preserve_key_and_value_semantics() {
+        let matchers = compile_matchers(&filter_with_values(
+            1,
+            "^hit$",
+            vec![
+                Filter::Prefix(Bytes::from_static(b"keep")),
+                Filter::Exact(Bytes::from_static(b"exact")),
+                Filter::Regex("^regex$".into()),
+            ],
+        ))
+        .unwrap();
+
+        assert!(matchers.matches_key(key(1, b"hit").as_ref()));
+        assert!(!matchers.matches_key(key(1, b"miss").as_ref()));
+        assert!(!matchers.matches_key(key(2, b"hit").as_ref()));
+        assert!(matchers.matches_value(b"keep-suffix"));
+        assert!(matchers.matches_value(b"exact"));
+        assert!(matchers.matches_value(b"regex"));
+        assert!(!matchers.matches_value(b"drop"));
+
+        let without_value_filters = compile_matchers(&filter(1, "(?s).*")).unwrap();
+        assert!(without_value_filters.matches_value(b"anything"));
     }
 }

--- a/server/src/stream.rs
+++ b/server/src/stream.rs
@@ -37,6 +37,14 @@ struct CompiledKeyMatcher {
     regex: Regex,
 }
 
+/// A stream filter rejected during validation or compilation.
+///
+/// Messages describe the invalid selector or value filter and are safe to
+/// surface to clients.
+#[derive(Clone, Debug, thiserror::Error)]
+#[error("{0}")]
+pub struct InvalidFilter(String);
+
 /// Validated stream matchers compiled for repeated evaluation.
 #[derive(Clone, Debug)]
 pub struct CompiledMatchers {
@@ -45,6 +53,35 @@ pub struct CompiledMatchers {
 }
 
 impl CompiledMatchers {
+    /// Validate and compile a `StreamFilter`.
+    pub fn compile(filter: &StreamFilter) -> Result<Self, InvalidFilter> {
+        validate_filter(filter).map_err(|e| InvalidFilter(e.to_string()))?;
+        let keys = filter
+            .selectors
+            .iter()
+            .map(|mk| {
+                let regex = compile_payload_regex(&mk.payload_regex)
+                    .map_err(|e| InvalidFilter(e.to_string()))?;
+                let prefix =
+                    Prefix::new(mk.prefix.clone()).map_err(|e| InvalidFilter(e.to_string()))?;
+                Ok(CompiledKeyMatcher { prefix, regex })
+            })
+            .collect::<Result<Vec<_>, InvalidFilter>>()?;
+        let values = CompiledFilters::compile(&filter.value_filters)
+            .map_err(|e| InvalidFilter(format!("invalid value_filter: {e}")))?;
+        Ok(Self { keys, values })
+    }
+
+    /// Return whether both predicates accept an already-resolved entry.
+    ///
+    /// The key predicate runs first, so key-excluded entries avoid the
+    /// value-filter scan. Implementations that resolve values lazily must call
+    /// [`Self::matches_key`] before resolving the value and
+    /// [`Self::matches_value`] afterward.
+    pub fn matches(&self, key: &[u8], value: &[u8]) -> bool {
+        self.matches_key(key) && self.matches_value(value)
+    }
+
     /// Return whether any selector matches the key.
     ///
     /// Selector regular expressions evaluate bytes after the matching prefix.
@@ -71,29 +108,13 @@ impl CompiledMatchers {
 /// delivery so both paths match identically and regexes are compiled once per
 /// subscribe.
 pub(crate) fn compile_matchers(filter: &StreamFilter) -> Result<CompiledMatchers, ConnectError> {
-    validate_filter(filter).map_err(|e| ConnectError::invalid_argument(e.to_string()))?;
-    let keys = filter
-        .selectors
-        .iter()
-        .map(|mk| {
-            let regex = compile_payload_regex(&mk.payload_regex)
-                .map_err(|e| ConnectError::invalid_argument(e.to_string()))?;
-            let prefix = Prefix::new(mk.prefix.clone())
-                .map_err(|e| ConnectError::invalid_argument(e.to_string()))?;
-            Ok(CompiledKeyMatcher { prefix, regex })
-        })
-        .collect::<Result<Vec<_>, ConnectError>>()?;
-    let values = CompiledFilters::compile(&filter.value_filters)
-        .map_err(|e| ConnectError::invalid_argument(format!("invalid value_filter: {e}")))?;
-    Ok(CompiledMatchers { keys, values })
+    CompiledMatchers::compile(filter).map_err(|e| ConnectError::invalid_argument(e.to_string()))
 }
 
 /// Apply compiled matchers while consuming the source entries.
 pub(crate) fn apply_filter(matchers: &CompiledMatchers, kvs: Vec<Entry>) -> Vec<Entry> {
     kvs.into_iter()
-        .filter(|kv| {
-            matchers.matches_value(kv.value.as_ref()) && matchers.matches_key(kv.key.as_ref())
-        })
+        .filter(|kv| matchers.matches(kv.key.as_ref(), kv.value.as_ref()))
         .collect()
 }
 
@@ -157,11 +178,9 @@ impl StreamNotifier for StreamHub {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{Filter, Selector, StreamFilter, Utf8};
     use bytes::Bytes;
     use exoware_sdk::keys::Key;
-    use exoware_sdk::kv_codec::Utf8;
-    use exoware_sdk::selector::Selector;
-    use exoware_sdk::stream_filter::Filter;
 
     fn filter(prefix: u8, regex: &str) -> StreamFilter {
         StreamFilter {
@@ -264,6 +283,98 @@ mod tests {
         let kvs = vec![kv(1, b"a", b"one"), kv(1, b"b", b"two")];
         let entries = apply_filter(&matchers, kvs);
         assert_eq!(entries.len(), 2);
+    }
+
+    // Verbatim copy of the pre-refactor apply_filter loop. The differential
+    // test below pins the rewrite to the old first-match-wins semantics.
+    fn apply_filter_reference(matchers: &CompiledMatchers, kvs: &[Entry]) -> Vec<Entry> {
+        let mut out = Vec::with_capacity(kvs.len());
+        'outer: for kv in kvs {
+            let v = kv.value.as_ref();
+            let value_ok = matchers.values.as_ref().is_none_or(|m| m.matches(v));
+            if !value_ok {
+                continue;
+            }
+            for matcher in &matchers.keys {
+                let Some(payload) = matcher.prefix.strip_slice(&kv.key) else {
+                    continue;
+                };
+                if matcher.regex.is_match(payload) {
+                    out.push(kv.clone());
+                    continue 'outer;
+                }
+            }
+        }
+        out
+    }
+
+    #[test]
+    fn apply_filter_matches_reference_implementation() {
+        let overlapping = StreamFilter {
+            selectors: vec![
+                Selector {
+                    prefix: Bytes::from_static(&[1]),
+                    payload_regex: Utf8::from("^a"),
+                },
+                Selector {
+                    prefix: Bytes::from_static(&[1]),
+                    payload_regex: Utf8::from("b$"),
+                },
+                Selector {
+                    prefix: Bytes::from_static(&[2]),
+                    payload_regex: Utf8::from("(?s).*"),
+                },
+            ],
+            value_filters: vec![],
+        };
+        let with_values = StreamFilter {
+            value_filters: vec![
+                Filter::Prefix(Bytes::from_static(b"keep")),
+                Filter::Exact(Bytes::from_static(b"exact")),
+                Filter::Regex("^regex$".into()),
+            ],
+            ..overlapping.clone()
+        };
+        let entries = vec![
+            // Matches both prefix-1 selectors and must appear exactly once.
+            kv(1, b"ab", b"keep-anything"),
+            kv(1, b"aX", b"exact"),
+            kv(1, b"Xb", b"regex"),
+            kv(1, b"XX", b"keep"),
+            kv(1, b"", b"keep"),
+            kv(2, b"", b"exact"),
+            kv(2, b"anything", b"drop"),
+            kv(3, b"ab", b"keep"),
+            // Duplicate entry preserves multiplicity.
+            kv(1, b"ab", b"keep-anything"),
+            kv(1, b"ab", b"nope"),
+        ];
+
+        for filter in [overlapping, with_values] {
+            let matchers = compile_matchers(&filter).unwrap();
+            let expected = apply_filter_reference(&matchers, &entries);
+            let actual = apply_filter(&matchers, entries.clone());
+            assert_eq!(actual, expected);
+        }
+    }
+
+    #[test]
+    fn public_compile_builds_usable_matchers_and_rejects_invalid_filters() {
+        let matchers = CompiledMatchers::compile(&filter_with_values(
+            1,
+            "^hit$",
+            vec![Filter::Exact(Bytes::from_static(b"v"))],
+        ))
+        .expect("compile");
+        assert!(matchers.matches(key(1, b"hit").as_ref(), b"v"));
+        assert!(!matchers.matches(key(1, b"miss").as_ref(), b"v"));
+        assert!(!matchers.matches(key(1, b"hit").as_ref(), b"other"));
+
+        let invalid = StreamFilter {
+            selectors: vec![],
+            value_filters: vec![],
+        };
+        assert!(CompiledMatchers::compile(&invalid).is_err());
     }
 
     #[test]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the subscribe/replay hot path and adds a new `Log` contract backends may implement; behavior is heavily tested but wrong overrides could affect filtering or cursor semantics.
> 
> **Overview**
> **Subscribe** now loads replay and live batches through **`Log::get_batch_filtered`** instead of decoding full batches and filtering in the Connect layer. **`FilteredBatch`** carries only matching entries; **`SubscribeResponse.sequence_number`** comes from the **requested** sequence (paired on the read stream), not from stored batch metadata—so custom backends cannot mis-stamp resume cursors.
> 
> **`Get`** still uses unfiltered **`get_batch`**. The default **`get_batch_filtered`** implementation decodes and applies matchers; engines can override to filter without materializing whole batches (e.g. key-before-value resolution per trait docs).
> 
> **Public API for backends:** **`CompiledMatchers`** (`compile`, `matches_key` / `matches_value`), **`InvalidFilter`**, **`FilteredBatch`**, and re-exported **`StreamFilter`** / selector types from **`lib`**. Matcher application in **`apply_filter`** is aligned with a differential test against the old loop.
> 
> New connect tests cover filtered vs unfiltered dispatch, evicted/malformed replay setup and stream errors, all-filtered replay skipping to live, and lookahead with a custom filtered override.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 783f477f8e98af3acf3a84bec500ba195b70dab1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->