### PR TITLE
Update Commonware to `dfe4c5a9ab89edb1e64052aa931498d6552444d9`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,7 +11,7 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   UDEPS_VERSION: 0.1.57
-  NIGHTLY_VERSION: nightly-2025-11-15
+  NIGHTLY_VERSION: nightly-2026-06-21
 
 jobs:
   lint:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,12 +10,12 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aead"
-version = "0.5.2"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+checksum = "1973cfbc1a2daf9cf550e74e1f088c28e7f7d8c1e1418fb6c9dc5184b7e84c99"
 dependencies = [
- "crypto-common 0.1.7",
- "generic-array",
+ "crypto-common 0.2.2",
+ "inout",
 ]
 
 [[package]]
@@ -54,6 +54,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e76a019e91224d279006ff972f1e984179a6e9feb050adba6ce8274aef23195"
 dependencies = [
  "alloc-no-stdlib",
+]
+
+[[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -540,7 +549,7 @@ dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "regex",
@@ -765,37 +774,26 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
-dependencies = [
- "cfg-if",
- "cipher",
- "cpufeatures 0.2.17",
-]
-
-[[package]]
-name = "chacha20"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
+ "cipher",
  "cpufeatures 0.3.0",
  "rand_core 0.10.1",
 ]
 
 [[package]]
 name = "chacha20poly1305"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+checksum = "9b89e1c441e926b9c82a8d023f6e1b7ae0adcfaa7d621814e4d60789bac751cb"
 dependencies = [
  "aead",
- "chacha20 0.9.1",
+ "chacha20",
  "cipher",
  "poly1305",
- "zeroize",
 ]
 
 [[package]]
@@ -809,7 +807,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -851,13 +849,13 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.4.4"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
 dependencies = [
- "crypto-common 0.1.7",
+ "block-buffer 0.12.1",
+ "crypto-common 0.2.2",
  "inout",
- "zeroize",
 ]
 
 [[package]]
@@ -922,12 +920,6 @@ dependencies = [
 
 [[package]]
 name = "cmov"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d5ce5728ecb5285a5dd35f02a6a8e34e0828e0b38e8e632e249a3fe3f320211"
-
-[[package]]
-name = "cmov"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
@@ -961,7 +953,7 @@ dependencies = [
 [[package]]
 name = "commonware-actor"
 version = "2026.7.0"
-source = "git+https://github.com/commonwarexyz/monorepo.git?rev=5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7#5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7"
+source = "git+https://github.com/commonwarexyz/monorepo.git?rev=dfe4c5a9ab89edb1e64052aa931498d6552444d9#dfe4c5a9ab89edb1e64052aa931498d6552444d9"
 dependencies = [
  "cfg-if",
  "commonware-macros",
@@ -974,7 +966,7 @@ dependencies = [
 [[package]]
 name = "commonware-broadcast"
 version = "2026.7.0"
-source = "git+https://github.com/commonwarexyz/monorepo.git?rev=5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7#5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7"
+source = "git+https://github.com/commonwarexyz/monorepo.git?rev=dfe4c5a9ab89edb1e64052aa931498d6552444d9#dfe4c5a9ab89edb1e64052aa931498d6552444d9"
 dependencies = [
  "commonware-actor",
  "commonware-codec",
@@ -990,7 +982,7 @@ dependencies = [
 [[package]]
 name = "commonware-codec"
 version = "2026.7.0"
-source = "git+https://github.com/commonwarexyz/monorepo.git?rev=5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7#5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7"
+source = "git+https://github.com/commonwarexyz/monorepo.git?rev=dfe4c5a9ab89edb1e64052aa931498d6552444d9#dfe4c5a9ab89edb1e64052aa931498d6552444d9"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -1004,7 +996,7 @@ dependencies = [
 [[package]]
 name = "commonware-codec-macros"
 version = "2026.7.0"
-source = "git+https://github.com/commonwarexyz/monorepo.git?rev=5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7#5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7"
+source = "git+https://github.com/commonwarexyz/monorepo.git?rev=dfe4c5a9ab89edb1e64052aa931498d6552444d9#dfe4c5a9ab89edb1e64052aa931498d6552444d9"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -1015,7 +1007,7 @@ dependencies = [
 [[package]]
 name = "commonware-coding"
 version = "2026.7.0"
-source = "git+https://github.com/commonwarexyz/monorepo.git?rev=5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7#5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7"
+source = "git+https://github.com/commonwarexyz/monorepo.git?rev=dfe4c5a9ab89edb1e64052aa931498d6552444d9#dfe4c5a9ab89edb1e64052aa931498d6552444d9"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -1033,7 +1025,7 @@ dependencies = [
 [[package]]
 name = "commonware-consensus"
 version = "2026.7.0"
-source = "git+https://github.com/commonwarexyz/monorepo.git?rev=5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7#5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7"
+source = "git+https://github.com/commonwarexyz/monorepo.git?rev=dfe4c5a9ab89edb1e64052aa931498d6552444d9#dfe4c5a9ab89edb1e64052aa931498d6552444d9"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -1064,7 +1056,7 @@ dependencies = [
 [[package]]
 name = "commonware-cryptography"
 version = "2026.7.0"
-source = "git+https://github.com/commonwarexyz/monorepo.git?rev=5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7#5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7"
+source = "git+https://github.com/commonwarexyz/monorepo.git?rev=dfe4c5a9ab89edb1e64052aa931498d6552444d9#dfe4c5a9ab89edb1e64052aa931498d6552444d9"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1080,15 +1072,15 @@ dependencies = [
  "commonware-math",
  "commonware-parallel",
  "commonware-utils",
- "cpufeatures 0.2.17",
+ "cpufeatures 0.3.0",
  "crc-fast",
- "ctutils 0.3.1",
+ "ctutils",
  "curve25519-dalek",
  "ecdsa",
  "fixedbitset",
  "getrandom 0.2.17",
  "getrandom 0.4.3",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "num-rational",
  "num-traits",
  "once_cell",
@@ -1105,7 +1097,7 @@ dependencies = [
 [[package]]
 name = "commonware-formatting"
 version = "2026.7.0"
-source = "git+https://github.com/commonwarexyz/monorepo.git?rev=5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7#5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7"
+source = "git+https://github.com/commonwarexyz/monorepo.git?rev=dfe4c5a9ab89edb1e64052aa931498d6552444d9#dfe4c5a9ab89edb1e64052aa931498d6552444d9"
 dependencies = [
  "commonware-macros",
  "const-hex",
@@ -1114,14 +1106,16 @@ dependencies = [
 [[package]]
 name = "commonware-glue"
 version = "2026.7.0"
-source = "git+https://github.com/commonwarexyz/monorepo.git?rev=5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7#5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7"
+source = "git+https://github.com/commonwarexyz/monorepo.git?rev=dfe4c5a9ab89edb1e64052aa931498d6552444d9#dfe4c5a9ab89edb1e64052aa931498d6552444d9"
 dependencies = [
  "bytes",
  "commonware-actor",
+ "commonware-broadcast",
  "commonware-codec",
  "commonware-consensus",
  "commonware-cryptography",
  "commonware-macros",
+ "commonware-math",
  "commonware-p2p",
  "commonware-parallel",
  "commonware-resolver",
@@ -1138,7 +1132,7 @@ dependencies = [
 [[package]]
 name = "commonware-macros"
 version = "2026.7.0"
-source = "git+https://github.com/commonwarexyz/monorepo.git?rev=5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7#5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7"
+source = "git+https://github.com/commonwarexyz/monorepo.git?rev=dfe4c5a9ab89edb1e64052aa931498d6552444d9#dfe4c5a9ab89edb1e64052aa931498d6552444d9"
 dependencies = [
  "commonware-macros-impl",
  "tokio",
@@ -1147,7 +1141,7 @@ dependencies = [
 [[package]]
 name = "commonware-macros-impl"
 version = "2026.7.0"
-source = "git+https://github.com/commonwarexyz/monorepo.git?rev=5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7#5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7"
+source = "git+https://github.com/commonwarexyz/monorepo.git?rev=dfe4c5a9ab89edb1e64052aa931498d6552444d9#dfe4c5a9ab89edb1e64052aa931498d6552444d9"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -1159,7 +1153,7 @@ dependencies = [
 [[package]]
 name = "commonware-math"
 version = "2026.7.0"
-source = "git+https://github.com/commonwarexyz/monorepo.git?rev=5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7#5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7"
+source = "git+https://github.com/commonwarexyz/monorepo.git?rev=dfe4c5a9ab89edb1e64052aa931498d6552444d9#dfe4c5a9ab89edb1e64052aa931498d6552444d9"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -1172,7 +1166,7 @@ dependencies = [
 [[package]]
 name = "commonware-p2p"
 version = "2026.7.0"
-source = "git+https://github.com/commonwarexyz/monorepo.git?rev=5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7#5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7"
+source = "git+https://github.com/commonwarexyz/monorepo.git?rev=dfe4c5a9ab89edb1e64052aa931498d6552444d9#dfe4c5a9ab89edb1e64052aa931498d6552444d9"
 dependencies = [
  "commonware-actor",
  "commonware-codec",
@@ -1198,7 +1192,7 @@ dependencies = [
 [[package]]
 name = "commonware-parallel"
 version = "2026.7.0"
-source = "git+https://github.com/commonwarexyz/monorepo.git?rev=5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7#5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7"
+source = "git+https://github.com/commonwarexyz/monorepo.git?rev=dfe4c5a9ab89edb1e64052aa931498d6552444d9#dfe4c5a9ab89edb1e64052aa931498d6552444d9"
 dependencies = [
  "cfg-if",
  "commonware-macros",
@@ -1210,7 +1204,7 @@ dependencies = [
 [[package]]
 name = "commonware-resolver"
 version = "2026.7.0"
-source = "git+https://github.com/commonwarexyz/monorepo.git?rev=5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7#5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7"
+source = "git+https://github.com/commonwarexyz/monorepo.git?rev=dfe4c5a9ab89edb1e64052aa931498d6552444d9#dfe4c5a9ab89edb1e64052aa931498d6552444d9"
 dependencies = [
  "bytes",
  "commonware-actor",
@@ -1231,7 +1225,7 @@ dependencies = [
 [[package]]
 name = "commonware-runtime"
 version = "2026.7.0"
-source = "git+https://github.com/commonwarexyz/monorepo.git?rev=5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7#5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7"
+source = "git+https://github.com/commonwarexyz/monorepo.git?rev=dfe4c5a9ab89edb1e64052aa931498d6552444d9#dfe4c5a9ab89edb1e64052aa931498d6552444d9"
 dependencies = [
  "ahash",
  "axum",
@@ -1244,7 +1238,7 @@ dependencies = [
  "commonware-parallel",
  "commonware-runtime-macros",
  "commonware-utils",
- "criterion 0.7.0",
+ "criterion 0.8.2",
  "crossbeam-utils",
  "futures",
  "getrandom 0.2.17",
@@ -1270,7 +1264,7 @@ dependencies = [
 [[package]]
 name = "commonware-runtime-macros"
 version = "2026.7.0"
-source = "git+https://github.com/commonwarexyz/monorepo.git?rev=5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7#5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7"
+source = "git+https://github.com/commonwarexyz/monorepo.git?rev=dfe4c5a9ab89edb1e64052aa931498d6552444d9#dfe4c5a9ab89edb1e64052aa931498d6552444d9"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -1281,7 +1275,7 @@ dependencies = [
 [[package]]
 name = "commonware-storage"
 version = "2026.7.0"
-source = "git+https://github.com/commonwarexyz/monorepo.git?rev=5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7#5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7"
+source = "git+https://github.com/commonwarexyz/monorepo.git?rev=dfe4c5a9ab89edb1e64052aa931498d6552444d9#dfe4c5a9ab89edb1e64052aa931498d6552444d9"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1296,7 +1290,7 @@ dependencies = [
  "commonware-utils",
  "futures",
  "futures-util",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "thiserror",
  "tracing",
  "zstd",
@@ -1305,7 +1299,7 @@ dependencies = [
 [[package]]
 name = "commonware-stream"
 version = "2026.7.0"
-source = "git+https://github.com/commonwarexyz/monorepo.git?rev=5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7#5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7"
+source = "git+https://github.com/commonwarexyz/monorepo.git?rev=dfe4c5a9ab89edb1e64052aa931498d6552444d9#dfe4c5a9ab89edb1e64052aa931498d6552444d9"
 dependencies = [
  "chacha20poly1305",
  "commonware-codec",
@@ -1324,11 +1318,10 @@ dependencies = [
 [[package]]
 name = "commonware-utils"
 version = "2026.7.0"
-source = "git+https://github.com/commonwarexyz/monorepo.git?rev=5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7#5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7"
+source = "git+https://github.com/commonwarexyz/monorepo.git?rev=dfe4c5a9ab89edb1e64052aa931498d6552444d9#dfe4c5a9ab89edb1e64052aa931498d6552444d9"
 dependencies = [
  "ahash",
  "bytes",
- "cfg-if",
  "commonware-codec",
  "commonware-formatting",
  "commonware-macros",
@@ -1336,7 +1329,7 @@ dependencies = [
  "getrandom 0.2.17",
  "getrandom 0.3.4",
  "getrandom 0.4.3",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "num-bigint",
  "num-integer",
  "num-rational",
@@ -1602,18 +1595,20 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.7.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1c047a62b0cc3e145fa84415a3191f628e980b194c2755aa12300a4e6cbd928"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
 dependencies = [
+ "alloca",
  "anes",
  "cast",
  "ciborium",
  "clap",
- "criterion-plot 0.6.0",
+ "criterion-plot 0.8.2",
  "itertools 0.13.0",
  "num-traits",
  "oorandom",
+ "page_size",
  "plotters",
  "rayon",
  "regex",
@@ -1635,9 +1630,9 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.6.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b1bcc0dc7dfae599d84ad0b1a55f80cde8af3725da8313b528da95ef783e338"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
 dependencies = [
  "cast",
  "itertools 0.13.0",
@@ -1690,7 +1685,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a52aa3fcda4e6302a9f48734f234d35d4721b96f8fe07d073f07ce9df4f0271"
 dependencies = [
  "cpubits",
- "ctutils 0.4.2",
+ "ctutils",
  "getrandom 0.4.3",
  "hybrid-array",
  "num-traits",
@@ -1706,7 +1701,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
- "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -1744,20 +1738,11 @@ dependencies = [
 
 [[package]]
 name = "ctutils"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c67c81499f542d1dd38c6a2a2fe825f4dd4bca5162965dd2eea0c8119873d3c"
-dependencies = [
- "cmov 0.4.6",
-]
-
-[[package]]
-name = "ctutils"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
 dependencies = [
- "cmov 0.5.4",
+ "cmov",
  "subtle",
 ]
 
@@ -2491,7 +2476,17 @@ dependencies = [
  "block-buffer 0.12.1",
  "const-oid",
  "crypto-common 0.2.2",
- "ctutils 0.4.2",
+ "ctutils",
+]
+
+[[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags",
+ "objc2",
 ]
 
 [[package]]
@@ -3170,6 +3165,9 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "heck"
@@ -3334,7 +3332,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -3461,11 +3459,11 @@ dependencies = [
 
 [[package]]
 name = "inout"
-version = "0.1.4"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -3544,7 +3542,7 @@ dependencies = [
  "simd_cesu8",
  "thiserror",
  "walkdir",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -3682,7 +3680,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -3977,12 +3975,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
 name = "objc2-core-foundation"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags",
+ "objc2",
 ]
 
 [[package]]
@@ -3993,6 +4018,17 @@ checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
 dependencies = [
  "libc",
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-open-directory"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb82bed227edf5201dfedf072bba4015a33d3d4a98519837295a90f0a23f676d"
+dependencies = [
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -4045,12 +4081,6 @@ name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
-
-[[package]]
-name = "opaque-debug"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl-probe"
@@ -4153,6 +4183,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4172,7 +4212,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -4326,12 +4366,11 @@ dependencies = [
 
 [[package]]
 name = "poly1305"
-version = "0.8.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+checksum = "6e2d0073b297041425c7c3df6eb4792d598a15323fe63346852b092eca02904c"
 dependencies = [
- "cpufeatures 0.2.17",
- "opaque-debug",
+ "cpufeatures 0.3.0",
  "universal-hash",
 ]
 
@@ -4422,9 +4461,9 @@ dependencies = [
 
 [[package]]
 name = "prometheus-client"
-version = "0.24.1"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cca3d75b4566b9a29fe1ed623587fb058e826eb329a0be4b7c4da1ebb2d7a6ca"
+checksum = "ba70bf887030e45213b4a95c9b08d5a450b157f87c1d63661ed0847a12fa2aad"
 dependencies = [
  "dtoa",
  "itoa",
@@ -4475,7 +4514,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn",
@@ -4615,7 +4654,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
- "chacha20 0.10.1",
+ "chacha20",
  "getrandom 0.4.3",
  "rand_core 0.10.1",
 ]
@@ -4638,15 +4677,6 @@ checksum = "3e6af7f3e25ded52c41df4e0b1af2d047e45896c2f3281792ed68a1c243daedb"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.10.1",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -5002,7 +5032,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d56d437c2f19203ce5f7122e507831de96f3d2d4d3be5af44a0b0a09d8a80e4d"
 dependencies = [
  "base16ct",
- "ctutils 0.4.2",
+ "ctutils",
  "der",
  "hybrid-array",
  "subtle",
@@ -5339,9 +5369,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.118"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5370,15 +5400,16 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.37.2"
+version = "0.39.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16607d5caffd1c07ce073528f9ed972d88db15dd44023fa57142963be3feb11f"
+checksum = "d2071df9448915b71c4fe6d25deaf1c22f12bd234f01540b77312bb8e41361e6"
 dependencies = [
  "libc",
  "memchr",
  "ntapi",
  "objc2-core-foundation",
  "objc2-io-kit",
+ "objc2-open-directory",
  "windows",
 ]
 
@@ -5603,26 +5634,17 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.12+spec-1.1.0"
+version = "1.1.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
 dependencies = [
  "indexmap",
  "serde_core",
  "serde_spanned",
- "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_datetime",
  "toml_parser",
  "toml_writer",
- "winnow 0.7.15",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.7.5+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
-dependencies = [
- "serde_core",
+ "winnow",
 ]
 
 [[package]]
@@ -5641,25 +5663,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
 dependencies = [
  "indexmap",
- "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_datetime",
  "toml_parser",
- "winnow 1.0.3",
+ "winnow",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
- "winnow 1.0.3",
+ "winnow",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.1.1+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tower"
@@ -5859,12 +5881,12 @@ checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "universal-hash"
-version = "0.5.1"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+checksum = "f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96"
 dependencies = [
- "crypto-common 0.1.7",
- "subtle",
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -6083,37 +6105,23 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.61.3"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
  "windows-collections",
- "windows-core 0.61.2",
+ "windows-core",
  "windows-future",
- "windows-link 0.1.3",
  "windows-numerics",
 ]
 
 [[package]]
 name = "windows-collections"
-version = "0.2.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-core 0.61.2",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.61.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
- "windows-strings 0.4.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -6124,19 +6132,19 @@ checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
 name = "windows-future"
-version = "0.2.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
- "windows-core 0.61.2",
- "windows-link 0.1.3",
+ "windows-core",
+ "windows-link",
  "windows-threading",
 ]
 
@@ -6164,24 +6172,18 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
-
-[[package]]
-name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-numerics"
-version = "0.2.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-core 0.61.2",
- "windows-link 0.1.3",
+ "windows-core",
+ "windows-link",
 ]
 
 [[package]]
@@ -6190,18 +6192,9 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
-dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
@@ -6210,16 +6203,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link 0.2.1",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
-dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
@@ -6228,7 +6212,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -6246,7 +6230,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -6267,11 +6251,11 @@ dependencies = [
 
 [[package]]
 name = "windows-threading"
-version = "0.1.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
@@ -6321,12 +6305,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "winnow"
-version = "0.7.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,18 +35,18 @@ axum = "0.8.1"
 base64 = "0.22.1"
 hex = "0.4"
 regex = "1"
-commonware-codec = { git = "https://github.com/commonwarexyz/monorepo.git", rev = "5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7" }
-commonware-actor = { git = "https://github.com/commonwarexyz/monorepo.git", rev = "5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7" }
-commonware-consensus = { git = "https://github.com/commonwarexyz/monorepo.git", rev = "5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7" }
-commonware-cryptography = { git = "https://github.com/commonwarexyz/monorepo.git", rev = "5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7" }
-commonware-glue = { git = "https://github.com/commonwarexyz/monorepo.git", rev = "5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7" }
-commonware-math = { git = "https://github.com/commonwarexyz/monorepo.git", rev = "5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7" }
-commonware-parallel = { git = "https://github.com/commonwarexyz/monorepo.git", rev = "5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7" }
-commonware-p2p = { git = "https://github.com/commonwarexyz/monorepo.git", rev = "5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7" }
-commonware-resolver = { git = "https://github.com/commonwarexyz/monorepo.git", rev = "5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7" }
-commonware-runtime = { git = "https://github.com/commonwarexyz/monorepo.git", rev = "5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7" }
-commonware-storage = { git = "https://github.com/commonwarexyz/monorepo.git", rev = "5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7" }
-commonware-utils = { git = "https://github.com/commonwarexyz/monorepo.git", rev = "5ad08eaf2035796e5b01114e8f9fbdb79ff4cef7" }
+commonware-codec = { git = "https://github.com/commonwarexyz/monorepo.git", rev = "dfe4c5a9ab89edb1e64052aa931498d6552444d9" }
+commonware-actor = { git = "https://github.com/commonwarexyz/monorepo.git", rev = "dfe4c5a9ab89edb1e64052aa931498d6552444d9" }
+commonware-consensus = { git = "https://github.com/commonwarexyz/monorepo.git", rev = "dfe4c5a9ab89edb1e64052aa931498d6552444d9" }
+commonware-cryptography = { git = "https://github.com/commonwarexyz/monorepo.git", rev = "dfe4c5a9ab89edb1e64052aa931498d6552444d9" }
+commonware-glue = { git = "https://github.com/commonwarexyz/monorepo.git", rev = "dfe4c5a9ab89edb1e64052aa931498d6552444d9" }
+commonware-math = { git = "https://github.com/commonwarexyz/monorepo.git", rev = "dfe4c5a9ab89edb1e64052aa931498d6552444d9" }
+commonware-parallel = { git = "https://github.com/commonwarexyz/monorepo.git", rev = "dfe4c5a9ab89edb1e64052aa931498d6552444d9" }
+commonware-p2p = { git = "https://github.com/commonwarexyz/monorepo.git", rev = "dfe4c5a9ab89edb1e64052aa931498d6552444d9" }
+commonware-resolver = { git = "https://github.com/commonwarexyz/monorepo.git", rev = "dfe4c5a9ab89edb1e64052aa931498d6552444d9" }
+commonware-runtime = { git = "https://github.com/commonwarexyz/monorepo.git", rev = "dfe4c5a9ab89edb1e64052aa931498d6552444d9" }
+commonware-storage = { git = "https://github.com/commonwarexyz/monorepo.git", rev = "dfe4c5a9ab89edb1e64052aa931498d6552444d9" }
+commonware-utils = { git = "https://github.com/commonwarexyz/monorepo.git", rev = "dfe4c5a9ab89edb1e64052aa931498d6552444d9" }
 rocksdb = "0.24.0"
 mimalloc = "0.1.52"
 rand = "0.10.2"

--- a/qmdb/rs/src/auth.rs
+++ b/qmdb/rs/src/auth.rs
@@ -8,7 +8,8 @@ use exoware_sdk::{RangeMode, SerializableReadSession};
 use crate::codec::{
     decode_digest, decode_operation_location_key, decode_watermark_location, encode_node_key,
     encode_operation_key, encode_presence_key, encode_update_index_value, encode_update_key,
-    encode_watermark_key, ensure_encoded_value_size, merkle_size_for_watermark, WATERMARK_PREFIX,
+    encode_watermark_key, ensure_encoded_value_size, merkle_size_for_watermark,
+    op_count_for_watermark, WATERMARK_PREFIX,
 };
 use crate::error::QmdbError;
 
@@ -156,7 +157,7 @@ pub(crate) fn auth_inactive_peaks<F: Family>(
     inactivity_floor: Location<F>,
 ) -> Result<usize, QmdbError> {
     Ok(F::inactive_peaks(
-        merkle_size_for_watermark(watermark)?,
+        op_count_for_watermark(watermark)?,
         inactivity_floor,
     ))
 }
@@ -167,9 +168,7 @@ pub(crate) async fn compute_auth_root<F: Family, H: Hasher>(
     inactive_peaks: usize,
 ) -> Result<H::Digest, QmdbError> {
     let size = merkle_size_for_watermark(watermark)?;
-    let leaves = watermark
-        .checked_add(1)
-        .ok_or_else(|| QmdbError::CorruptData("watermark overflow".to_string()))?;
+    let leaves = op_count_for_watermark(watermark)?;
     let peak_positions: Vec<(Position<F>, u32)> = F::peaks(size).collect();
     let fetched = if peak_positions.is_empty() {
         std::collections::HashMap::new()

--- a/qmdb/rs/src/bin/qmdb.rs
+++ b/qmdb/rs/src/bin/qmdb.rs
@@ -221,6 +221,8 @@ async fn seed(
                 grafted_metadata_partition: "mmb-grafted-metadata".into(),
                 translator: TwoCap,
                 init_cache_size: None,
+                init_buffer: NZUsize!(1 << 21),
+                init_concurrency: (),
             };
             let mut db = LocalQmdbDb::<
                 DemoFamily,
@@ -318,8 +320,8 @@ async fn seed(
                         .await
                         .expect("merkleize")
                 };
-                db.apply_batch(finalized).await.expect("apply batch");
-                db.sync().await.expect("sync local ordered db");
+                (db, _) = db.apply_batch(finalized).await.expect("apply batch");
+                db = db.sync().await.expect("sync local ordered db");
 
                 let latest = db.bounds().end - 1;
                 let count = NonZeroU64::new(*latest + 1).expect("non-zero op count");

--- a/qmdb/rs/src/boundary.rs
+++ b/qmdb/rs/src/boundary.rs
@@ -301,11 +301,11 @@ where
 {
     let previous_floor = previous_operations
         .and_then(|ops| ops.last())
-        .and_then(QmdbOperation::has_floor)
+        .and_then(|operation| operation.has_floor())
         .unwrap_or(Location::new(0));
     let floor = operations
         .last()
-        .and_then(QmdbOperation::has_floor)
+        .and_then(|operation| operation.has_floor())
         .unwrap_or(Location::new(0));
     let chunk_bits = bitmap_chunk_bits::<N>();
 

--- a/qmdb/rs/src/codec.rs
+++ b/qmdb/rs/src/codec.rs
@@ -101,11 +101,17 @@ pub(crate) fn decode_current_boundary_metadata<D: Digest>(
 pub(crate) fn merkle_size_for_watermark<F: Family>(
     watermark: Location<F>,
 ) -> Result<Position<F>, QmdbError> {
-    let leaves = watermark
-        .checked_add(1)
-        .ok_or_else(|| QmdbError::CorruptData("watermark overflow".to_string()))?;
+    let leaves = op_count_for_watermark(watermark)?;
     Position::try_from(leaves)
         .map_err(|e| QmdbError::CorruptData(format!("invalid merkle size for watermark: {e}")))
+}
+
+pub(crate) fn op_count_for_watermark<F: Family>(
+    watermark: Location<F>,
+) -> Result<Location<F>, QmdbError> {
+    watermark
+        .checked_add(1)
+        .ok_or_else(|| QmdbError::CorruptData("watermark overflow".to_string()))
 }
 
 pub(crate) fn ensure_encoded_value_size(len: usize) -> Result<(), QmdbError> {

--- a/qmdb/rs/src/connect_client.rs
+++ b/qmdb/rs/src/connect_client.rs
@@ -28,13 +28,13 @@ use commonware_storage::{
         current::unordered::db::KeyValueProof as UnorderedKeyValueProof,
         operation::Key as QmdbKey,
         sync::{
-            resolver::{fetch_operation_range, FetchResult, FetchedOperations, Resolver},
+            FeedbackTx, Request as SyncRequest, Response as SyncResponse, Source,
             Target as SyncTarget,
         },
         verify::{verify_multi_proof, verify_proof_and_pinned_nodes},
     },
 };
-use commonware_utils::{channel::oneshot, range::NonEmptyRange};
+use commonware_utils::range::NonEmptyRange;
 use connectrpc::client::{ClientConfig, ClientTransport, ServerStream};
 use connectrpc::ConnectError;
 use exoware_sdk::proto::PreferZstdHttpClient;
@@ -598,11 +598,11 @@ where
         .await
     }
 
-    fn decode_fetched_operations(
+    fn decode_sync_response(
         &self,
         proto: HistoricalOperationRangeProof,
-        include_pinned_nodes: bool,
-    ) -> Result<FetchedOperations<F, Op, H::Digest>, QmdbError> {
+        request: SyncRequest<F>,
+    ) -> Result<SyncResponse<F, Op, H::Digest>, QmdbError> {
         let max_digests = proof_digest_cap::<H::Digest>(&proto.proof);
         let proof = Proof::<F, H::Digest>::decode_cfg(proto.proof.as_ref(), &max_digests).map_err(
             |err| {
@@ -620,24 +620,33 @@ where
                 })
             })
             .collect::<Result<Vec<_>, _>>()?;
-        let pinned_nodes = if include_pinned_nodes {
-            Some(
-                proto
+        match request {
+            SyncRequest::Operations { .. } => Ok(SyncResponse::Operations { proof, operations }),
+            SyncRequest::Boundary { .. } => {
+                let [op] = operations.try_into().map_err(|operations: Vec<Op>| {
+                    QmdbError::CorruptData(format!(
+                        "sync boundary response contained {} operations instead of one",
+                        operations.len()
+                    ))
+                })?;
+                let pinned_nodes = proto
                     .pinned_nodes
                     .iter()
                     .map(|bytes| {
                         decode_digest::<H::Digest>(bytes.as_ref(), "operation sync pinned node")
                     })
-                    .collect::<Result<Vec<_>, _>>()?,
-            )
-        } else {
-            None
-        };
-        Ok(FetchedOperations::new(proof, operations, pinned_nodes))
+                    .collect::<Result<Vec<_>, _>>()?;
+                Ok(SyncResponse::Boundary {
+                    proof,
+                    op,
+                    pinned_nodes,
+                })
+            }
+        }
     }
 }
 
-impl<T, F, H, Op> Resolver for OperationLogSyncResolver<T, F, H, Op>
+impl<T, F, H, Op> Source for OperationLogSyncResolver<T, F, H, Op>
 where
     T: ClientTransport + Clone + Send + Sync + 'static,
     T::ResponseBody: Body<Data = Bytes> + Unpin,
@@ -652,37 +661,20 @@ where
     type Op = Op;
     type Error = QmdbError;
 
-    async fn get_operations(
+    async fn serve(
         &self,
-        op_count: Location<Self::Family>,
-        start_loc: Location<Self::Family>,
-        max_ops: NonZeroU64,
-        include_pinned_nodes: bool,
-        mut cancel_rx: oneshot::Receiver<()>,
-    ) -> Result<FetchResult<Self::Family, Self::Op, Self::Digest>, Self::Error> {
-        let fetch_result = tokio::select! {
-            biased;
-            _ = &mut cancel_rx => return Err(QmdbError::SyncFetchCancelled),
-            fetch_result = fetch_operation_range(
-                op_count,
-                start_loc,
-                max_ops,
-                include_pinned_nodes,
-                |op_count, start_loc, max_ops, include_pinned_nodes| async move {
-                    let proto = self
-                        .operation_range_proto(op_count, start_loc, max_ops)
-                        .await?;
-                    self.decode_fetched_operations(proto, include_pinned_nodes)
-                },
-            ) => fetch_result?,
-        };
-        match cancel_rx.try_recv() {
-            Ok(()) | Err(oneshot::error::TryRecvError::Closed) => {
-                return Err(QmdbError::SyncFetchCancelled);
-            }
-            Err(oneshot::error::TryRecvError::Empty) => {}
-        }
-        Ok(fetch_result)
+        request: SyncRequest<Self::Family>,
+    ) -> Result<
+        (
+            SyncResponse<Self::Family, Self::Op, Self::Digest>,
+            FeedbackTx,
+        ),
+        Self::Error,
+    > {
+        let proto = self
+            .operation_range_proto(request.size(), request.start(), request.max_ops())
+            .await?;
+        Ok((self.decode_sync_response(proto, request)?, None))
     }
 }
 
@@ -792,7 +784,7 @@ where
     }
 }
 
-impl<T, F, H, Op> Resolver for CurrentSyncResolver<T, F, H, Op>
+impl<T, F, H, Op> Source for CurrentSyncResolver<T, F, H, Op>
 where
     T: ClientTransport + Clone + Send + Sync + 'static,
     T::ResponseBody: Body<Data = Bytes> + Unpin,
@@ -807,23 +799,17 @@ where
     type Op = Op;
     type Error = QmdbError;
 
-    async fn get_operations(
+    async fn serve(
         &self,
-        op_count: Location<Self::Family>,
-        start_loc: Location<Self::Family>,
-        max_ops: NonZeroU64,
-        include_pinned_nodes: bool,
-        cancel_rx: oneshot::Receiver<()>,
-    ) -> Result<FetchResult<Self::Family, Self::Op, Self::Digest>, Self::Error> {
-        self.operation_log
-            .get_operations(
-                op_count,
-                start_loc,
-                max_ops,
-                include_pinned_nodes,
-                cancel_rx,
-            )
-            .await
+        request: SyncRequest<Self::Family>,
+    ) -> Result<
+        (
+            SyncResponse<Self::Family, Self::Op, Self::Digest>,
+            FeedbackTx,
+        ),
+        Self::Error,
+    > {
+        self.operation_log.serve(request).await
     }
 }
 

--- a/qmdb/rs/src/core.rs
+++ b/qmdb/rs/src/core.rs
@@ -689,9 +689,7 @@ mod tests {
 
     #[test]
     fn current_boundary_upload_keys_grafted_nodes_by_grafted_space_position() {
-        let mut hasher = Sha256::default();
-        hasher.update(b"grafted-node");
-        let digest = hasher.finalize();
+        let digest = Sha256::hash(&[b"grafted-node".as_slice()]);
 
         let ops_position = Position::new(2046);
         let latest_location = Location::new(1024);

--- a/qmdb/rs/src/keyless.rs
+++ b/qmdb/rs/src/keyless.rs
@@ -24,7 +24,6 @@ use crate::proof::{OperationRangeCheckpoint, RawBatchMultiProof, VerifiedOperati
 use crate::storage::KvMerkleStorage;
 use crate::WriterState;
 
-#[derive(Clone)]
 pub struct KeylessClient<
     F: Family,
     H: Hasher,
@@ -36,6 +35,24 @@ pub struct KeylessClient<
     client: PrefixedStoreClient,
     op_cfg: <keyless::Operation<F, E> as CodecRead>::Cfg,
     _marker: PhantomData<(F, H, E)>,
+}
+
+impl<F, H, V, E> Clone for KeylessClient<F, H, V, E>
+where
+    F: Family,
+    H: Hasher,
+    V: Codec + Send + Sync,
+    E: ValueEncoding<Value = V>,
+    keyless::Operation<F, E>: CodecRead,
+    <keyless::Operation<F, E> as CodecRead>::Cfg: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            client: self.client.clone(),
+            op_cfg: self.op_cfg.clone(),
+            _marker: PhantomData,
+        }
+    }
 }
 
 impl<F, H, V, E> std::fmt::Debug for KeylessClient<F, H, V, E>

--- a/qmdb/rs/src/ordered.rs
+++ b/qmdb/rs/src/ordered.rs
@@ -28,7 +28,7 @@ use crate::codec::{
     decode_current_boundary_metadata, decode_update_index_value_present, decode_update_location,
     decode_update_raw_key, encode_chunk_key, encode_current_meta_key, encode_operation_key,
     encode_ops_root_witness_key, encode_update_key, merkle_size_for_watermark,
-    CurrentBoundaryMetadata, UPDATE_PREFIX,
+    op_count_for_watermark, CurrentBoundaryMetadata, UPDATE_PREFIX,
 };
 use crate::connect::OperationKv;
 use crate::core::HistoricalOpsClientCore;
@@ -1349,7 +1349,7 @@ where
             .load_ops_inactivity_floor_at(session, watermark)
             .await?;
         Ok(F::inactive_peaks(
-            merkle_size_for_watermark(watermark)?,
+            op_count_for_watermark(watermark)?,
             inactivity_floor,
         ))
     }

--- a/qmdb/rs/src/unordered.rs
+++ b/qmdb/rs/src/unordered.rs
@@ -21,7 +21,7 @@ use crate::codec::{
     bitmap_chunk_bits, chunk_index_for_location, clear_below_floor,
     decode_current_boundary_metadata, decode_update_index_value_present, decode_update_location,
     encode_chunk_key, encode_current_meta_key, encode_ops_root_witness_key,
-    merkle_size_for_watermark, CurrentBoundaryMetadata,
+    merkle_size_for_watermark, op_count_for_watermark, CurrentBoundaryMetadata,
 };
 use crate::connect::OperationKv;
 use crate::core::HistoricalOpsClientCore;
@@ -801,7 +801,7 @@ where
             .load_ops_inactivity_floor_at(session, watermark)
             .await?;
         Ok(F::inactive_peaks(
-            merkle_size_for_watermark(watermark)?,
+            op_count_for_watermark(watermark)?,
             inactivity_floor,
         ))
     }

--- a/qmdb/rs/src/writer/ordered.rs
+++ b/qmdb/rs/src/writer/ordered.rs
@@ -175,7 +175,7 @@ where
         }
     };
     Ok(F::inactive_peaks(
-        crate::codec::merkle_size_for_watermark(latest_location)?,
+        crate::codec::op_count_for_watermark(latest_location)?,
         floor,
     ))
 }

--- a/qmdb/rs/src/writer/unordered.rs
+++ b/qmdb/rs/src/writer/unordered.rs
@@ -142,7 +142,7 @@ where
         }
     };
     Ok(F::inactive_peaks(
-        crate::codec::merkle_size_for_watermark(latest_location)?,
+        crate::codec::op_count_for_watermark(latest_location)?,
         floor,
     ))
 }

--- a/qmdb/rs/tests/common/mod.rs
+++ b/qmdb/rs/tests/common/mod.rs
@@ -95,6 +95,8 @@ pub fn any_variable_config<C>(
         ),
         translator: TwoCap,
         init_cache_size: None,
+        init_buffer: NZUsize!(1 << 21),
+        init_concurrency: (),
     }
 }
 
@@ -126,6 +128,8 @@ pub fn ordered_variable_config<C>(
         grafted_metadata_partition: format!("{prefix}-grafted-metadata"),
         translator: TwoCap,
         init_cache_size: None,
+        init_buffer: NZUsize!(1 << 21),
+        init_concurrency: (),
     }
 }
 
@@ -141,6 +145,7 @@ pub fn immutable_variable_config<C>(
         log: variable_journal_config(prefix, page_cache, codec_config, items_per_section),
         translator: TwoCap,
         init_cache_size: None,
+        init_buffer: NZUsize!(1 << 21),
     }
 }
 

--- a/qmdb/rs/tests/e2e_immutable.rs
+++ b/qmdb/rs/tests/e2e_immutable.rs
@@ -124,7 +124,7 @@ async fn build_local_db() -> LocalReference {
                     .merkleize(&db, None::<Vec<u8>>, db.inactivity_floor_loc())
                     .await
             };
-            db.apply_batch(finalized).await.expect("apply");
+            (db, _) = db.apply_batch(finalized).await.expect("apply");
 
             let latest = db.bounds().end - 1;
             let n = NonZeroU64::new(*latest + 1).unwrap();
@@ -163,6 +163,7 @@ async fn build_fixed_local_db() -> FixedLocalReference {
                 },
                 translator: TwoCap,
                 init_cache_size: None,
+                init_buffer: NZUsize!(1 << 21),
             };
             let mut db: FixedLocalDb = FixedLocalDb::init(context.child("immutable_fixed"), cfg)
                 .await
@@ -179,7 +180,7 @@ async fn build_fixed_local_db() -> FixedLocalReference {
                     .merkleize(&db, None::<Digest>, db.inactivity_floor_loc())
                     .await
             };
-            db.apply_batch(finalized).await.expect("apply fixed");
+            (db, _) = db.apply_batch(finalized).await.expect("apply fixed");
 
             let latest = db.bounds().end - 1;
             let n = NonZeroU64::new(*latest + 1).unwrap();

--- a/qmdb/rs/tests/e2e_immutable_connect.rs
+++ b/qmdb/rs/tests/e2e_immutable_connect.rs
@@ -87,14 +87,14 @@ async fn build_local_batch() -> LocalBatch {
                     .merkleize(&db, None::<Vec<u8>>, db.inactivity_floor_loc())
                     .await
             };
-            db.apply_batch(finalized).await.expect("apply");
+            (db, _) = db.apply_batch(finalized).await.expect("apply");
             let finalized = {
                 let batch = db.new_batch().set(key_c, b"gamma".to_vec());
                 batch
                     .merkleize(&db, None::<Vec<u8>>, db.bounds().end - 1)
                     .await
             };
-            db.apply_batch(finalized).await.expect("apply second");
+            (db, _) = db.apply_batch(finalized).await.expect("apply second");
 
             let latest = db.bounds().end - 1;
             let n = NonZeroU64::new(*latest + 1).unwrap();

--- a/qmdb/rs/tests/e2e_immutable_writer.rs
+++ b/qmdb/rs/tests/e2e_immutable_writer.rs
@@ -75,7 +75,7 @@ async fn build_local_reference(batches: Vec<Vec<(K, V)>>) -> LocalReference {
                         .merkleize(&db, None::<Vec<u8>>, db.bounds().end - 1)
                         .await
                 };
-                db.apply_batch(finalized).await.expect("apply");
+                (db, _) = db.apply_batch(finalized).await.expect("apply");
             }
             let latest = db.bounds().end - 1;
             let n = NonZeroU64::new(*latest + 1).unwrap();

--- a/qmdb/rs/tests/e2e_keyless.rs
+++ b/qmdb/rs/tests/e2e_keyless.rs
@@ -111,7 +111,7 @@ where
                     .merkleize(&db, None::<Vec<u8>>, db.inactivity_floor_loc())
                     .await
             };
-            db.apply_batch(finalized).await.expect("apply");
+            (db, _) = db.apply_batch(finalized).await.expect("apply");
 
             let finalized = {
                 let batch = db.new_batch().append(b"eighth-value".to_vec());
@@ -119,7 +119,7 @@ where
                     .merkleize(&db, None::<Vec<u8>>, db.bounds().end - 1)
                     .await
             };
-            db.apply_batch(finalized).await.expect("apply second");
+            (db, _) = db.apply_batch(finalized).await.expect("apply second");
 
             let latest = db.bounds().end - 1;
             let n = NonZeroU64::new(*latest + 1).unwrap();
@@ -135,7 +135,7 @@ where
                     .merkleize(&db, None::<Vec<u8>>, db.bounds().end - 1)
                     .await
             };
-            db.apply_batch(finalized).await.expect("apply third");
+            (db, _) = db.apply_batch(finalized).await.expect("apply third");
 
             let continued_latest_location = db.bounds().end - 1;
             let n = NonZeroU64::new(*continued_latest_location + 1).unwrap();
@@ -200,7 +200,7 @@ where
                     .merkleize(&db, None::<Digest>, db.inactivity_floor_loc())
                     .await
             };
-            db.apply_batch(finalized).await.expect("apply fixed");
+            (db, _) = db.apply_batch(finalized).await.expect("apply fixed");
 
             let latest = db.bounds().end - 1;
             let n = NonZeroU64::new(*latest + 1).unwrap();

--- a/qmdb/rs/tests/e2e_keyless_connect.rs
+++ b/qmdb/rs/tests/e2e_keyless_connect.rs
@@ -13,8 +13,8 @@ use commonware_glue::stateful::db::{StateSyncDb, SyncEngineConfig};
 use commonware_runtime::{deterministic, tokio as cw_tokio, Runner as _};
 use commonware_storage::merkle::{mmr, Location};
 use commonware_storage::qmdb::keyless::variable::{Db as Keyless, Operation as KeylessOperation};
-use commonware_storage::qmdb::sync::resolver::Resolver as _;
-use commonware_utils::channel::{mpsc, oneshot};
+use commonware_storage::qmdb::sync::{Request, Response, Source as _};
+use commonware_utils::channel::mpsc;
 use commonware_utils::{NZUsize, NZU16, NZU64};
 use exoware_qmdb::proto::qmdb::v1::{
     GetOperationRangeRequest as ProtoGetOperationRangeRequest,
@@ -87,14 +87,14 @@ async fn build_local_batch() -> LocalBatch {
                     .merkleize(&db, None::<Vec<u8>>, db.inactivity_floor_loc())
                     .await
             };
-            db.apply_batch(finalized).await.expect("apply");
+            (db, _) = db.apply_batch(finalized).await.expect("apply");
             let finalized = {
                 let batch = db.new_batch().append(b"third-value".to_vec());
                 batch
                     .merkleize(&db, None::<Vec<u8>>, db.bounds().end - 1)
                     .await
             };
-            db.apply_batch(finalized).await.expect("apply second");
+            (db, _) = db.apply_batch(finalized).await.expect("apply second");
 
             let latest = db.bounds().end - 1;
             let n = NonZeroU64::new(*latest + 1).unwrap();
@@ -235,27 +235,27 @@ async fn keyless_operation_log_sync_resolver_fetches_api_batches() {
     let target = resolver.target(op_count).await.expect("sync target");
     assert_eq!(target.root, local.root);
 
-    let (_cancel_tx, cancel_rx) = oneshot::channel();
-    let fetched = resolver
-        .get_operations(op_count, Location::new(0), NZU64!(2), false, cancel_rx)
+    let (response, callback) = resolver
+        .serve(Request::Operations {
+            size: op_count,
+            start: Location::new(0),
+            max_ops: NZU64!(2),
+        })
         .await
         .expect("fetch sync operations");
-    assert_eq!(fetched.operations.as_slice(), &local.operations[..2]);
+    let Response::Operations { proof, operations } = response else {
+        panic!("operation request returned boundary response");
+    };
+    assert_eq!(operations.as_slice(), &local.operations[..2]);
 
     let hasher = commonware_storage::qmdb::hasher::<commonware_cryptography::Sha256>();
-    let elements = fetched
-        .operations
+    let elements = operations
         .iter()
         .map(|operation| operation.encode())
         .collect::<Vec<_>>();
-    assert!(fetched.proof.verify_range_inclusion(
-        &hasher,
-        &elements,
-        Location::new(0),
-        &target.root
-    ));
+    assert!(proof.verify_range_inclusion(&hasher, &elements, Location::new(0), &target.root));
     assert!(
-        fetched.callback.is_none(),
+        callback.is_none(),
         "direct sync resolver fetches do not allocate an unused validation callback"
     );
 }
@@ -332,7 +332,7 @@ async fn keyless_commonware_glue_state_sync_uses_operation_log_resolver() {
                 None,
                 SyncEngineConfig {
                     fetch_batch_size: NZU64!(1),
-                    apply_batch_size: 1,
+                    apply_batch_size: NZU64!(1),
                     max_outstanding_requests: 2,
                     update_channel_size: NZUsize!(1),
                     max_retained_roots: 4,
@@ -356,30 +356,6 @@ async fn keyless_commonware_glue_state_sync_uses_operation_log_resolver() {
     })
     .await
     .expect("join glue state sync runner");
-}
-
-#[tokio::test]
-async fn keyless_operation_log_sync_resolver_observes_cancelled_fetch() {
-    let resolver = OperationLogSyncResolver::<
-        _,
-        mmr::Family,
-        commonware_cryptography::Sha256,
-        BatchOperation,
-    >::plaintext("http://127.0.0.1:1", ((0..=10000).into(), ()));
-    let (cancel_tx, cancel_rx) = oneshot::channel();
-    drop(cancel_tx);
-
-    let err = resolver
-        .get_operations(
-            Location::new(1),
-            Location::new(0),
-            NZU64!(1),
-            false,
-            cancel_rx,
-        )
-        .await
-        .expect_err("closed cancellation channel aborts fetch");
-    assert!(matches!(err, QmdbError::SyncFetchCancelled));
 }
 
 #[tokio::test]

--- a/qmdb/rs/tests/e2e_keyless_writer.rs
+++ b/qmdb/rs/tests/e2e_keyless_writer.rs
@@ -65,7 +65,7 @@ async fn build_local_reference(
                         .merkleize(&db, None::<Vec<u8>>, db.bounds().end - 1)
                         .await
                 };
-                db.apply_batch(finalized).await.expect("apply");
+                (db, _) = db.apply_batch(finalized).await.expect("apply");
             }
 
             let latest = db.bounds().end - 1;

--- a/qmdb/rs/tests/e2e_mirror_from_local.rs
+++ b/qmdb/rs/tests/e2e_mirror_from_local.rs
@@ -123,7 +123,7 @@ async fn run_keyless_local(
                     b.merkleize(&db, None::<Vec<u8>>, db.inactivity_floor_loc())
                         .await
                 };
-                db.apply_batch(finalized).await.expect("apply");
+                (db, _) = db.apply_batch(finalized).await.expect("apply");
             }
             let latest = db.bounds().end - 1;
             let n = NonZeroU64::new(*latest + 1).unwrap();
@@ -244,7 +244,7 @@ async fn run_unordered_local(
                     }
                     b.merkleize(&db, None::<Vec<u8>>).await.expect("merkleize")
                 };
-                db.apply_batch(finalized).await.expect("apply");
+                (db, _) = db.apply_batch(finalized).await.expect("apply");
             }
             let latest = db.bounds().end - 1;
             let n = NonZeroU64::new(*latest + 1).unwrap();
@@ -354,7 +354,7 @@ async fn run_immutable_local(
                     b.merkleize(&db, None::<Vec<u8>>, db.inactivity_floor_loc())
                         .await
                 };
-                db.apply_batch(finalized).await.expect("apply");
+                (db, _) = db.apply_batch(finalized).await.expect("apply");
             }
             let latest = db.bounds().end - 1;
             let n = NonZeroU64::new(*latest + 1).unwrap();
@@ -535,7 +535,7 @@ async fn run_ordered_local(
                     }
                     b.merkleize(&db, None::<Vec<u8>>).await.expect("merkleize")
                 };
-                db.apply_batch(finalized).await.expect("apply");
+                (db, _) = db.apply_batch(finalized).await.expect("apply");
             }
             let latest = db.bounds().end - 1;
             let n = NonZeroU64::new(*latest + 1).unwrap();
@@ -546,7 +546,7 @@ async fn run_ordered_local(
             let boundary =
                 ordered_boundary_from_local_db(&db, previous_operations.as_deref(), &ops).await;
             let root = db.root();
-            db.sync().await.expect("sync");
+            db = db.sync().await.expect("sync");
             db.destroy().await.expect("destroy");
             (ops, proof, latest, root, boundary)
         })

--- a/qmdb/rs/tests/e2e_ordered.rs
+++ b/qmdb/rs/tests/e2e_ordered.rs
@@ -216,7 +216,7 @@ where
                     .await
                     .expect("merkleize")
             };
-            db.apply_batch(finalized).await.expect("apply");
+            (db, _) = db.apply_batch(finalized).await.expect("apply");
 
             let latest = db.bounds().end - 1;
             let n = NonZeroU64::new(*latest + 1).unwrap();
@@ -237,7 +237,7 @@ where
                 db.get(&b"beta".to_vec()).await.expect("get"),
             );
 
-            db.sync().await.expect("sync");
+            db = db.sync().await.expect("sync");
             db.destroy().await.expect("destroy");
 
             LocalReference {
@@ -340,7 +340,7 @@ where
                     .await
                     .expect("merkleize")
             };
-            db.apply_batch(finalized).await.expect("apply");
+            (db, _) = db.apply_batch(finalized).await.expect("apply");
 
             let latest = db.bounds().end - 1;
             let n = NonZeroU64::new(*latest + 1).unwrap();
@@ -351,7 +351,7 @@ where
 
             let boundary = boundary_from_local_db_with_chunk_size::<F, M>(&db, None, &ops).await;
 
-            db.sync().await.expect("sync");
+            db = db.sync().await.expect("sync");
             db.destroy().await.expect("destroy");
 
             ChunkSizedLocalReference {
@@ -385,6 +385,8 @@ where
                 grafted_metadata_partition: "ordered_fixed_grafted_metadata".to_string(),
                 translator: TwoCap,
                 init_cache_size: None,
+                init_buffer: NZUsize!(1 << 21),
+                init_concurrency: (),
             };
             let mut db: FixedLocalDb<F> = FixedLocalDb::init(context.child("ordered_fixed"), cfg)
                 .await
@@ -404,7 +406,7 @@ where
                     .await
                     .expect("fixed merkleize")
             };
-            db.apply_batch(finalized).await.expect("apply fixed");
+            (db, _) = db.apply_batch(finalized).await.expect("apply fixed");
 
             let latest = db.bounds().end - 1;
             let n = NonZeroU64::new(*latest + 1).unwrap();
@@ -425,7 +427,7 @@ where
                 db.get(&beta).await.expect("get beta"),
             );
 
-            db.sync().await.expect("sync fixed");
+            db = db.sync().await.expect("sync fixed");
             db.destroy().await.expect("destroy fixed");
 
             FixedLocalReference {
@@ -630,7 +632,7 @@ async fn assert_incremental_seed_batches_keep_current_proofs_verifiable<F>(
                             .await
                             .expect("merkleize")
                     };
-                    db.apply_batch(finalized).await.expect("apply");
+                    (db, _) = db.apply_batch(finalized).await.expect("apply");
 
                     let latest = db.bounds().end - 1;
                     let count = NonZeroU64::new(*latest + 1).expect("non-zero op count");
@@ -788,8 +790,8 @@ async fn ordered_mmb_persistent_interleaved_seed_batches_keep_current_proofs_ver
                                 .await
                                 .expect("merkleize")
                         };
-                        db.apply_batch(finalized).await.expect("apply");
-                        db.sync().await.expect("sync");
+                        (db, _) = db.apply_batch(finalized).await.expect("apply");
+                        db = db.sync().await.expect("sync");
 
                         let latest = db.bounds().end - 1;
                         let count = NonZeroU64::new(*latest + 1).expect("non-zero op count");

--- a/qmdb/rs/tests/e2e_ordered_connect.rs
+++ b/qmdb/rs/tests/e2e_ordered_connect.rs
@@ -218,7 +218,7 @@ async fn build_local_batch_with_writes(label: &str, writes: &[(Vec<u8>, Vec<u8>)
                     .await
                     .expect("merkleize")
             };
-            db.apply_batch(finalized).await.expect("apply");
+            (db, _) = db.apply_batch(finalized).await.expect("apply");
 
             let latest = db.bounds().end - 1;
             let n = NonZeroU64::new(*latest + 1).unwrap();
@@ -229,7 +229,7 @@ async fn build_local_batch_with_writes(label: &str, writes: &[(Vec<u8>, Vec<u8>)
 
             let boundary = boundary_from_local_db(&db, None, &ops).await;
 
-            db.sync().await.expect("sync");
+            db = db.sync().await.expect("sync");
             db.destroy().await.expect("destroy");
 
             LocalBatch {

--- a/qmdb/rs/tests/e2e_ordered_prune.rs
+++ b/qmdb/rs/tests/e2e_ordered_prune.rs
@@ -150,12 +150,13 @@ async fn mirror_ordered_prune_past_chunk_zero() {
                             .await
                             .expect("merkleize")
                     };
-                    db.apply_batch(finalized).await.expect("apply");
+                    (db, _) = db.apply_batch(finalized).await.expect("apply");
                     // Current pruning is now explicit in Commonware. Keep the
                     // historical operation log intact for this mirror test while
                     // allowing the current bitmap/grafted overlay to prune as far
                     // as the sync boundary permits.
-                    db.prune(Location::<mmr::Family>::new(0))
+                    db = db
+                        .prune(Location::<mmr::Family>::new(0))
                         .await
                         .expect("prune current");
 
@@ -202,7 +203,7 @@ async fn mirror_ordered_prune_past_chunk_zero() {
                         Ok(_) => false,
                     }
                 };
-                db.sync().await.expect("sync");
+                db = db.sync().await.expect("sync");
                 db.destroy().await.expect("destroy");
                 (
                     batches,

--- a/qmdb/rs/tests/e2e_ordered_range_connect.rs
+++ b/qmdb/rs/tests/e2e_ordered_range_connect.rs
@@ -14,17 +14,13 @@ use commonware_runtime::tokio as cw_tokio;
 use commonware_runtime::Runner as _;
 use commonware_storage::merkle::{mmb, mmr, Location, Proof};
 use commonware_storage::qmdb::any::ordered::variable::Operation as QmdbOperation;
-use commonware_storage::qmdb::sync::resolver::Resolver as _;
 use commonware_storage::qmdb::{
     any::ordered::{variable::Db as AnyOrderedQmdbDb, Update},
     current::ordered::variable::Db as LocalQmdbDb,
-    sync as qmdb_sync,
+    sync::{self as qmdb_sync, Request, Response, Source as _},
 };
 use commonware_storage::translator::TwoCap;
-use commonware_utils::{
-    channel::{mpsc, oneshot},
-    NZUsize, NZU16, NZU64,
-};
+use commonware_utils::{channel::mpsc, NZUsize, NZU16, NZU64};
 use exoware_qmdb::proto::qmdb::v1::{
     GetCurrentOperationRangeRequest as ProtoGetCurrentOperationRangeRequest,
     GetOperationRangeRequest as ProtoGetOperationRangeRequest,
@@ -227,7 +223,7 @@ async fn build_local_batch() -> LocalBatch {
                         .await
                         .expect("merkleize")
                 };
-                db.apply_batch(finalized).await.expect("apply");
+                (db, _) = db.apply_batch(finalized).await.expect("apply");
 
                 let latest = db.bounds().end - 1;
                 let n = NonZeroU64::new(*latest + 1).unwrap();
@@ -246,7 +242,7 @@ async fn build_local_batch() -> LocalBatch {
                 "MMR subscribe fixture must exercise nonzero inactivity floor"
             );
             let boundary = boundary_from_local_db(&db, None, &ops).await;
-            db.sync().await.expect("sync");
+            db = db.sync().await.expect("sync");
             db.destroy().await.expect("destroy");
 
             LocalBatch {
@@ -340,7 +336,7 @@ async fn build_mmb_local_batch() -> MmbLocalBatch {
                         .await
                         .expect("merkleize")
                 };
-                db.apply_batch(finalized).await.expect("apply");
+                (db, _) = db.apply_batch(finalized).await.expect("apply");
 
                 let latest = db.bounds().end - 1;
                 let n = NonZeroU64::new(*latest + 1).unwrap();
@@ -359,7 +355,7 @@ async fn build_mmb_local_batch() -> MmbLocalBatch {
                 "MMB fixture must exercise nonzero inactivity floor and multiple sync batches"
             );
             let boundary = boundary_from_mmb_local_db(&db, &ops).await;
-            db.sync().await.expect("sync");
+            db = db.sync().await.expect("sync");
             db.destroy().await.expect("destroy");
 
             MmbLocalBatch {
@@ -409,7 +405,7 @@ async fn build_mmb_growing_local_batch() -> MmbGrowingLocalBatch {
                         .await
                         .expect("merkleize")
                 };
-                db.apply_batch(finalized).await.expect("apply");
+                (db, _) = db.apply_batch(finalized).await.expect("apply");
 
                 let latest = db.bounds().end - 1;
                 let n = NonZeroU64::new(*latest + 1).unwrap();
@@ -445,7 +441,7 @@ async fn build_mmb_growing_local_batch() -> MmbGrowingLocalBatch {
                 "MMB growing fixture must add enough operations for multiple updated sync fetches"
             );
             let boundary = boundary_from_mmb_local_db(&db, &ops).await;
-            db.sync().await.expect("sync");
+            db = db.sync().await.expect("sync");
             db.destroy().await.expect("destroy");
 
             MmbGrowingLocalBatch {
@@ -551,11 +547,11 @@ async fn ordered_current_state_sync_from_connect_api_reconstructs_current_db() {
             );
             let db: LocalDb = qmdb_sync::sync(qmdb_sync::engine::Config {
                 context: context.child("sync"),
-                resolver,
+                source: resolver,
                 target,
                 max_outstanding_requests: 4,
                 fetch_batch_size: NZU64!(7),
-                apply_batch_size: 32,
+                apply_batch_size: NZU64!(32),
                 db_config: cfg,
                 update_rx: None,
                 finish_rx: None,
@@ -637,11 +633,11 @@ async fn ordered_mmb_current_state_sync_from_nonzero_connect_api_reconstructs_cu
             );
             let db: MmbLocalDb = qmdb_sync::sync(qmdb_sync::engine::Config {
                 context: context.child("sync"),
-                resolver,
+                source: resolver,
                 target,
                 max_outstanding_requests: 4,
                 fetch_batch_size: NZU64!(3),
-                apply_batch_size: 32,
+                apply_batch_size: NZU64!(32),
                 db_config: cfg,
                 update_rx: None,
                 finish_rx: None,
@@ -696,26 +692,28 @@ async fn ordered_mmb_sync_resolvers_return_pinned_nodes_for_nonzero_fetches() {
         .target_range(start, op_count)
         .await
         .expect("any nonzero sync target");
-    let (_cancel_tx, cancel_rx) = oneshot::channel();
-    let any_fetch = any_resolver
-        .get_operations(op_count, start, NZU64!(1), true, cancel_rx)
+    let (any_response, _) = any_resolver
+        .serve(Request::Boundary {
+            size: op_count,
+            start,
+        })
         .await
         .expect("any resolver nonzero pinned fetch");
-    let any_pinned_nodes = any_fetch
-        .pinned_nodes
-        .as_ref()
-        .expect("any resolver returned pinned nodes");
+    let Response::Boundary {
+        proof: any_proof,
+        op: any_op,
+        pinned_nodes: any_pinned_nodes,
+    } = any_response
+    else {
+        panic!("boundary request returned operations response");
+    };
     assert!(!any_pinned_nodes.is_empty());
-    let any_elements = any_fetch
-        .operations
-        .iter()
-        .map(|operation| operation.encode())
-        .collect::<Vec<_>>();
-    assert!(any_fetch.proof.verify_proof_and_pinned_nodes(
+    let any_elements = [any_op.encode()];
+    assert!(any_proof.verify_proof_and_pinned_nodes(
         &hasher,
         &any_elements,
         start,
-        any_pinned_nodes,
+        &any_pinned_nodes,
         &any_target.root,
     ));
 
@@ -729,26 +727,28 @@ async fn ordered_mmb_sync_resolvers_return_pinned_nodes_for_nonzero_fetches() {
         .target_range(start, op_count)
         .await
         .expect("current nonzero sync target");
-    let (_cancel_tx, cancel_rx) = oneshot::channel();
-    let current_fetch = current_resolver
-        .get_operations(op_count, start, NZU64!(1), true, cancel_rx)
+    let (current_response, _) = current_resolver
+        .serve(Request::Boundary {
+            size: op_count,
+            start,
+        })
         .await
         .expect("current resolver nonzero pinned fetch");
-    let current_pinned_nodes = current_fetch
-        .pinned_nodes
-        .as_ref()
-        .expect("current resolver returned pinned nodes");
+    let Response::Boundary {
+        proof: current_proof,
+        op: current_op,
+        pinned_nodes: current_pinned_nodes,
+    } = current_response
+    else {
+        panic!("boundary request returned operations response");
+    };
     assert!(!current_pinned_nodes.is_empty());
-    let current_elements = current_fetch
-        .operations
-        .iter()
-        .map(|operation| operation.encode())
-        .collect::<Vec<_>>();
-    assert!(current_fetch.proof.verify_proof_and_pinned_nodes(
+    let current_elements = [current_op.encode()];
+    assert!(current_proof.verify_proof_and_pinned_nodes(
         &hasher,
         &current_elements,
         start,
-        current_pinned_nodes,
+        &current_pinned_nodes,
         &current_target.root,
     ));
 }
@@ -1296,11 +1296,11 @@ async fn ordered_mmb_operation_log_any_sync_from_connect_api_reconstructs_any_db
             );
             let db: MmbAnyLocalDb = qmdb_sync::sync(qmdb_sync::engine::Config {
                 context: context.child("sync"),
-                resolver,
+                source: resolver,
                 target,
                 max_outstanding_requests: 4,
                 fetch_batch_size: NZU64!(3),
-                apply_batch_size: 32,
+                apply_batch_size: NZU64!(32),
                 db_config: cfg,
                 update_rx: None,
                 finish_rx: None,
@@ -1372,11 +1372,11 @@ async fn ordered_mmb_operation_log_any_sync_from_nonzero_connect_api_reconstruct
             );
             let db: MmbAnyLocalDb = qmdb_sync::sync(qmdb_sync::engine::Config {
                 context: context.child("sync"),
-                resolver,
+                source: resolver,
                 target,
                 max_outstanding_requests: 4,
                 fetch_batch_size: NZU64!(3),
-                apply_batch_size: 32,
+                apply_batch_size: NZU64!(32),
                 db_config: cfg,
                 update_rx: None,
                 finish_rx: None,
@@ -1469,11 +1469,11 @@ async fn ordered_mmb_operation_log_any_sync_accepts_target_update_from_growing_b
             );
             let db: MmbAnyLocalDb = qmdb_sync::sync(qmdb_sync::engine::Config {
                 context: context.child("sync"),
-                resolver,
+                source: resolver,
                 target: initial_target,
                 max_outstanding_requests: 1,
                 fetch_batch_size: NZU64!(3),
-                apply_batch_size: 4,
+                apply_batch_size: NZU64!(4),
                 db_config: cfg,
                 update_rx: Some(update_rx),
                 finish_rx: Some(finish_rx),

--- a/qmdb/rs/tests/e2e_ordered_writer.rs
+++ b/qmdb/rs/tests/e2e_ordered_writer.rs
@@ -143,7 +143,7 @@ async fn build_local_reference(
                         .await
                         .expect("merkleize")
                 };
-                db.apply_batch(finalized).await.expect("apply");
+                (db, _) = db.apply_batch(finalized).await.expect("apply");
             }
             let latest = db.bounds().end - 1;
             let n = NonZeroU64::new(*latest + 1).unwrap();
@@ -152,7 +152,7 @@ async fn build_local_reference(
                 .await
                 .expect("proof");
             let boundary = boundary_from_local_db(&db, previous_operations.as_deref(), &ops).await;
-            db.sync().await.expect("sync");
+            db = db.sync().await.expect("sync");
             let root = db.root();
             db.destroy().await.expect("destroy");
             LocalReference {

--- a/qmdb/rs/tests/e2e_recovery_strategy.rs
+++ b/qmdb/rs/tests/e2e_recovery_strategy.rs
@@ -83,14 +83,15 @@ where
                 .append(b"seventh-value".to_vec())
                 .merkleize(&db, None::<Vec<u8>>, db.inactivity_floor_loc())
                 .await;
-            db.apply_batch(initial).await.expect("apply initial batch");
+            (db, _) = db.apply_batch(initial).await.expect("apply initial batch");
 
             let checkpoint_batch = db
                 .new_batch()
                 .append(b"eighth-value".to_vec())
                 .merkleize(&db, None::<Vec<u8>>, db.bounds().end - 1)
                 .await;
-            db.apply_batch(checkpoint_batch)
+            (db, _) = db
+                .apply_batch(checkpoint_batch)
                 .await
                 .expect("apply checkpoint batch");
 
@@ -106,7 +107,8 @@ where
                 .append(b"ninth-value".to_vec())
                 .merkleize(&db, None::<Vec<u8>>, db.bounds().end - 1)
                 .await;
-            db.apply_batch(continuation)
+            (db, _) = db
+                .apply_batch(continuation)
                 .await
                 .expect("apply continuation batch");
 

--- a/qmdb/rs/tests/e2e_unordered.rs
+++ b/qmdb/rs/tests/e2e_unordered.rs
@@ -94,7 +94,7 @@ async fn build_local_db() -> LocalReference {
                     .await
                     .expect("merkleize")
             };
-            db.apply_batch(finalized).await.expect("apply");
+            (db, _) = db.apply_batch(finalized).await.expect("apply");
 
             let latest = db.bounds().end - 1;
             let n = NonZeroU64::new(*latest + 1).unwrap();
@@ -113,7 +113,7 @@ async fn build_local_db() -> LocalReference {
                 db.get(&b"beta".to_vec()).await.expect("get"),
             );
 
-            db.sync().await.expect("sync");
+            db = db.sync().await.expect("sync");
             db.destroy().await.expect("destroy");
 
             LocalReference {
@@ -142,6 +142,8 @@ async fn build_fixed_local_db() -> FixedLocalReference {
                 },
                 translator: TwoCap,
                 init_cache_size: None,
+                init_buffer: NZUsize!(1 << 21),
+                init_concurrency: (),
             };
             let mut db: FixedLocalDb = FixedLocalDb::init(context.child("unordered_fixed"), cfg)
                 .await
@@ -161,7 +163,7 @@ async fn build_fixed_local_db() -> FixedLocalReference {
                     .await
                     .expect("merkleize fixed")
             };
-            db.apply_batch(finalized).await.expect("apply fixed");
+            (db, _) = db.apply_batch(finalized).await.expect("apply fixed");
 
             let latest = db.bounds().end - 1;
             let n = NonZeroU64::new(*latest + 1).unwrap();
@@ -180,7 +182,7 @@ async fn build_fixed_local_db() -> FixedLocalReference {
                 db.get(&beta).await.expect("get beta"),
             );
 
-            db.sync().await.expect("sync fixed");
+            db = db.sync().await.expect("sync fixed");
             db.destroy().await.expect("destroy fixed");
 
             FixedLocalReference {

--- a/qmdb/rs/tests/e2e_unordered_connect.rs
+++ b/qmdb/rs/tests/e2e_unordered_connect.rs
@@ -244,7 +244,7 @@ async fn build_local_batch() -> LocalBatch {
                         .await
                         .expect("merkleize")
                 };
-                db.apply_batch(finalized).await.expect("apply");
+                (db, _) = db.apply_batch(finalized).await.expect("apply");
 
                 let latest = db.bounds().end - 1;
                 let n = NonZeroU64::new(*latest + 1).unwrap();
@@ -264,7 +264,7 @@ async fn build_local_batch() -> LocalBatch {
             );
             let root = db.root();
 
-            db.sync().await.expect("sync");
+            db = db.sync().await.expect("sync");
             db.destroy().await.expect("destroy");
 
             LocalBatch {
@@ -323,7 +323,7 @@ async fn build_mmb_local_batch() -> MmbLocalBatch {
                         .await
                         .expect("merkleize")
                 };
-                db.apply_batch(finalized).await.expect("apply");
+                (db, _) = db.apply_batch(finalized).await.expect("apply");
 
                 let latest = db.bounds().end - 1;
                 let n = NonZeroU64::new(*latest + 1).unwrap();
@@ -343,7 +343,7 @@ async fn build_mmb_local_batch() -> MmbLocalBatch {
             );
             let root = db.root();
 
-            db.sync().await.expect("sync");
+            db = db.sync().await.expect("sync");
             db.destroy().await.expect("destroy");
 
             MmbLocalBatch {
@@ -395,7 +395,7 @@ async fn build_fixed_local_batch() -> FixedLocalBatch {
                     .await
                     .expect("merkleize")
             };
-            db.apply_batch(finalized).await.expect("apply");
+            (db, _) = db.apply_batch(finalized).await.expect("apply");
 
             let latest = db.bounds().end - 1;
             let n = NonZeroU64::new(*latest + 1).unwrap();
@@ -405,7 +405,7 @@ async fn build_fixed_local_batch() -> FixedLocalBatch {
                 .expect("proof");
             let boundary = boundary_from_local_current_db(&db, &ops).await;
 
-            db.sync().await.expect("sync");
+            db = db.sync().await.expect("sync");
             db.destroy().await.expect("destroy");
 
             FixedLocalBatch {

--- a/qmdb/rs/tests/e2e_unordered_writer.rs
+++ b/qmdb/rs/tests/e2e_unordered_writer.rs
@@ -88,7 +88,7 @@ async fn build_local_reference(batches: Vec<WriteBatch>) -> LocalReference {
                         .await
                         .expect("merkleize")
                 };
-                db.apply_batch(finalized).await.expect("apply");
+                (db, _) = db.apply_batch(finalized).await.expect("apply");
             }
             let latest = db.bounds().end - 1;
             let n = NonZeroU64::new(*latest + 1).unwrap();

--- a/qmdb/rs/wasm/src/lib.rs
+++ b/qmdb/rs/wasm/src/lib.rs
@@ -227,7 +227,7 @@ where
         };
         if end_chunk == complete_chunks {
             let last_chunk = chunks.last().expect("chunks non-empty");
-            if *last_chunk_digest != grafting_verifier.hash([last_chunk.as_slice()]) {
+            if *last_chunk_digest != grafting_verifier.hash(&[last_chunk.as_slice()]) {
                 return Err("current proof partial chunk digest mismatch".to_string());
             }
         }
@@ -243,7 +243,7 @@ where
             let Some(pending_chunk) = chunks.get(local) else {
                 return Err("current proof pending chunk index out of range".to_string());
             };
-            if *pending_digest != grafting_verifier.hash([pending_chunk.as_slice()]) {
+            if *pending_digest != grafting_verifier.hash(&[pending_chunk.as_slice()]) {
                 return Err("current proof pending chunk digest mismatch".to_string());
             }
         }

--- a/simplex/rs/src/bin/simplex.rs
+++ b/simplex/rs/src/bin/simplex.rs
@@ -87,9 +87,7 @@ impl DemoBlock {
     fn compute_digest(&self) -> Sha256Digest {
         let mut header = BytesMut::with_capacity(self.encode_size());
         self.write(&mut header);
-        let mut hasher = Sha256::new();
-        hasher.update(&header);
-        hasher.finalize()
+        Sha256::hash(&[&header])
     }
 }
 
@@ -304,7 +302,7 @@ async fn seed(
         }
 
         let body = Bytes::from(format!("simplex-demo-block-body-{height}").into_bytes());
-        let body_digest = Sha256::hash(&body);
+        let body_digest = Sha256::hash(&[&body]);
         let block = DemoBlock::new(
             height,
             parent_view,

--- a/simplex/rs/tests/e2e.rs
+++ b/simplex/rs/tests/e2e.rs
@@ -68,9 +68,7 @@ impl TestBlock {
     fn compute_digest(&self) -> Sha256Digest {
         let mut header = BytesMut::with_capacity(self.encode_size());
         self.write(&mut header);
-        let mut hasher = Sha256::new();
-        hasher.update(&header);
-        hasher.finalize()
+        Sha256::hash(&[&header])
     }
 }
 
@@ -367,7 +365,7 @@ async fn marshal_resolver_sinks_finalized_chain_from_simplex_api() {
                     start: Start::Genesis(genesis),
                     partition_prefix: partition_prefix.to_string(),
                     mailbox_size: NZUsize!(100),
-                    view_retention_timeout: ViewDelta::new(10),
+                    view_retention: ViewDelta::new(10),
                     prunable_items_per_section: NZU64!(10),
                     page_cache,
                     replay_buffer: NZUsize!(1024),

--- a/simplex/rs/wasm/src/lib.rs
+++ b/simplex/rs/wasm/src/lib.rs
@@ -407,20 +407,8 @@ mod tests {
 
     const DEMO_NAMESPACE: &[u8] = b"_EXOWARE_SIMPLEX_DEMO";
 
-    fn sha256_payload(header: &[u8]) -> sha256::Digest {
-        let mut hasher = Sha256::new();
-        hasher.update(header);
-        hasher.finalize()
-    }
-
-    fn blake3_payload(header: &[u8]) -> blake3::Digest {
-        let mut hasher = Blake3::new();
-        hasher.update(header);
-        hasher.finalize()
-    }
-
     fn transcript_summary_payload(header: &[u8]) -> transcript::Summary {
-        transcript::Transcript::new(DEMO_NAMESPACE)
+        transcript::Transcript::new(DEMO_NAMESPACE, transcript::Version::V0)
             .commit(header)
             .summarize()
     }
@@ -673,7 +661,7 @@ mod tests {
             schemes,
             verification_material.clone(),
             "sha256",
-            sha256_payload,
+            |header| Sha256::hash(&[header]),
         );
         verify_round_trip(
             identity_name,
@@ -681,7 +669,7 @@ mod tests {
             schemes,
             verification_material.clone(),
             "blake3",
-            blake3_payload,
+            |header| Blake3::hash(&[header]),
         );
         verify_round_trip(
             identity_name,


### PR DESCRIPTION
## Summary

- Pin all Commonware workspace dependencies to `dfe4c5a9ab89edb1e64052aa931498d6552444d9`.
- Migrate QMDB synchronization from the `Resolver` API to the new `Source` request and response API.
- Adapt call sites to Commonware’s consuming database APIs, which return the updated database handle after `apply_batch` and `sync`.
- Update configuration, hashing, transcript, and toolchain usage for the remaining breaking API changes.

## Testing

All required PR checks pass, including Rust linting, formatting, documentation, tests, unused dependency checks, TypeScript checks, and simulator validation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches cryptography dependencies, QMDB sync protocol surface, and merkle/auth peak sizing; wide test churn but behavior should match upstream Commonware semantics if pins are correct.
> 
> **Overview**
> Pins all **commonware** workspace git dependencies to `dfe4c5a9ab89edb1e64052aa931498d6552444d9` and refreshes **Cargo.lock** (crypto stack, criterion 0.8, prometheus-client 0.25, sysinfo 0.39, etc.). CI **NIGHTLY_VERSION** moves to `nightly-2026-06-21`.
> 
> **QMDB sync** drops the old `Resolver::get_operations` + cancel-channel flow in favor of **`Source::serve`** with typed **`SyncRequest`** / **`SyncResponse`** (`Operations` vs **`Boundary`** with a single op and pinned nodes). Sync engine config renames **`resolver` → `source`** and uses **`NZU64!`** for **`apply_batch_size`**.
> 
> Call sites adopt Commonware’s **consuming DB API**: **`apply_batch`**, **`sync`**, and **`prune`** return the updated handle (tests and binaries assign `(db, _) = …` / `db = …`). QMDB DB **`Config`** gains **`init_buffer`** and **`init_concurrency`**.
> 
> Smaller API fixes: **`op_count_for_watermark`** for inactive-peak / leaf counts; **`Hasher::hash`** slice-of-slices; **`Transcript::new(..., Version::V0)`**; Simplex marshal **`view_retention`**; WASM grafting **`hash(&[…])`**; manual **`Clone`** for **`KeylessClient`** when codec cfg is cloneable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7e898784f7331001df00c786abfb40c42909675. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->