### PR TITLE
[sdk/ts] Avoid retrying mutation RPCs

### DIFF
--- a/sdk/ts/__tests__/retry.test.ts
+++ b/sdk/ts/__tests__/retry.test.ts
@@ -1,0 +1,36 @@
+import { Code, ConnectError } from '@connectrpc/connect';
+import { Client } from '../src/client';
+
+const methods = [
+    { name: 'Put', call: (client: Client) => client.ingest.put({}), attempts: 1 },
+    { name: 'Prune', call: (client: Client) => client.prune.prune({}), attempts: 1 },
+    { name: 'SetRetention', call: (client: Client) => client.retention.setRetention({}), attempts: 1 },
+    { name: 'query Get', call: (client: Client) => client.query.get({}), attempts: 3 },
+    { name: 'stream Get', call: (client: Client) => client.stream.get({}), attempts: 3 },
+];
+
+describe.each([
+    { code: 'aborted', connectCode: Code.Aborted, status: 409 },
+    { code: 'unavailable', connectCode: Code.Unavailable, status: 503 },
+    { code: 'resource_exhausted', connectCode: Code.ResourceExhausted, status: 429 },
+])('retryable $code failures', ({ code, connectCode, status }) => {
+    test.each(methods)('$name makes $attempts attempts', async ({ call, attempts }) => {
+        const fetch = jest.spyOn(globalThis, 'fetch').mockImplementation(async () =>
+            new Response(JSON.stringify({ code, message: 'retryable failure' }), {
+                status,
+                headers: { 'content-type': 'application/json' },
+            }));
+        try {
+            const client = new Client('http://retry.test', {
+                token: '',
+                retry: { maxAttempts: 3, initialBackoffMs: 0, maxBackoffMs: 0 },
+            });
+            const result = call(client);
+            await expect(result).rejects.toBeInstanceOf(ConnectError);
+            await expect(result).rejects.toMatchObject({ code: connectCode });
+            expect(fetch).toHaveBeenCalledTimes(attempts);
+        } finally {
+            fetch.mockRestore();
+        }
+    });
+});

--- a/sdk/ts/src/client.ts
+++ b/sdk/ts/src/client.ts
@@ -38,6 +38,10 @@ function retryBackoffDelay(attempt: number, config: RetryConfig): number {
 function makeRetryInterceptor(config: RetryConfig): Interceptor {
     const maxAttempts = Math.max(config.maxAttempts, 1);
     return (next) => async (req) => {
+        // These mutations have no idempotency key and must not be replayed after a lost response.
+        const allowsRetry = req.method !== IngestService.method.put &&
+            req.method !== PruneService.method.prune &&
+            req.method !== RetentionService.method.setRetention;
         if (req.stream && req.method === QueryService.method.reduce) {
             // Each retry must serialize the same input after Connect consumes its request iterator.
             const input = await req.message[Symbol.asyncIterator]().next();
@@ -71,6 +75,7 @@ function makeRetryInterceptor(config: RetryConfig): Interceptor {
                 return response;
             } catch (err) {
                 if (
+                    allowsRetry &&
                     attempt < maxAttempts &&
                     err instanceof ConnectError &&
                     RETRYABLE_CODES.has(err.code)


### PR DESCRIPTION
## Purpose

The TypeScript SDK retry interceptor currently retries mutation RPCs on `ABORTED`, `UNAVAILABLE`, and `RESOURCE_EXHAUSTED`.

If a mutation commits but its response is lost, retrying it can create another Store sequence/log event or repeat an administrative operation.

## Implementation

Exclude these non-idempotent methods from automatic retries:

- `Put`
- `Prune`
- `SetRetention`

Read retries, backoff behavior, credentials, cancellation, and public APIs are unchanged.

## Tests

Added table-driven coverage confirming:

- Mutation RPCs are attempted once for every retryable error.
- Query and stream reads retain their configured retry behavior.

## Validation

- `npm run lint`
- `npm run build`
- `npm test -- --runInBand` — 100 tests passed
- `git diff --check`
