### PR TITLE
Use npm trusted publishing

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -36,5 +36,4 @@ runs:
     - name: Set up Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: '20'
-        registry-url: 'https://registry.npmjs.org'
+        node-version: '24'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   All:
@@ -70,8 +71,6 @@ jobs:
         npm run build
         npm publish --access public --ignore-scripts
       continue-on-error: true
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
     - name: Publish @exowarexyz/qmdb
       run: |
         cd qmdb/ts
@@ -82,8 +81,6 @@ jobs:
         cd qmdb/ts
         npm publish --access public --ignore-scripts
       continue-on-error: true
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
     - name: Publish @exowarexyz/simplex
       run: |
         cd simplex/ts
@@ -94,8 +91,6 @@ jobs:
         cd simplex/ts
         npm publish --access public --ignore-scripts
       continue-on-error: true
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
     - name: Publish @exowarexyz/sql
       run: |
         cd sql/ts
@@ -106,5 +101,3 @@ jobs:
         cd sql/ts
         npm publish --access public --ignore-scripts
       continue-on-error: true
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,8 +30,6 @@ $ cargo +nightly fmt --all
 
 Releases are automatically published to crates.io and npm by [GitHub Actions](.github/workflows/publish.yml) whenever a version update is merged into the `main` branch.
 
-The npm packages `@exowarexyz/sdk`, `@exowarexyz/qmdb`, `@exowarexyz/simplex`, and `@exowarexyz/sql` use [trusted publishing](https://docs.npmjs.com/trusted-publishers/). Each package's npm settings must configure GitHub Actions as a trusted publisher for `exowarexyz/monorepo`, with workflow filename `publish.yml`, no environment, and permission to run `npm publish`.
-
 # Licensing and Copyright
 
 You agree that any work submitted to this repository shall be dual-licensed under the included [Apache 2.0](./LICENSE-APACHE) and [MIT](./LICENSE-MIT) licenses, without any additional terms or conditions. Additionally, you agree to release your copyright interest in said work to the public domain, such that anyone is free to use, modify, and distribute your contributions without restriction.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,9 @@ $ cargo +nightly fmt --all
 
 # Releases
 
-Releases are automatically published to `cargo` by [GitHub Actions](.github/workflows/publish.yml) whenever a version update is merged into the `main` branch.
+Releases are automatically published to crates.io and npm by [GitHub Actions](.github/workflows/publish.yml) whenever a version update is merged into the `main` branch.
+
+The npm packages `@exowarexyz/sdk`, `@exowarexyz/qmdb`, `@exowarexyz/simplex`, and `@exowarexyz/sql` use [trusted publishing](https://docs.npmjs.com/trusted-publishers/). Each package's npm settings must configure GitHub Actions as a trusted publisher for `exowarexyz/monorepo`, with workflow filename `publish.yml`, no environment, and permission to run `npm publish`.
 
 # Licensing and Copyright
 


### PR DESCRIPTION
npm uploads from GitHub Actions can hit an OTP challenge when publishing with `NPM_TOKEN`. Switch all four `@exowarexyz` packages to npm trusted publishing through GitHub OIDC, grant `id-token: write`, and remove the token environment variables and generated npm authentication configuration. Use Node 24 across CI so builds and publishing share a runtime with a compatible bundled npm CLI.

Before merging, register a GitHub Actions trusted publisher in the npm settings for `@exowarexyz/sdk`, `@exowarexyz/qmdb`, `@exowarexyz/simplex`, and `@exowarexyz/sql`:

| Setting | Value |
| --- | --- |
| Organization or user | `exowarexyz` |
| Repository | `monorepo` |
| Workflow filename | `publish.yml` |
| Environment | Leave blank |
| Allowed actions | Enable direct `npm publish` |

These settings are also documented in `CONTRIBUTING.md`. npm registration and a live OIDC publication remain to be verified after configuration. See the [npm trusted publishing documentation](https://docs.npmjs.com/trusted-publishers/).

Validated locally with Node 24.21.0 and npm 11.19.0:

- SDK build/lint and 64 unit tests; QMDB WASM/TypeScript build and 86 client tests; Simplex WASM/TypeScript build and 21 tests; SQL build and 10 tests; sandbox build and 4 display tests.
- `git diff --check` and Actionlint 1.7.12. Actionlint passes with the existing missing-description diagnostics for the local Setup and Free Disk Space actions excluded; those diagnostics also occur on `main`. Shellcheck and Pyflakes integrations were disabled.
